### PR TITLE
Fix github-release in MAKEFILE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ remove-dev:
 
 github-release:
 	git push
-	python3 -m util.github-release
+	python3 -m util.github_release
 
 bump:
 	python3 -m util.bump_version_post_release

--- a/util/github_release.py
+++ b/util/github_release.py
@@ -31,6 +31,7 @@ import requests
 from trlc.version import TRLC_VERSION
 import util.changelog
 
+
 def main():
     username = os.environ.get("GITHUB_USERNAME", None)
     if username is None:
@@ -58,6 +59,7 @@ def main():
 
     r = requests.post(api_endpoint, auth=auth, data=json.dumps(data))
     print(r)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
The MAKEFILE target `github-release` was pointing to a non-existent file due to a typo in the file name.