### PR TITLE
Add Token_Stream class as new lexer and ast_link to every token

### DIFF
--- a/trlc/ast.py
+++ b/trlc/ast.py
@@ -112,6 +112,10 @@ class Node(metaclass=ABCMeta):
         assert isinstance(location, Location)
         self.location = location
 
+    def set_ast_link(self, tok):
+        assert isinstance(tok, Token)
+        tok.ast_link = self
+
     def write_indent(self, indent, message):  # pragma: no cover
         # lobster-exclude: Debugging feature
         assert isinstance(indent, int)
@@ -266,7 +270,9 @@ class Compilation_Unit(Node):
             # We can ignore errors here, because that just means we
             # generate more error later.
             try:
-                self.imports.add(stab.lookup(mh, t_import, Package))
+                a_import = stab.lookup(mh, t_import, Package)
+                self.imports.add(a_import)
+                a_import.set_ast_link(t_import)
             except TRLC_Error:
                 pass
 
@@ -2399,6 +2405,10 @@ class Package(Entity):
         self.write_indent(indent + 1, "Declared_Late: %s" % self.declared_late)
         self.symbols.dump(indent + 1, omit_heading=True)
 
+    def __repr__(self):
+        return "%s<%s>" % (self.__class__.__name__,
+                           self.name)
+
 
 class Composite_Type(Concrete_Type, metaclass=ABCMeta):
     """Abstract base for record and tuple types, as they share some
@@ -2494,6 +2504,11 @@ class Composite_Component(Typed_Entity):
             self.write_indent(indent + 1, "Description: %s" % self.description)
         self.write_indent(indent + 1, "Optional: %s" % self.optional)
         self.write_indent(indent + 1, "Type: %s" % self.n_typ.name)
+
+    def __repr__(self):
+        return "%s<%s>" % (self.__class__.__name__,
+                           self.member_of.fully_qualified_name() + "." +
+                           self.name)
 
 
 class Record_Type(Composite_Type):
@@ -2949,6 +2964,12 @@ class Record_Object(Typed_Entity):
                 ok = False
 
         return ok
+
+    def __repr__(self):
+        return "%s<%s>" % (self.__class__.__name__,
+                           self.n_package.name + "." +
+                           self.n_typ.name + "." +
+                           self.name)
 
 
 class Section(Entity):

--- a/trlc/lexer.py
+++ b/trlc/lexer.py
@@ -159,7 +159,7 @@ class Token(Token_Base):
         "STRING"     : "string literal",
     }
 
-    def __init__(self, location, kind, value=None):
+    def __init__(self, location, kind, value=None, ast_link=None):
         assert kind in Token.KIND
         if kind in ("COMMENT", "IDENTIFIER", "BUILTIN",
                     "KEYWORD", "OPERATOR", "STRING"):
@@ -171,6 +171,7 @@ class Token(Token_Base):
         else:
             assert value is None
         super().__init__(location, kind, value)
+        self.ast_link = ast_link
 
     def __repr__(self):
         if self.value is None:
@@ -186,6 +187,7 @@ class Lexer_Base(metaclass=ABCMeta):
         self.mh        = mh
         self.content   = content
         self.length    = len(self.content)
+        self.tokens    = []
 
         self.lexpos  = -3
         self.line_no = 0
@@ -641,6 +643,15 @@ class TRLC_Lexer(Lexer_Base):
             value = None
 
         return Token(sref, kind, value)
+
+
+class Token_Stream(TRLC_Lexer):
+
+    def token(self):
+        tok = super().token()
+        if tok is not None:
+            self.tokens.append(tok)
+        return tok
 
 
 def sanity_test():

--- a/trlc/trlc.py
+++ b/trlc/trlc.py
@@ -30,7 +30,7 @@ from trlc import ast
 from trlc import lint
 from trlc.errors import TRLC_Error, Location, Message_Handler, Kind
 from trlc.parser import Parser
-from trlc.lexer import TRLC_Lexer
+from trlc.lexer import Token_Stream
 from trlc.version import TRLC_VERSION, BUGS_URL
 
 # pylint: disable=unused-import
@@ -160,7 +160,7 @@ class Source_Manager:
         assert isinstance(file_content, str) or file_content is None
         assert isinstance(primary_file, bool)
 
-        lexer = TRLC_Lexer(self.mh, file_name, file_content)
+        lexer = Token_Stream(self.mh, file_name, file_content)
 
         return Parser(mh             = self.mh,
                       stab           = self.stab,


### PR DESCRIPTION
Infos:
- I will take out the assertion for the ast_link attribute at the end of your review. I will squash the commits.
- I have not considered Markup-Strings yet. They are just normal Strings.
- I added string representations for some ast objects to better see how things are connected.
- All ast_links are set in the parser except for import statements as their names are resolved in the [ast.py](http://ast.py/).
- The import token itself is set to the files own package because it was easier to set the link at the moment the token first appears. The names are resolved after the graph was built and set correctly to their own ast package's object.
- Comments are linked to the files main package. I have put that at the end of each file's parsing because comments could appear at the top before the "package ..." clause.