### PR TITLE
Always print statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ generated in the following situations:
 
 * [TRLC] Fix help message for command line argument `--no-detailed-info`.
 
+* [TRLC] Modify behavior of `--brief`:
+  the summary showing the total number of processed model and requirement files and
+  issues is always printed.
+
 ### 2.0.1
 
 * [TRLC] Fix an UnboundLocalError when missing a term

--- a/tests-system/array-length/output.brief
+++ b/tests-system/array-length/output.brief
@@ -1,2 +1,3 @@
 array-length/foo.trlc:4:27: trlc error: this array requires at most 2 elements (3 provided)
 array-length/foo.trlc:8:18: trlc error: this array requires at least 2 elements (only 1 provided)
+Processed 1 model and 1 requirement file and found 2 errors

--- a/tests-system/array-membership-1/output.brief
+++ b/tests-system/array-membership-1/output.brief
@@ -4,3 +4,4 @@ array-membership-1/foo.trlc:22:12: trlc check warning: 42 is not in array
 array-membership-1/foo.trlc:22:12: trlc check warning: 42 is in array
 array-membership-1/foo.trlc:34:12: trlc check warning: 42 is not in array
 array-membership-1/foo.trlc:34:12: trlc check warning: 42 is in array
+Processed 1 model and 1 requirement file and found 6 warnings

--- a/tests-system/array-membership-2/output.brief
+++ b/tests-system/array-membership-2/output.brief
@@ -1,1 +1,2 @@
 array-membership-2/foo.rsl:9:3: trlc error: expected expression of type Builtin_String, got Builtin_Integer instead
+Processed 1 model and 0 requirement files and found 1 error

--- a/tests-system/array-membership-3/output.brief
+++ b/tests-system/array-membership-3/output.brief
@@ -1,1 +1,2 @@
 array-membership-3/foo.rsl:10:3: trlc error: unknown symbol kitten
+Processed 1 model and 0 requirement files and found 1 error

--- a/tests-system/arrays-1/output.brief
+++ b/tests-system/arrays-1/output.brief
@@ -1,1 +1,2 @@
 arrays-1/example.trlc:8:10: trlc check error: potato
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/arrays-2/output.brief
+++ b/tests-system/arrays-2/output.brief
@@ -1,1 +1,2 @@
 arrays-2/example.rsl:8:4: trlc error: expression 'arr' has type Integer, which is not an array
+Processed 1 model and 0 requirement files and found 1 error

--- a/tests-system/base-types/output.brief
+++ b/tests-system/base-types/output.brief
@@ -1,1 +1,2 @@
 base-types/instances.trlc:10:27: trlc check error: int must be 42
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/bazel-dirs/output.brief
+++ b/tests-system/bazel-dirs/output.brief
@@ -1,0 +1,1 @@
+Processed 1 model and 0 requirement files and found no issues

--- a/tests-system/bug-69/output.brief
+++ b/tests-system/bug-69/output.brief
@@ -1,1 +1,2 @@
 bug-69/foo.trlc:21:5: trlc error: expected reference of type RE, but Tiger is of type R
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/builtin-1/output.brief
+++ b/tests-system/builtin-1/output.brief
@@ -1,1 +1,2 @@
 builtin-1/example.trlc:10:10: trlc check warning: potato
+Processed 1 model and 1 requirement file and found 1 warning

--- a/tests-system/builtin-2/output.brief
+++ b/tests-system/builtin-2/output.brief
@@ -1,1 +1,2 @@
 builtin-2/legacy.rsl:9:11: trlc error: unknown symbol trlc
+Processed 1 model and 0 requirement files and found 1 error

--- a/tests-system/bulk/output.brief
+++ b/tests-system/bulk/output.brief
@@ -8,3 +8,4 @@ bulk/bulk_566329.trlc:3255:28: trlc error: unknown symbol Unknown
 bulk/bulk_566329.trlc:3268:28: trlc error: unknown symbol Unknown
 bulk/bulk_566329.trlc:3281:28: trlc error: unknown symbol Unknown
 bulk/bulk_566329.trlc:3294:28: trlc error: unknown symbol Unknown
+Processed 1 model and 85 requirement files and found 10 errors

--- a/tests-system/check-wo-type/output.brief
+++ b/tests-system/check-wo-type/output.brief
@@ -1,1 +1,2 @@
 check-wo-type/bar.rsl:14:8: trlc error: expected identifier, encountered opening brace '{' instead
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/checks-1/output.brief
+++ b/tests-system/checks-1/output.brief
@@ -1,2 +1,3 @@
 checks-1/foo.trlc:3:3: trlc error: rhs of check a < b (foo.rsl:9) must not be null
 checks-1/foo.trlc:7:3: trlc check error: a must be less than b
+Processed 1 model and 1 requirement file and found 2 errors

--- a/tests-system/checks-2/output.brief
+++ b/tests-system/checks-2/output.brief
@@ -1,2 +1,3 @@
 checks-2/foo.trlc:3:3: trlc check error: please define b
 checks-2/foo.trlc:8:8: trlc check error: a must be less than b
+Processed 1 model and 1 requirement file and found 2 errors

--- a/tests-system/checks-3/output.brief
+++ b/tests-system/checks-3/output.brief
@@ -1,1 +1,2 @@
 checks-3/foo.trlc:8:8: trlc check error: a must be less than b
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/checks-4/output.brief
+++ b/tests-system/checks-4/output.brief
@@ -1,2 +1,3 @@
 checks-4/foo.trlc:3:3: trlc error: values in quantified expression (forall v in values => v != foo) (foo.rsl:9) must not be null
 checks-4/foo.trlc:9:13: trlc check error: value cannot be same as value of foo
+Processed 1 model and 1 requirement file and found 2 errors

--- a/tests-system/checks-5/output.brief
+++ b/tests-system/checks-5/output.brief
@@ -1,1 +1,2 @@
 checks-5/foo.trlc:3:13: trlc check error: linkage incorrect
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/checks-6/output.brief
+++ b/tests-system/checks-6/output.brief
@@ -1,1 +1,2 @@
 checks-6/foo.rsl:6:9: trlc error: error message must not contain a newline
+Processed 1 model and 0 requirement files and found 1 error

--- a/tests-system/combined-rsl-file-1/output.brief
+++ b/tests-system/combined-rsl-file-1/output.brief
@@ -1,1 +1,2 @@
 combined-rsl-file-1/example.trlc:3:3: trlc check error: potato
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/combined-rsl-file-2/output.brief
+++ b/tests-system/combined-rsl-file-2/output.brief
@@ -1,1 +1,2 @@
 combined-rsl-file-2/b.rsl:1:9: trlc error: duplicate definition, previous definition at a.rsl:1
+Processed 2 models and 0 requirement files and found 1 error

--- a/tests-system/comments-1/output.brief
+++ b/tests-system/comments-1/output.brief
@@ -1,0 +1,1 @@
+Processed 0 models and 1 requirement file and found no issues

--- a/tests-system/comments-2/output.brief
+++ b/tests-system/comments-2/output.brief
@@ -1,0 +1,1 @@
+Processed 1 model and 0 requirement files and found no issues

--- a/tests-system/cross-refs-in-errors/output.brief
+++ b/tests-system/cross-refs-in-errors/output.brief
@@ -1,1 +1,2 @@
 cross-refs-in-errors/potato/foo.rsl:1:9: trlc error: duplicate definition, previous definition at kitten/bar.rsl:1
+Processed 2 models and 0 requirement files and found 1 error

--- a/tests-system/cyclic-inheritance/output.brief
+++ b/tests-system/cyclic-inheritance/output.brief
@@ -1,2 +1,3 @@
 cyclic-inheritance/bar.rsl:5:22: trlc error: unknown symbol MyType3
 cyclic-inheritance/bar.rsl:9:22: trlc error: unknown symbol MyType2
+Processed 1 model and 0 requirement files and found 2 errors

--- a/tests-system/cyclic-packages/output.brief
+++ b/tests-system/cyclic-packages/output.brief
@@ -1,1 +1,2 @@
 cyclic-packages/bar.rsl: trlc error: circular inheritence between Baz | Bork
+Processed 4 models and 0 requirement files and found 1 error

--- a/tests-system/decimal-1/output.brief
+++ b/tests-system/decimal-1/output.brief
@@ -1,3 +1,4 @@
 decimal-1/foo.trlc:9:7: trlc check warning: D is not less that I
 decimal-1/foo.trlc:14:7: trlc check warning: D is not less that I
 decimal-1/foo.trlc:14:7: trlc check warning: D is not positive
+Processed 1 model and 1 requirement file and found 3 warnings

--- a/tests-system/decimal-2/output.brief
+++ b/tests-system/decimal-2/output.brief
@@ -1,1 +1,2 @@
 decimal-2/foo.rsl:8:8: trlc error: expected expression of type Decimal, got Integer instead
+Processed 1 model and 0 requirement files and found 1 error

--- a/tests-system/decimal-3/output.brief
+++ b/tests-system/decimal-3/output.brief
@@ -1,1 +1,2 @@
 decimal-3/foo.rsl:8:15: trlc error: expected expression of type Decimal, got Integer instead
+Processed 1 model and 0 requirement files and found 1 error

--- a/tests-system/decimal-4/output.brief
+++ b/tests-system/decimal-4/output.brief
@@ -1,0 +1,1 @@
+Processed 1 model and 0 requirement files and found no issues

--- a/tests-system/decimal-5/output.brief
+++ b/tests-system/decimal-5/output.brief
@@ -1,0 +1,1 @@
+Processed 1 model and 0 requirement files and found no issues

--- a/tests-system/decimal-6/output.brief
+++ b/tests-system/decimal-6/output.brief
@@ -1,0 +1,1 @@
+Processed 1 model and 1 requirement file and found no issues

--- a/tests-system/decimal-7/output.brief
+++ b/tests-system/decimal-7/output.brief
@@ -1,0 +1,1 @@
+Processed 1 model and 0 requirement files and found no issues

--- a/tests-system/decimal-8/output.brief
+++ b/tests-system/decimal-8/output.brief
@@ -1,1 +1,2 @@
 decimal-8/foo.rsl:9:5: trlc error: type mismatch: Decimal and Integer do not match
+Processed 1 model and 0 requirement files and found 1 error

--- a/tests-system/delayed-references-1/output.brief
+++ b/tests-system/delayed-references-1/output.brief
@@ -1,0 +1,1 @@
+Processed 1 model and 2 requirement files and found no issues

--- a/tests-system/derived-type-ref/output.brief
+++ b/tests-system/derived-type-ref/output.brief
@@ -1,0 +1,1 @@
+Processed 1 model and 1 requirement file and found no issues

--- a/tests-system/duplicate-imports/output.brief
+++ b/tests-system/duplicate-imports/output.brief
@@ -1,1 +1,2 @@
 duplicate-imports/bar.trlc:4:8: trlc warning: duplicate import of package Foo
+Processed 1 model and 1 requirement file and found 1 warning

--- a/tests-system/empty-attributes/output.brief
+++ b/tests-system/empty-attributes/output.brief
@@ -1,1 +1,2 @@
 empty-attributes/instances.trlc:4:29: trlc check error: Asil must be set
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/empty-files/output.brief
+++ b/tests-system/empty-files/output.brief
@@ -1,1 +1,2 @@
 empty-files/foo.trlc:1:1: trlc error: expected keyword package, encountered end-of-file instead
+Processed 0 models and 1 requirement file and found 1 error

--- a/tests-system/enum-null/output.brief
+++ b/tests-system/enum-null/output.brief
@@ -1,1 +1,2 @@
 enum-null/instances.trlc:4:16: trlc check error: Status must be not null
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/enum-ok/output.brief
+++ b/tests-system/enum-ok/output.brief
@@ -1,0 +1,1 @@
+Processed 1 model and 1 requirement file and found no issues

--- a/tests-system/enum/output.brief
+++ b/tests-system/enum/output.brief
@@ -1,1 +1,2 @@
 enum/instances.trlc:4:16: trlc check error: Status must be NEW
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/error-in-check/output.brief
+++ b/tests-system/error-in-check/output.brief
@@ -1,1 +1,2 @@
 error-in-check/bar.rsl:8:3: trlc error: unknown symbol startsXwith, did you mean startswith?
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/freezing-1/output.brief
+++ b/tests-system/freezing-1/output.brief
@@ -1,1 +1,2 @@
 freezing-1/foo.rsl:16:14: trlc check warning: n should be positive
+Processed 1 model and 1 requirement file and found 1 warning

--- a/tests-system/freezing-2/output.brief
+++ b/tests-system/freezing-2/output.brief
@@ -1,1 +1,2 @@
 freezing-2/foo.rsl:6:10: trlc error: duplicate freezing of a, previously frozen at foo.rsl:5
+Processed 1 model and 0 requirement files and found 1 error

--- a/tests-system/freezing-3/output.brief
+++ b/tests-system/freezing-3/output.brief
@@ -1,1 +1,2 @@
 freezing-3/foo.trlc:4:3: trlc error: cannot overwrite frozen component n
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/inheritance-2/output.brief
+++ b/tests-system/inheritance-2/output.brief
@@ -1,1 +1,2 @@
 inheritance-2/instances.trlc:4:25: trlc check error: name must have specific length
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/inheritance/output.brief
+++ b/tests-system/inheritance/output.brief
@@ -1,1 +1,2 @@
 inheritance/instances.trlc:4:25: trlc check error: name must have specific length
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/int-literals-1/output.brief
+++ b/tests-system/int-literals-1/output.brief
@@ -1,0 +1,1 @@
+Processed 1 model and 1 requirement file and found no issues

--- a/tests-system/int-literals-2/output.brief
+++ b/tests-system/int-literals-2/output.brief
@@ -1,1 +1,2 @@
 int-literals-2/foo.trlc:3:15: trlc error: decimal point is not allowed here
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/int-literals-3/output.brief
+++ b/tests-system/int-literals-3/output.brief
@@ -1,1 +1,2 @@
 int-literals-3/foo.trlc:3:15: trlc error: base 10 digit is required here
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/int-literals-4/output.brief
+++ b/tests-system/int-literals-4/output.brief
@@ -1,1 +1,2 @@
 int-literals-4/foo.trlc:3:15: trlc error: base 16 integer may not contain a decimal point
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/int-literals-5/output.brief
+++ b/tests-system/int-literals-5/output.brief
@@ -1,1 +1,2 @@
 int-literals-5/foo.trlc:3:15: trlc error: f is not a valid base 2 digit
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/int-literals-6/output.brief
+++ b/tests-system/int-literals-6/output.brief
@@ -1,2 +1,3 @@
 int-literals-6/foo.trlc:3:15: trlc error: base 10 digit is required here
 int-literals-6/foo.trlc:3:17: trlc error: unexpected character '_'
+Processed 1 model and 1 requirement file and found 2 errors

--- a/tests-system/int-literals-7/output.brief
+++ b/tests-system/int-literals-7/output.brief
@@ -1,2 +1,3 @@
 int-literals-7/foo.trlc:3:15: trlc error: base 16 digit is required here
 int-literals-7/foo.trlc:3:17: trlc error: unexpected character '_'
+Processed 1 model and 1 requirement file and found 2 errors

--- a/tests-system/int-literals-8/output.brief
+++ b/tests-system/int-literals-8/output.brief
@@ -1,1 +1,2 @@
 int-literals-8/foo.trlc:5:15: trlc error: unfinished base 16 integer
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/late-packages-1/output.brief
+++ b/tests-system/late-packages-1/output.brief
@@ -1,0 +1,1 @@
+Processed 1 model and 2 requirement files and found no issues

--- a/tests-system/late-packages-2/output.brief
+++ b/tests-system/late-packages-2/output.brief
@@ -1,0 +1,1 @@
+Processed 0 models and 2 requirement files and found no issues

--- a/tests-system/lint-63-false-alarm-in-exists/output.brief
+++ b/tests-system/lint-63-false-alarm-in-exists/output.brief
@@ -1,0 +1,1 @@
+Processed 1 model and 0 requirement files and found no issues

--- a/tests-system/lint-ambiguous-literals/output.brief
+++ b/tests-system/lint-ambiguous-literals/output.brief
@@ -1,0 +1,1 @@
+Processed 1 model and 0 requirement files and found no issues

--- a/tests-system/lint-null/output.brief
+++ b/tests-system/lint-null/output.brief
@@ -1,0 +1,1 @@
+Processed 1 model and 0 requirement files and found no issues

--- a/tests-system/lint-record-refs/output.brief
+++ b/tests-system/lint-record-refs/output.brief
@@ -1,0 +1,1 @@
+Processed 4 models and 0 requirement files and found no issues

--- a/tests-system/lint-ug-examples/output.brief
+++ b/tests-system/lint-ug-examples/output.brief
@@ -1,0 +1,1 @@
+Processed 14 models and 0 requirement files and found no issues

--- a/tests-system/lint-vcg-arrays/output.brief
+++ b/tests-system/lint-vcg-arrays/output.brief
@@ -1,0 +1,1 @@
+Processed 2 models and 0 requirement files and found no issues

--- a/tests-system/lint-vcg-basic/output.brief
+++ b/tests-system/lint-vcg-basic/output.brief
@@ -1,0 +1,1 @@
+Processed 7 models and 0 requirement files and found no issues

--- a/tests-system/lint-vcg-connectives/output.brief
+++ b/tests-system/lint-vcg-connectives/output.brief
@@ -1,0 +1,1 @@
+Processed 2 models and 0 requirement files and found no issues

--- a/tests-system/lint-vcg-decimal/output.brief
+++ b/tests-system/lint-vcg-decimal/output.brief
@@ -1,0 +1,1 @@
+Processed 3 models and 0 requirement files and found no issues

--- a/tests-system/lint-vcg-empty-enum/output.brief
+++ b/tests-system/lint-vcg-empty-enum/output.brief
@@ -1,1 +1,2 @@
 lint-vcg-empty-enum/foo.rsl:3:6: trlc error: empty enumerations are not permitted
+Processed 1 model and 0 requirement files and found 1 error

--- a/tests-system/lint-vcg-frozen/output.brief
+++ b/tests-system/lint-vcg-frozen/output.brief
@@ -1,0 +1,1 @@
+Processed 1 model and 0 requirement files and found no issues

--- a/tests-system/lint-vcg-int-real/output.brief
+++ b/tests-system/lint-vcg-int-real/output.brief
@@ -1,0 +1,1 @@
+Processed 2 models and 0 requirement files and found no issues

--- a/tests-system/lint-vcg-ite/output.brief
+++ b/tests-system/lint-vcg-ite/output.brief
@@ -1,0 +1,1 @@
+Processed 1 model and 0 requirement files and found no issues

--- a/tests-system/lint-vcg-membership/output.brief
+++ b/tests-system/lint-vcg-membership/output.brief
@@ -1,0 +1,1 @@
+Processed 1 model and 0 requirement files and found no issues

--- a/tests-system/lint-vcg-oneof/output.brief
+++ b/tests-system/lint-vcg-oneof/output.brief
@@ -1,0 +1,1 @@
+Processed 1 model and 0 requirement files and found no issues

--- a/tests-system/lint-vcg-power/output.brief
+++ b/tests-system/lint-vcg-power/output.brief
@@ -1,0 +1,1 @@
+Processed 2 models and 0 requirement files and found no issues

--- a/tests-system/lint-vcg-quant/output.brief
+++ b/tests-system/lint-vcg-quant/output.brief
@@ -1,0 +1,1 @@
+Processed 3 models and 0 requirement files and found no issues

--- a/tests-system/lint-vcg-strings/output.brief
+++ b/tests-system/lint-vcg-strings/output.brief
@@ -1,0 +1,1 @@
+Processed 3 models and 0 requirement files and found no issues

--- a/tests-system/lint-vcg-tuple/output.brief
+++ b/tests-system/lint-vcg-tuple/output.brief
@@ -1,0 +1,1 @@
+Processed 5 models and 0 requirement files and found no issues

--- a/tests-system/markup-1/output.brief
+++ b/tests-system/markup-1/output.brief
@@ -1,0 +1,1 @@
+Processed 1 model and 1 requirement file and found no issues

--- a/tests-system/markup-2/output.brief
+++ b/tests-system/markup-2/output.brief
@@ -1,1 +1,2 @@
 markup-2/bar.trlc:18:14: trlc error: package must be imported before use
+Processed 2 models and 3 requirement files and found 1 error

--- a/tests-system/markup-3/output.brief
+++ b/tests-system/markup-3/output.brief
@@ -1,1 +1,2 @@
 markup-3/foo.trlc:8:10: trlc error: unknown symbol Test_3, did you mean Test_2?
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/mult/output.brief
+++ b/tests-system/mult/output.brief
@@ -2,3 +2,4 @@ mult/instances.trlc:6:22: trlc error: this array requires at least 5 elements (o
 mult/instances.trlc:16:22: trlc error: this array requires at least 5 elements (only 2 provided)
 mult/instances.trlc:21:22: trlc error: this array requires at least 3 elements (only 2 provided)
 mult/instances.trlc:4:12: trlc check error: mult must have 3 elements
+Processed 1 model and 1 requirement file and found 4 errors

--- a/tests-system/multiple-check-expressions/output.brief
+++ b/tests-system/multiple-check-expressions/output.brief
@@ -1,2 +1,3 @@
 multiple-check-expressions/instances.trlc:5:24: trlc check error: name must start with Q
 multiple-check-expressions/instances.trlc:5:24: trlc check error: name must end with t
+Processed 1 model and 1 requirement file and found 2 errors

--- a/tests-system/multiple-models/output.brief
+++ b/tests-system/multiple-models/output.brief
@@ -1,3 +1,4 @@
 multiple-models/foo.trlc:4:7: trlc check error: this is not a good name
 multiple-models/foo.trlc:8:7: trlc check error: this is not a good name
 multiple-models/foo.trlc:8:7: trlc check error: also not a good name
+Processed 2 models and 3 requirement files and found 3 errors

--- a/tests-system/name-shadowing-1/output.brief
+++ b/tests-system/name-shadowing-1/output.brief
@@ -1,1 +1,2 @@
 name-shadowing-1/foo.trlc:3:3: trlc error: duplicate definition, previous definition at foo.rsl:1
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/names_unique_globally/output.brief
+++ b/tests-system/names_unique_globally/output.brief
@@ -1,2 +1,3 @@
 names_unique_globally/f1.trlc:4:5: trlc error: required component l (see def.rsl:4) is not defined
 names_unique_globally/f2.trlc:3:5: trlc error: duplicate definition, previous definition at f1.trlc:4
+Processed 1 model and 2 requirement files and found 2 errors

--- a/tests-system/negative-values/output.brief
+++ b/tests-system/negative-values/output.brief
@@ -1,3 +1,4 @@
 negative-values/foo.trlc:4:9: trlc check warning: potato
 negative-values/foo.trlc:10:9: trlc check warning: potato
 negative-values/foo.trlc:13:9: trlc check warning: potato
+Processed 1 model and 1 requirement file and found 3 warnings

--- a/tests-system/null-expr-1/output.brief
+++ b/tests-system/null-expr-1/output.brief
@@ -1,0 +1,1 @@
+Processed 1 model and 0 requirement files and found no issues

--- a/tests-system/null-value/output.brief
+++ b/tests-system/null-value/output.brief
@@ -1,1 +1,2 @@
 null-value/instances.trlc:4:24: trlc error: required component other (see bar.rsl:5) is not defined
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/preamble-1/output.brief
+++ b/tests-system/preamble-1/output.brief
@@ -1,3 +1,4 @@
 preamble-1/bar.rsl:1:1: trlc error: expected keyword package, encountered keyword import instead
 preamble-1/baz.rsl:2:8: trlc error: package Baz cannot import itself
 preamble-1/foo.rsl:1:1: trlc error: expected keyword package, encountered keyword type instead
+Processed 3 models and 0 requirement files and found 3 errors

--- a/tests-system/quantifiers/output.brief
+++ b/tests-system/quantifiers/output.brief
@@ -8,3 +8,4 @@ quantifiers/foo.trlc:46:9: trlc check warning: not everything is 42
 quantifiers/foo.trlc:46:9: trlc check warning: nothing is 42
 quantifiers/foo.trlc:58:9: trlc check warning: not everything is 42
 quantifiers/foo.trlc:58:9: trlc check warning: nothing is 42
+Processed 1 model and 1 requirement file and found 10 warnings

--- a/tests-system/rbt-applicable-components/output.brief
+++ b/tests-system/rbt-applicable-components/output.brief
@@ -1,1 +1,2 @@
 rbt-applicable-components/foo.rsl:9:9: trlc error: unknown symbol c
+Processed 1 model and 0 requirement files and found 1 error

--- a/tests-system/rbt-applicable-types/output.brief
+++ b/tests-system/rbt-applicable-types/output.brief
@@ -1,1 +1,2 @@
 rbt-applicable-types/foo.rsl:8:8: trlc error: unknown symbol B
+Processed 2 models and 0 requirement files and found 1 error

--- a/tests-system/rbt-boolean-values/output.brief
+++ b/tests-system/rbt-boolean-values/output.brief
@@ -1,0 +1,1 @@
+Processed 1 model and 0 requirement files and found no issues

--- a/tests-system/rbt-builtin-functions-1/output.brief
+++ b/tests-system/rbt-builtin-functions-1/output.brief
@@ -1,0 +1,1 @@
+Processed 1 model and 1 requirement file and found no issues

--- a/tests-system/rbt-builtin-functions-2/output.brief
+++ b/tests-system/rbt-builtin-functions-2/output.brief
@@ -1,1 +1,2 @@
 rbt-builtin-functions-2/foo.rsl:10:13: trlc error: expected identifier, encountered comma ',' instead
+Processed 1 model and 0 requirement files and found 1 error

--- a/tests-system/rbt-builtin-types/output.brief
+++ b/tests-system/rbt-builtin-types/output.brief
@@ -1,0 +1,1 @@
+Processed 1 model and 0 requirement files and found no issues

--- a/tests-system/rbt-check-evaluation-order-for-extensions/output.brief
+++ b/tests-system/rbt-check-evaluation-order-for-extensions/output.brief
@@ -1,2 +1,3 @@
 rbt-check-evaluation-order-for-extensions/bar.trlc:4:9: trlc check warning: a has to be more than 7 chars
 rbt-check-evaluation-order-for-extensions/bar.trlc:4:9: trlc check error: a has to be more than 10 chars
+Processed 2 models and 1 requirement file and found 1 warning and 1 error

--- a/tests-system/rbt-check-evaluation-order/output.brief
+++ b/tests-system/rbt-check-evaluation-order/output.brief
@@ -1,3 +1,4 @@
 rbt-check-evaluation-order/foo.trlc:4:7: trlc check warning: First warning: a is positive
 rbt-check-evaluation-order/foo.trlc:5:7: trlc check warning: Second warning: b is negative
 rbt-check-evaluation-order/foo.trlc:3:3: trlc check warning: Third warning: a is greater than b
+Processed 1 model and 1 requirement file and found 3 warnings

--- a/tests-system/rbt-check-severity-1/output.brief
+++ b/tests-system/rbt-check-severity-1/output.brief
@@ -1,3 +1,4 @@
 rbt-check-severity-1/foo.trlc:4:9: trlc check error: a must be longer than 3
 rbt-check-severity-1/foo.trlc:5:9: trlc check error: b must be longer than 7
 rbt-check-severity-1/foo.trlc:6:9: trlc check error: c must be longer than 10
+Processed 1 model and 1 requirement file and found 3 errors

--- a/tests-system/rbt-check-severity-2/output.brief
+++ b/tests-system/rbt-check-severity-2/output.brief
@@ -1,1 +1,2 @@
 rbt-check-severity-2/foo.trlc:4:9: trlc check error: a must be longer than 3
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/rbt-check-severity-3/output.brief
+++ b/tests-system/rbt-check-severity-3/output.brief
@@ -1,3 +1,4 @@
 rbt-check-severity-3/foo.trlc:4:9: trlc check warning: a must be longer than 3
 rbt-check-severity-3/foo.trlc:5:9: trlc check warning: b must be longer than 7
 rbt-check-severity-3/foo.trlc:6:9: trlc check warning: c must be longer than 10
+Processed 1 model and 1 requirement file and found 3 warnings

--- a/tests-system/rbt-conditional-expression-types/output.brief
+++ b/tests-system/rbt-conditional-expression-types/output.brief
@@ -1,1 +1,2 @@
 rbt-conditional-expression-types/foo.rsl:10:8: trlc error: expected expression of type Builtin_Boolean, got Builtin_Integer instead
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/rbt-conditional-expression/output.brief
+++ b/tests-system/rbt-conditional-expression/output.brief
@@ -2,3 +2,4 @@ rbt-conditional-expression/foo.trlc:3:3: trlc check error: kitten
 rbt-conditional-expression/foo.trlc:3:3: trlc check error: foobar evaluation if
 rbt-conditional-expression/foo.trlc:3:3: trlc check error: foobar evaluation elsif
 rbt-conditional-expression/foo.trlc:3:3: trlc check error: potato else
+Processed 1 model and 1 requirement file and found 4 errors

--- a/tests-system/rbt-decimal-values/output.brief
+++ b/tests-system/rbt-decimal-values/output.brief
@@ -1,0 +1,1 @@
+Processed 2 models and 2 requirement files and found no issues

--- a/tests-system/rbt-described-name-equality/output.brief
+++ b/tests-system/rbt-described-name-equality/output.brief
@@ -1,1 +1,2 @@
 rbt-described-name-equality/foo.rsl:5:3: trlc error: duplicate definition, previous definition at foo.rsl:4
+Processed 1 model and 0 requirement files and found 1 error

--- a/tests-system/rbt-described-names/output.brief
+++ b/tests-system/rbt-described-names/output.brief
@@ -1,0 +1,1 @@
+Processed 1 model and 0 requirement files and found no issues

--- a/tests-system/rbt-duplicate-types/output.brief
+++ b/tests-system/rbt-duplicate-types/output.brief
@@ -1,3 +1,4 @@
 rbt-duplicate-types/foo.rsl:7:6: trlc error: duplicate definition, previous definition at foo.rsl:3
 rbt-duplicate-types/foo.rsl:10:6: trlc error: duplicate definition, previous definition at foo.rsl:4
 rbt-duplicate-types/foo.rsl:14:7: trlc error: duplicate definition, previous definition at foo.rsl:5
+Processed 1 model and 0 requirement files and found 3 errors

--- a/tests-system/rbt-endswith-semantics/output.brief
+++ b/tests-system/rbt-endswith-semantics/output.brief
@@ -1,1 +1,2 @@
 rbt-endswith-semantics/foo.trlc:8:9: trlc check warning: b should end with en
+Processed 1 model and 1 requirement file and found 1 warning

--- a/tests-system/rbt-evaluation-of-checks/output.brief
+++ b/tests-system/rbt-evaluation-of-checks/output.brief
@@ -1,1 +1,2 @@
 rbt-evaluation-of-checks/foo.trlc:3:3: trlc check warning: a should be less than b
+Processed 1 model and 1 requirement file and found 1 warning

--- a/tests-system/rbt-existential-quantification-semantics/output.brief
+++ b/tests-system/rbt-existential-quantification-semantics/output.brief
@@ -1,1 +1,2 @@
 rbt-existential-quantification-semantics/foo.trlc:7:3: trlc check warning: there is no 7 in a
+Processed 1 model and 1 requirement file and found 1 warning

--- a/tests-system/rbt-expression/output.brief
+++ b/tests-system/rbt-expression/output.brief
@@ -37,3 +37,4 @@ rbt-expression/foo.trlc:3:3: trlc check warning: 31: bad lnot
 rbt-expression/foo.trlc:3:3: trlc check warning: 32: bad iabs
 rbt-expression/foo.trlc:3:3: trlc check warning: 33: bad dabs
 rbt-expression/foo.trlc:3:3: trlc check warning: 34: bad ifexpr
+Processed 1 model and 1 requirement file and found 39 warnings

--- a/tests-system/rbt-integer-values/output.brief
+++ b/tests-system/rbt-integer-values/output.brief
@@ -1,0 +1,1 @@
+Processed 1 model and 1 requirement file and found no issues

--- a/tests-system/rbt-late-package-declarations/output.brief
+++ b/tests-system/rbt-late-package-declarations/output.brief
@@ -1,0 +1,1 @@
+Processed 0 models and 3 requirement files and found no issues

--- a/tests-system/rbt-late-reference-checking/output.brief
+++ b/tests-system/rbt-late-reference-checking/output.brief
@@ -1,1 +1,2 @@
 rbt-late-reference-checking/foo.trlc:10:11: trlc error: unknown symbol Potato
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/rbt-len-semantics/output.brief
+++ b/tests-system/rbt-len-semantics/output.brief
@@ -1,0 +1,1 @@
+Processed 1 model and 1 requirement file and found no issues

--- a/tests-system/rbt-mandatory-components/output.brief
+++ b/tests-system/rbt-mandatory-components/output.brief
@@ -1,1 +1,2 @@
 rbt-mandatory-components/foo.trlc:3:3: trlc error: required component b (see foo.rsl:5) is not defined
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/rbt-markup-string-errors/output.brief
+++ b/tests-system/rbt-markup-string-errors/output.brief
@@ -1,3 +1,4 @@
 rbt-markup-string-errors/foo.trlc:4:12: trlc error: expected ]], encountered end-of-string instead
 rbt-markup-string-errors/foo.trlc:8:13: trlc error: opening [[ for this ]] found
 rbt-markup-string-errors/foo.trlc:12:15: trlc error: cannot nest reference lists
+Processed 1 model and 1 requirement file and found 3 errors

--- a/tests-system/rbt-markup-string-format/output.brief
+++ b/tests-system/rbt-markup-string-format/output.brief
@@ -1,0 +1,1 @@
+Processed 1 model and 1 requirement file and found no issues

--- a/tests-system/rbt-markup-string-late-reference-resolution/output.brief
+++ b/tests-system/rbt-markup-string-late-reference-resolution/output.brief
@@ -1,0 +1,1 @@
+Processed 1 model and 1 requirement file and found no issues

--- a/tests-system/rbt-markup-string-resolution/output.brief
+++ b/tests-system/rbt-markup-string-resolution/output.brief
@@ -1,1 +1,2 @@
 rbt-markup-string-resolution/potato.trlc:4:12: trlc error: package must be imported before use
+Processed 2 models and 2 requirement files and found 1 error

--- a/tests-system/rbt-markup-string-types/output.brief
+++ b/tests-system/rbt-markup-string-types/output.brief
@@ -1,1 +1,2 @@
 rbt-markup-string-types/foo.trlc:4:12: trlc error: Record_Type T is not a Record_Object
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/rbt-markup-string-values/output.brief
+++ b/tests-system/rbt-markup-string-values/output.brief
@@ -1,1 +1,2 @@
 rbt-markup-string-values/foo.trlc:8:50: trlc error: expected ]], encountered identifier instead
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/rbt-matches-semantics/output.brief
+++ b/tests-system/rbt-matches-semantics/output.brief
@@ -2,3 +2,4 @@ rbt-matches-semantics/foo.trlc:4:9: trlc check warning: a should match with 6 to
 rbt-matches-semantics/foo.trlc:5:9: trlc check warning: b should match only letters, digits, or underscores.
 rbt-matches-semantics/foo.trlc:6:9: trlc check warning: b should start with 'potato'.
 rbt-matches-semantics/foo.trlc:7:9: trlc check warning: d should start with D
+Processed 1 model and 1 requirement file and found 4 warnings

--- a/tests-system/rbt-matching-value-types/output.brief
+++ b/tests-system/rbt-matching-value-types/output.brief
@@ -1,2 +1,3 @@
 rbt-matching-value-types/foo.trlc:4:9: trlc error: expected integer literal, encountered decimal literal instead
 rbt-matching-value-types/foo.trlc:10:10: trlc error: expected string literal, encountered integer literal instead
+Processed 1 model and 1 requirement file and found 2 errors

--- a/tests-system/rbt-names/output.brief
+++ b/tests-system/rbt-names/output.brief
@@ -1,1 +1,2 @@
 rbt-names/foo.trlc:6:9: trlc check warning: try to minimize the length
+Processed 1 model and 1 requirement file and found 1 warning

--- a/tests-system/rbt-oneof-semantics/output.brief
+++ b/tests-system/rbt-oneof-semantics/output.brief
@@ -2,3 +2,4 @@ rbt-oneof-semantics/foo.trlc:7:4: trlc check error: potato
 rbt-oneof-semantics/foo.trlc:11:4: trlc check error: potato
 rbt-oneof-semantics/foo.trlc:21:4: trlc check error: potato
 rbt-oneof-semantics/foo.trlc:26:4: trlc check error: potato
+Processed 1 model and 1 requirement file and found 4 errors

--- a/tests-system/rbt-qualified-name/output.brief
+++ b/tests-system/rbt-qualified-name/output.brief
@@ -1,3 +1,4 @@
 rbt-qualified-name/test1.trlc:4:1: trlc error: unknown symbol T
 rbt-qualified-name/test2.trlc:4:1: trlc error: package must be imported before use
 rbt-qualified-name/test3.trlc:4:1: trlc error: unknown symbol Bar
+Processed 1 model and 6 requirement files and found 3 errors

--- a/tests-system/rbt-quantification-naming-scope/output.brief
+++ b/tests-system/rbt-quantification-naming-scope/output.brief
@@ -1,1 +1,2 @@
 rbt-quantification-naming-scope/foo.rsl:10:13: trlc error: shadows Composite_Component a from foo.rsl:4
+Processed 1 model and 0 requirement files and found 1 error

--- a/tests-system/rbt-quantification-object-1/output.brief
+++ b/tests-system/rbt-quantification-object-1/output.brief
@@ -1,1 +1,2 @@
 rbt-quantification-object-1/foo.rsl:8:21: trlc error: you can only quantify over arrays
+Processed 1 model and 0 requirement files and found 1 error

--- a/tests-system/rbt-quantification-object-2/output.brief
+++ b/tests-system/rbt-quantification-object-2/output.brief
@@ -1,1 +1,2 @@
 rbt-quantification-object-2/foo.rsl:8:21: trlc error: unknown symbol b
+Processed 1 model and 0 requirement files and found 1 error

--- a/tests-system/rbt-quantified-expression/output.brief
+++ b/tests-system/rbt-quantified-expression/output.brief
@@ -1,1 +1,2 @@
 rbt-quantified-expression/foo.rsl:10:26: trlc error: expected expression of type Builtin_Boolean, got Builtin_Integer instead
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/rbt-record-object-declaration/output.brief
+++ b/tests-system/rbt-record-object-declaration/output.brief
@@ -1,0 +1,1 @@
+Processed 1 model and 1 requirement file and found no issues

--- a/tests-system/rbt-references-to-extensions/output.brief
+++ b/tests-system/rbt-references-to-extensions/output.brief
@@ -1,1 +1,2 @@
 rbt-references-to-extensions/foo.trlc:17:12: trlc error: expected reference of type RE, but Tiger is of type R
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/rbt-restricted-null-1/output.brief
+++ b/tests-system/rbt-restricted-null-1/output.brief
@@ -1,1 +1,2 @@
 rbt-restricted-null-1/foo.trlc:4:9: trlc check error: a is not null
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/rbt-restricted-null-2/output.brief
+++ b/tests-system/rbt-restricted-null-2/output.brief
@@ -1,2 +1,3 @@
 rbt-restricted-null-2/foo.rsl:14:15: trlc error: null is not permitted here
 rbt-restricted-null-2/foo.rsl:18:21: trlc error: null is not permitted here
+Processed 1 model and 1 requirement file and found 2 errors

--- a/tests-system/rbt-restricted-tuple-nesting-1/output.brief
+++ b/tests-system/rbt-restricted-tuple-nesting-1/output.brief
@@ -4,3 +4,4 @@ rbt-restricted-tuple-nesting-1/foo.trlc:4:3: trlc error: unknown symbol x
 rbt-restricted-tuple-nesting-1/foo.trlc:8:3: trlc error: unknown symbol x
 rbt-restricted-tuple-nesting-1/foo.trlc:12:3: trlc error: unknown symbol x
 rbt-restricted-tuple-nesting-1/foo.trlc:16:3: trlc error: unknown symbol x
+Processed 1 model and 1 requirement file and found 6 errors

--- a/tests-system/rbt-restricted-tuple-nesting-2/output.brief
+++ b/tests-system/rbt-restricted-tuple-nesting-2/output.brief
@@ -4,3 +4,4 @@ rbt-restricted-tuple-nesting-2/foo.trlc:4:3: trlc error: unknown symbol x
 rbt-restricted-tuple-nesting-2/foo.trlc:8:3: trlc error: unknown symbol x
 rbt-restricted-tuple-nesting-2/foo.trlc:12:3: trlc error: unknown symbol x
 rbt-restricted-tuple-nesting-2/foo.trlc:16:3: trlc error: unknown symbol x
+Processed 1 model and 1 requirement file and found 6 errors

--- a/tests-system/rbt-section-declaration/output.brief
+++ b/tests-system/rbt-section-declaration/output.brief
@@ -1,0 +1,1 @@
+Processed 1 model and 1 requirement file and found no issues

--- a/tests-system/rbt-signature-len-1/output.brief
+++ b/tests-system/rbt-signature-len-1/output.brief
@@ -1,1 +1,2 @@
 rbt-signature-len-1/foo.rsl:10:9: trlc error: expected expression of type Array_Type, got Builtin_Integer instead
+Processed 1 model and 0 requirement files and found 1 error

--- a/tests-system/rbt-signature-len-2/output.brief
+++ b/tests-system/rbt-signature-len-2/output.brief
@@ -1,1 +1,2 @@
 rbt-signature-len-2/foo.rsl:11:5: trlc error: function requires 1 parameters
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/rbt-signature-matches-1/output.brief
+++ b/tests-system/rbt-signature-matches-1/output.brief
@@ -1,1 +1,2 @@
 rbt-signature-matches-1/foo.rsl:8:13: trlc error: expected expression of type Builtin_String, got Builtin_Integer instead
+Processed 1 model and 0 requirement files and found 1 error

--- a/tests-system/rbt-signature-matches-2/output.brief
+++ b/tests-system/rbt-signature-matches-2/output.brief
@@ -1,1 +1,2 @@
 rbt-signature-matches-2/foo.rsl:9:5: trlc error: function requires 2 parameters
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/rbt-signature-matches-3/output.brief
+++ b/tests-system/rbt-signature-matches-3/output.brief
@@ -1,1 +1,2 @@
 rbt-signature-matches-3/foo.rsl:10:16: trlc error: missing ), unterminated subpattern at position 0
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/rbt-signature-string-end-functions-1/output.brief
+++ b/tests-system/rbt-signature-string-end-functions-1/output.brief
@@ -1,1 +1,2 @@
 rbt-signature-string-end-functions-1/foo.rsl:10:16: trlc error: expected expression of type Builtin_String, got Builtin_Integer instead
+Processed 1 model and 0 requirement files and found 1 error

--- a/tests-system/rbt-signature-string-end-functions-2/output.brief
+++ b/tests-system/rbt-signature-string-end-functions-2/output.brief
@@ -1,1 +1,2 @@
 rbt-signature-string-end-functions-2/foo.rsl:12:5: trlc error: function requires 2 parameters
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/rbt-signature-string-end-functions-3/output.brief
+++ b/tests-system/rbt-signature-string-end-functions-3/output.brief
@@ -1,1 +1,2 @@
 rbt-signature-string-end-functions-3/foo.rsl:9:14: trlc error: expected expression of type Builtin_String, got Builtin_Integer instead
+Processed 1 model and 0 requirement files and found 1 error

--- a/tests-system/rbt-signature-type-conversion/output.brief
+++ b/tests-system/rbt-signature-type-conversion/output.brief
@@ -1,2 +1,3 @@
 rbt-signature-type-conversion/foo.trlc:3:3: trlc check warning: a is less than b
 rbt-signature-type-conversion/foo.trlc:3:3: trlc check warning: b is greater than a
+Processed 1 model and 1 requirement file and found 2 warnings

--- a/tests-system/rbt-single-value-assignment/output.brief
+++ b/tests-system/rbt-single-value-assignment/output.brief
@@ -1,2 +1,3 @@
 rbt-single-value-assignment/foo.trlc:6:3: trlc error: component 'critical' already assigned at line 4
 rbt-single-value-assignment/foo.trlc:12:3: trlc error: component 'description' already assigned at line 10
+Processed 1 model and 1 requirement file and found 2 errors

--- a/tests-system/rbt-startswith-semantics/output.brief
+++ b/tests-system/rbt-startswith-semantics/output.brief
@@ -1,0 +1,1 @@
+Processed 1 model and 1 requirement file and found no issues

--- a/tests-system/rbt-static-regular-expression/output.brief
+++ b/tests-system/rbt-static-regular-expression/output.brief
@@ -1,1 +1,2 @@
 rbt-static-regular-expression/foo.rsl:9:16: trlc error: cannot be used in a static context
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/rbt-string-values/output.brief
+++ b/tests-system/rbt-string-values/output.brief
@@ -1,0 +1,1 @@
+Processed 1 model and 1 requirement file and found no issues

--- a/tests-system/rbt-sufficiently-distinct-1/output.brief
+++ b/tests-system/rbt-sufficiently-distinct-1/output.brief
@@ -1,3 +1,4 @@
 rbt-sufficiently-distinct-1/test.trlc:5:3: trlc error: Foo is too similar to foo, declared at test.trlc:3
 rbt-sufficiently-distinct-1/test.trlc:7:3: trlc error: f_oo is too similar to foo, declared at test.trlc:3
 rbt-sufficiently-distinct-1/test.trlc:9:3: trlc error: f_O_o is too similar to foo, declared at test.trlc:3
+Processed 1 model and 1 requirement file and found 3 errors

--- a/tests-system/rbt-sufficiently-distinct-2/output.brief
+++ b/tests-system/rbt-sufficiently-distinct-2/output.brief
@@ -1,1 +1,2 @@
 rbt-sufficiently-distinct-2/test.rsl:7:3: trlc error: FooBar is too similar to Foo_Bar, declared at test.rsl:6
+Processed 1 model and 0 requirement files and found 1 error

--- a/tests-system/rbt-sufficiently-distinct-3/output.brief
+++ b/tests-system/rbt-sufficiently-distinct-3/output.brief
@@ -1,2 +1,3 @@
 rbt-sufficiently-distinct-3/foo.rsl:7:6: trlc error: tbar is too similar to T_Bar, declared at foo.rsl:3
 rbt-sufficiently-distinct-3/foo.trlc:7:7: trlc error: bar_kitten is too similar to Bar_Kitten, declared at foo.trlc:3
+Processed 1 model and 1 requirement file and found 2 errors

--- a/tests-system/rbt-tuple-declaration/output.brief
+++ b/tests-system/rbt-tuple-declaration/output.brief
@@ -1,1 +1,2 @@
 rbt-tuple-declaration/foo.trlc:12:17: trlc check warning: Please link to a specific version
+Processed 1 model and 1 requirement file and found 1 warning

--- a/tests-system/rbt-tuple-field-types/output.brief
+++ b/tests-system/rbt-tuple-field-types/output.brief
@@ -1,1 +1,2 @@
 rbt-tuple-field-types/foo.rsl:6:16: trlc error: unknown symbol List
+Processed 1 model and 0 requirement files and found 1 error

--- a/tests-system/rbt-tuple-generic-form/output.brief
+++ b/tests-system/rbt-tuple-generic-form/output.brief
@@ -1,1 +1,2 @@
 rbt-tuple-generic-form/foo.trlc:4:14: trlc error: expected string literal, encountered decimal literal instead
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/rbt-tuple-optional-fields/output.brief
+++ b/tests-system/rbt-tuple-optional-fields/output.brief
@@ -1,1 +1,2 @@
 rbt-tuple-optional-fields/foo.rsl:8:5: trlc error: expected keyword optional, encountered identifier instead
+Processed 1 model and 0 requirement files and found 1 error

--- a/tests-system/rbt-tuple-optional-requires-separators/output.brief
+++ b/tests-system/rbt-tuple-optional-requires-separators/output.brief
@@ -1,1 +1,2 @@
 rbt-tuple-optional-requires-separators/foo.rsl:6:5: trlc error: optional only permitted in tuples with separators
+Processed 1 model and 0 requirement files and found 1 error

--- a/tests-system/rbt-tuple-separator-form-1/output.brief
+++ b/tests-system/rbt-tuple-separator-form-1/output.brief
@@ -1,1 +1,2 @@
 rbt-tuple-separator-form-1/foo.trlc:4:11: trlc error: expected integer literal, encountered separator ':' instead
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/rbt-tuple-separator-form-2/output.brief
+++ b/tests-system/rbt-tuple-separator-form-2/output.brief
@@ -1,0 +1,1 @@
+Processed 1 model and 1 requirement file and found no issues

--- a/tests-system/rbt-tuple-separators-all-or-none/output.brief
+++ b/tests-system/rbt-tuple-separators-all-or-none/output.brief
@@ -1,1 +1,2 @@
 rbt-tuple-separators-all-or-none/foo.rsl:6:3: trlc error: either all fields must be separated, or none
+Processed 1 model and 0 requirement files and found 1 error

--- a/tests-system/rbt-tuple-syntax-correct-form/output.brief
+++ b/tests-system/rbt-tuple-syntax-correct-form/output.brief
@@ -1,2 +1,3 @@
 rbt-tuple-syntax-correct-form/foo.trlc:5:13: trlc error: expected opening parenthesis '(', encountered integer literal instead
 rbt-tuple-syntax-correct-form/foo.trlc:9:11: trlc error: expected integer literal, encountered opening parenthesis '(' instead
+Processed 1 model and 1 requirement file and found 2 errors

--- a/tests-system/rbt-tuple-unique-field-names/output.brief
+++ b/tests-system/rbt-tuple-unique-field-names/output.brief
@@ -1,1 +1,2 @@
 rbt-tuple-unique-field-names/foo.rsl:12:3: trlc error: duplicate definition, previous definition at foo.rsl:10
+Processed 1 model and 0 requirement files and found 1 error

--- a/tests-system/rbt-unary-minus-parsing/output.brief
+++ b/tests-system/rbt-unary-minus-parsing/output.brief
@@ -1,0 +1,1 @@
+Processed 1 model and 0 requirement files and found no issues

--- a/tests-system/rbt-unique-enumeration-literals/output.brief
+++ b/tests-system/rbt-unique-enumeration-literals/output.brief
@@ -1,1 +1,2 @@
 rbt-unique-enumeration-literals/foo.rsl:6:3: trlc error: duplicate definition, previous definition at foo.rsl:4
+Processed 2 models and 0 requirement files and found 1 error

--- a/tests-system/rbt-unique-object-names/output.brief
+++ b/tests-system/rbt-unique-object-names/output.brief
@@ -1,3 +1,4 @@
 rbt-unique-object-names/foo.trlc:3:3: trlc error: duplicate definition, previous definition at foo.rsl:1
 rbt-unique-object-names/foo.trlc:5:3: trlc error: duplicate definition, previous definition at foo.rsl:3
 rbt-unique-object-names/foo.trlc:9:3: trlc error: duplicate definition, previous definition at foo.trlc:7
+Processed 1 model and 1 requirement file and found 3 errors

--- a/tests-system/rbt-universal-quantification-semantics/output.brief
+++ b/tests-system/rbt-universal-quantification-semantics/output.brief
@@ -1,2 +1,3 @@
 rbt-universal-quantification-semantics/foo.trlc:3:3: trlc check warning: All items must be positive
 rbt-universal-quantification-semantics/foo.trlc:11:3: trlc check warning: All items must be positive
+Processed 1 model and 1 requirement file and found 2 warnings

--- a/tests-system/rbt-valid-access-prefixes/output.brief
+++ b/tests-system/rbt-valid-access-prefixes/output.brief
@@ -1,2 +1,3 @@
 rbt-valid-access-prefixes/foo.rsl:21:28: trlc error: unknown symbol third
 rbt-valid-access-prefixes/foo.trlc:4:11: trlc error: unknown symbol D
+Processed 1 model and 1 requirement file and found 2 errors

--- a/tests-system/rbt-valid-base-names/output.brief
+++ b/tests-system/rbt-valid-base-names/output.brief
@@ -1,1 +1,2 @@
 rbt-valid-base-names/foo.trlc:8:5: trlc error: unknown symbol T
+Processed 2 models and 1 requirement file and found 1 error

--- a/tests-system/rbt-valid-components/output.brief
+++ b/tests-system/rbt-valid-components/output.brief
@@ -1,1 +1,2 @@
 rbt-valid-components/foo.trlc:4:5: trlc error: cannot overwrite frozen component a
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/rbt-valid-enumeration-literals/output.brief
+++ b/tests-system/rbt-valid-enumeration-literals/output.brief
@@ -1,2 +1,3 @@
 rbt-valid-enumeration-literals/foo.trlc:4:10: trlc error: unknown symbol Enumm
 rbt-valid-enumeration-literals/foo.trlc:8:15: trlc error: unknown symbol D
+Processed 1 model and 1 requirement file and found 2 errors

--- a/tests-system/rbt-valid-function-prefixes/output.brief
+++ b/tests-system/rbt-valid-function-prefixes/output.brief
@@ -1,1 +1,2 @@
 rbt-valid-function-prefixes/foo.rsl:10:5: trlc error: unknown symbol size
+Processed 1 model and 0 requirement files and found 1 error

--- a/tests-system/rbt-valid-index-prefixes/output.brief
+++ b/tests-system/rbt-valid-index-prefixes/output.brief
@@ -1,1 +1,2 @@
 rbt-valid-index-prefixes/foo.rsl:9:12: trlc error: expression 'b' has type Integer, which is not an array
+Processed 1 model and 0 requirement files and found 1 error

--- a/tests-system/rbt-valid-record-types/output.brief
+++ b/tests-system/rbt-valid-record-types/output.brief
@@ -1,1 +1,2 @@
 rbt-valid-record-types/foo.trlc:7:1: trlc error: cannot declare object of abstract record type Ref
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/recovery-1/output.brief
+++ b/tests-system/recovery-1/output.brief
@@ -1,3 +1,4 @@
 recovery-1/test_1.rsl:6:1: trlc error: expected identifier, encountered keyword instead
 recovery-1/test_1.trlc:12:3: trlc error: unknown symbol i
 recovery-1/test_1.trlc:15:3: trlc error: unknown symbol kitten
+Processed 1 model and 1 requirement file and found 3 errors

--- a/tests-system/redefined-attribute/output.brief
+++ b/tests-system/redefined-attribute/output.brief
@@ -1,1 +1,2 @@
 redefined-attribute/instances.trlc:5:16: trlc check error: name must start with Q
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/simple-info-warn-error/output.brief
+++ b/tests-system/simple-info-warn-error/output.brief
@@ -10,3 +10,4 @@ simple-info-warn-error/instances.trlc:13:24: trlc check error: name must start w
 simple-info-warn-error/instances.trlc:13:24: trlc check error: name must start with E
 simple-info-warn-error/instances.trlc:13:24: trlc check warning: name must start with W
 simple-info-warn-error/instances.trlc:13:24: trlc check warning: name must start with I
+Processed 1 model and 1 requirement file and found 6 warnings and 6 errors

--- a/tests-system/simple-instance-type-reference/output.brief
+++ b/tests-system/simple-instance-type-reference/output.brief
@@ -1,0 +1,1 @@
+Processed 1 model and 1 requirement file and found no issues

--- a/tests-system/simple-more-than-one/output.brief
+++ b/tests-system/simple-more-than-one/output.brief
@@ -1,2 +1,3 @@
 simple-more-than-one/instances.trlc:9:24: trlc check error: name must start with Q
 simple-more-than-one/instances.trlc:13:24: trlc check error: name must start with Q
+Processed 1 model and 1 requirement file and found 2 errors

--- a/tests-system/simple/output.brief
+++ b/tests-system/simple/output.brief
@@ -1,0 +1,1 @@
+Processed 2 models and 1 requirement file and found no issues

--- a/tests-system/strings/output.brief
+++ b/tests-system/strings/output.brief
@@ -1,0 +1,1 @@
+Processed 1 model and 1 requirement file and found no issues

--- a/tests-system/tuples-2/output.brief
+++ b/tests-system/tuples-2/output.brief
@@ -1,1 +1,2 @@
 tuples-2/foo.trlc:10:18: trlc error: expected integer literal, encountered = instead
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/tuples-3/output.brief
+++ b/tests-system/tuples-3/output.brief
@@ -1,0 +1,1 @@
+Processed 1 model and 1 requirement file and found no issues

--- a/tests-system/tuples-4/output.brief
+++ b/tests-system/tuples-4/output.brief
@@ -1,2 +1,3 @@
 tuples-4/foo.trlc:6:7: trlc error: lhs of check f2 >= 0 (foo.rsl:12) must not be null
 tuples-4/foo.trlc:14:14: trlc check warning: potato2
+Processed 1 model and 1 requirement file and found 1 warning and 1 error

--- a/tests-system/tuples-5/output.brief
+++ b/tests-system/tuples-5/output.brief
@@ -1,1 +1,2 @@
 tuples-5/foo.trlc:14:14: trlc check warning: potato2
+Processed 1 model and 1 requirement file and found 1 warning

--- a/tests-system/tuples-6/output.brief
+++ b/tests-system/tuples-6/output.brief
@@ -1,1 +1,2 @@
 tuples-6/foo.trlc:10:24: trlc check warning: potato
+Processed 1 model and 1 requirement file and found 1 warning

--- a/tests-system/tutorial-1/output.brief
+++ b/tests-system/tutorial-1/output.brief
@@ -1,1 +1,2 @@
 tutorial-1/car.trlc:13:13: trlc error: required component critical (see model.rsl:5) is not defined
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/tutorial-2/output.brief
+++ b/tests-system/tutorial-2/output.brief
@@ -1,1 +1,2 @@
 tutorial-2/example.trlc:4:17: trlc check warning: this is not very descriptive
+Processed 1 model and 1 requirement file and found 1 warning

--- a/tests-system/type-qualifiers-1/output.brief
+++ b/tests-system/type-qualifiers-1/output.brief
@@ -1,0 +1,1 @@
+Processed 1 model and 1 requirement file and found no issues

--- a/tests-system/type-qualifiers-2/output.brief
+++ b/tests-system/type-qualifiers-2/output.brief
@@ -1,1 +1,2 @@
 type-qualifiers-2/foo.trlc:3:1: trlc error: cannot declare object of abstract record type T1
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/type-qualifiers-3/output.brief
+++ b/tests-system/type-qualifiers-3/output.brief
@@ -1,1 +1,2 @@
 type-qualifiers-3/foo.rsl:20:3: trlc error: cannot declare new components in final record type
+Processed 1 model and 0 requirement files and found 1 error

--- a/tests-system/type-qualifiers-4/output.brief
+++ b/tests-system/type-qualifiers-4/output.brief
@@ -1,0 +1,1 @@
+Processed 2 models and 0 requirement files and found no issues

--- a/tests-system/typesystem-1/output.brief
+++ b/tests-system/typesystem-1/output.brief
@@ -1,1 +1,2 @@
 typesystem-1/instances.trlc:5:24: trlc error: expected string literal, encountered integer literal instead
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/typesystem-2/output.brief
+++ b/tests-system/typesystem-2/output.brief
@@ -1,3 +1,4 @@
 typesystem-2/foo.trlc:4:7: trlc error: expected integer literal, encountered decimal literal instead
 typesystem-2/foo.trlc:8:7: trlc error: expected integer literal, encountered decimal literal instead
 typesystem-2/foo.trlc:12:7: trlc error: expected decimal literal, encountered integer literal instead
+Processed 1 model and 1 requirement file and found 3 errors

--- a/tests-system/typesystem-mismatch-enums/output.brief
+++ b/tests-system/typesystem-mismatch-enums/output.brief
@@ -1,1 +1,2 @@
 typesystem-mismatch-enums/instances.trlc:6:20: trlc error: expected ASIL
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/typesystem-ok/output.brief
+++ b/tests-system/typesystem-ok/output.brief
@@ -1,0 +1,1 @@
+Processed 1 model and 1 requirement file and found no issues

--- a/tests-system/unicode/output.brief
+++ b/tests-system/unicode/output.brief
@@ -1,2 +1,3 @@
 unicode/instances.trlc:4:16: trlc error: unexpected character 'Ü'
 unicode/instances.trlc:4:22: trlc error: unexpected character 'ö'
+Processed 1 model and 1 requirement file and found 2 errors

--- a/tests-system/value-converter/output.brief
+++ b/tests-system/value-converter/output.brief
@@ -1,0 +1,1 @@
+Processed 1 model and 1 requirement file and found no issues

--- a/tests-system/value-exact/output.brief
+++ b/tests-system/value-exact/output.brief
@@ -1,1 +1,2 @@
 value-exact/instances.trlc:5:24: trlc check error: name must be 'Qbert'
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/visibility-1/output.brief
+++ b/tests-system/visibility-1/output.brief
@@ -1,1 +1,2 @@
 visibility-1/bar.trlc:3:1: trlc error: package must be imported before use
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/whitespace/output.brief
+++ b/tests-system/whitespace/output.brief
@@ -1,0 +1,1 @@
+Processed 0 models and 1 requirement file and found no issues

--- a/tests-system/xbase-operators/output.brief
+++ b/tests-system/xbase-operators/output.brief
@@ -1,1 +1,2 @@
 xbase-operators/instances.trlc:5:24: trlc check error: Must fail
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/xref-2/output.brief
+++ b/tests-system/xref-2/output.brief
@@ -1,1 +1,2 @@
 xref-2/bar.rsl:16:24: trlc error: expression 'link' has type MyType, which is not a tuple
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/xref-correct-lowercase/output.brief
+++ b/tests-system/xref-correct-lowercase/output.brief
@@ -1,0 +1,1 @@
+Processed 1 model and 1 requirement file and found no issues

--- a/tests-system/xref-correct/output.brief
+++ b/tests-system/xref-correct/output.brief
@@ -1,0 +1,1 @@
+Processed 1 model and 1 requirement file and found no issues

--- a/tests-system/xref-expressions/output.brief
+++ b/tests-system/xref-expressions/output.brief
@@ -1,0 +1,1 @@
+Processed 1 model and 2 requirement files and found no issues

--- a/tests-system/xref-uniqueness-across-files/output.brief
+++ b/tests-system/xref-uniqueness-across-files/output.brief
@@ -1,1 +1,2 @@
 xref-uniqueness-across-files/f2.trlc:3:5: trlc error: duplicate definition, previous definition at f1.trlc:4
+Processed 1 model and 2 requirement files and found 1 error

--- a/tests-system/xref/output.brief
+++ b/tests-system/xref/output.brief
@@ -1,1 +1,2 @@
 xref/instances.trlc:3:16: trlc check error: Must be linked
+Processed 1 model and 1 requirement file and found 1 error

--- a/trlc/trlc.py
+++ b/trlc/trlc.py
@@ -604,7 +604,8 @@ def trlc():
                            default=False,
                            action="store_true",
                            help=("Simpler output intended for CI. Does not"
-                                 " show context or additional information."))
+                                 " show context or additional information,"
+                                 " but prints the usual summary at the end."))
     og_output.add_argument("--no-detailed-info",
                            default=False,
                            action="store_true",
@@ -745,50 +746,49 @@ def trlc():
 
             print(json.dumps(tmp, indent=2, sort_keys=True))
 
-    if not options.brief:
-        total_models = len(sm.rsl_files)
-        parsed_models = len([item
-                             for item in sm.rsl_files.values()
-                             if item.primary or item.secondary])
-        total_trlc = len(sm.trlc_files)
-        parsed_trlc = len([item
-                           for item in sm.trlc_files.values()
-                           if item.primary or item.secondary])
+    total_models = len(sm.rsl_files)
+    parsed_models = len([item
+                            for item in sm.rsl_files.values()
+                            if item.primary or item.secondary])
+    total_trlc = len(sm.trlc_files)
+    parsed_trlc = len([item
+                        for item in sm.trlc_files.values()
+                        if item.primary or item.secondary])
 
-        def count(parsed, total, what):
-            rv = str(parsed)
-            if parsed < total:
-                rv += " (of %u)" % total
-            rv += " " + what
-            if total == 0 or total > 1:
-                rv += "s"
-            return rv
+    def count(parsed, total, what):
+        rv = str(parsed)
+        if parsed < total:
+            rv += " (of %u)" % total
+        rv += " " + what
+        if total == 0 or total > 1:
+            rv += "s"
+        return rv
 
-        summary = "Processed %s" % count(parsed_models,
-                                         total_models,
-                                         "model")
+    summary = "Processed %s" % count(parsed_models,
+                                        total_models,
+                                        "model")
 
-        if not options.skip_trlc_files:  # pragma: no cover
-            summary += " and %s" % count(parsed_trlc,
-                                         total_trlc,
-                                         "requirement file")
+    if not options.skip_trlc_files:  # pragma: no cover
+        summary += " and %s" % count(parsed_trlc,
+                                        total_trlc,
+                                        "requirement file")
 
-        summary += " and found"
+    summary += " and found"
 
-        if mh.errors and mh.warnings:
-            summary += " %s" % count(mh.warnings, mh.warnings, "warning")
-            summary += " and %s" % count(mh.errors, mh.errors, "error")
-        elif mh.warnings:
-            summary += " %s" % count(mh.warnings, mh.warnings, "warning")
-        elif mh.errors:
-            summary += " %s" % count(mh.errors, mh.errors, "error")
-        else:
-            summary += " no issues"
+    if mh.errors and mh.warnings:
+        summary += " %s" % count(mh.warnings, mh.warnings, "warning")
+        summary += " and %s" % count(mh.errors, mh.errors, "error")
+    elif mh.warnings:
+        summary += " %s" % count(mh.warnings, mh.warnings, "warning")
+    elif mh.errors:
+        summary += " %s" % count(mh.errors, mh.errors, "error")
+    else:
+        summary += " no issues"
 
-        if mh.suppressed:  # pragma: no cover
-            summary += " with %u supressed messages" % mh.suppressed
+    if mh.suppressed:  # pragma: no cover
+        summary += " with %u supressed messages" % mh.suppressed
 
-        print(summary)
+    print(summary)
 
     if options.show_file_list and ok:  # pragma: no cover
         def get_status(parser):


### PR DESCRIPTION
The statistics numbers are always printed,
regardless of the command line argument `--brief`.

That is, the tool always prints a message like this at the end:
`Processed 1 model and 1 requirement file and found no issues`

When admins integrate TRLC as a voting job into their CI they want
to get feedback if the tool finished without sudden termination
(possibly caused by the CI system).