### PR TITLE
Pin LOBSTER version in "docs" workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements_dev.txt
-          pip install bmw-lobster-core bmw-lobster-tool-python
+          pip install bmw-lobster-core==0.14.4 bmw-lobster-tool-python==0.14.4
           pip install --no-deps bmw-lobster-tool-trlc
           sudo apt-get install -y graphviz
       - name: Fetch CVC5


### PR DESCRIPTION
Use specific version of LOBSTER to ensure that future changes of LOBSTER do not break the workflow.