### PR TITLE
Fix help message of `--no-detailed-info`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ generated in the following situations:
 
 ### 2.0.2-dev
 
-
+* [TRLC] Fix help message for command line argument `--no-detailed-info`.
 
 ### 2.0.1
 

--- a/trlc/trlc.py
+++ b/trlc/trlc.py
@@ -613,8 +613,9 @@ def trlc():
                                  " supplemental information on failed"
                                  " checks. The specific values of"
                                  " counter-examples are unpredictable"
-                                 " from system to system, so if you need 100%"
-                                 " reproducible output then use this option."))
+                                 " from system to system, so if you need"
+                                 " perfectly reproducible output then use"
+                                 " this option."))
     og_output.add_argument("--no-user-warnings",
                            default=False,
                            action="store_true",


### PR DESCRIPTION
This is a bug fix.

When running `trlc -h`, the output now contains the following string:
> Do not print counter-examples and other supplemental information on failed checks. The specific values of counter-examples are unpredictable from system to system, so if you need perfectly reproducible output then use this option.

Previously it was:

> Do not print counter-examples and other supplemental information on failed checks. The specific values of counter-examples are unpredictable from system to system, so if you need 100{'option_strings': ['--no-detailed-info'], 'dest': 'no_detailed_info', 'nargs': 0, 'const': True, 'default': False, 'type': None, 'choices': None, 'required': False, 'help': 'Do not print counter-examples and other supplemental information on failed checks. The specific values of counter-examples are unpredictable from system to system, so if you need 100% reproducible output then use this option.', 'metavar': None, 'container': <argparse._ArgumentGroup object at 0x000001C1CD284910>, 'prog': 'trlc'}eproducible output then use this option.

The `%` character was causing the issue.