### PR TITLE
specifies github runner images explicitly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,14 @@ jobs:
   lint:
     name: PyLint
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
         run: |
-          python3 -m pip install --upgrade pip --break-system-packages
-          python3 -m pip install pylint==3.2.4 pycodestyle==2.12.0 --break-system-packages
-          python3 -m pip install --no-deps bmw-lobster-core bmw-lobster-tool-trlc --break-system-packages
+          python3 -m pip install --upgrade pip
+          python3 -m pip install pylint==3.2.4 pycodestyle==2.12.0
+          python3 -m pip install --no-deps bmw-lobster-core bmw-lobster-tool-trlc
       - name: Executing linter
         run: |
           make lint
@@ -29,12 +29,12 @@ jobs:
     if: success()
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+        os: [ubuntu-24.04, windows-2022, macos-13, macos-14]
         py-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             cvc5-plat: "linux"
-          - os: windows-latest
+          - os: windows-2022
             cvc5-plat: "windows"
           - os: macos-13
             brew: "/usr/local"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,7 +25,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -11,7 +11,7 @@ jobs:
 
   package:
     name: Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.9
@@ -34,7 +34,7 @@ jobs:
   upload-test:
     name: PyPI Upload
     needs: package
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     environment: release
     permissions:
       id-token: write


### PR DESCRIPTION
due to https://github.com/actions/runner-images/commit/e065c9ac282b89ce756801c56922614b998f0cbe the CI failed because somer runner images were set to ubuntu-latest

due to the fix https://github.com/actions/runner-images/commit/f3ad9cadef4f7c3609820a2396df4f9d662876f5 ![Endpoint Badge](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fijunaidm%2F0b5459bbe18604a639e1d2f7accd204f%2Fraw%2Fubuntu24.json) there is no explicit argument `--break-system-packages` needed anymore