### PR TITLE
detects multi string first instead of normal string, Nested_Lexer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ generated in the following situations:
 
 ### 2.0.2-dev
 
+* [TRLC] Fix AssertionError when using Markup_String with triple double quoted strings
+
 * [TRLC] Add linter warning on unused imports.
 
 * [TRLC] Add support for Python 3.13.

--- a/tests-system/markup-1/foo.trlc
+++ b/tests-system/markup-1/foo.trlc
@@ -15,3 +15,11 @@ T test_2 {
     potato]] is "good
   '''
 }
+
+T test_3 {
+  S = "potato"
+  M = """
+    pot"ato [[Foo.kitten,
+    potato]] is "good
+  """
+}

--- a/tests-system/markup-1/output.json
+++ b/tests-system/markup-1/output.json
@@ -8,6 +8,10 @@
   "test_2": {
     "M": "pot\"ato [[Foo.kitten,\npotato]] is \"good",
     "S": "potato"
+  },
+  "test_3": {
+    "M": "pot\"ato [[Foo.kitten,\npotato]] is \"good",
+    "S": "potato"
   }
 }
 Processed 1 model and 1 requirement file and found no issues


### PR DESCRIPTION
If I understood it correctly, it would make more sense to first detect the multi string.
The `startswith('"')` method used before does also detect a multi string as normal.

Basically the triple double quoted string version was not taken into account, so it had to be adapted to that.

fixes #129 