### PR TITLE
Fix sha256 for cvc5_mac

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -101,7 +101,7 @@ http_archive(
 http_archive(
     name = "cvc5_mac",
     build_file = "@trlc//:cvc5.BUILD",
-    sha256 = "9b00ae44d51903cd830e281c97066d7e4c0a57f1aa6c5b275435d3016427be64",
+    sha256 = "6c63ba3bd174d026be161be75f64df8d200c8a284012c49e91807f3ede5afc44",
     strip_prefix = "cvc5-macOS-arm64-static-gpl",
     url = "https://github.com/cvc5/cvc5/releases/download/cvc5-1.3.2/cvc5-macOS-arm64-static-gpl.zip",
 )


### PR DESCRIPTION
---

## Issue: Incorrect CVC5 1.3.2 macOS ARM64 SHA256 Checksum in MODULE.bazel

**Description**:
The TRLC MODULE.bazel contains an incorrect SHA256 checksum for the CVC5 1.3.2 macOS ARM64 static GPL binary.

**Current (incorrect) value**:
```
sha256 = "9b00ae44d51903cd830e281c97066d7e4c0a57f1aa6c5b275435d3016427be64"
```

**Expected (correct) value**:
```
sha256 = "6c63ba3bd174d026be161be75f64df8d200c8a284012c49e91807f3ede5afc44"
```

**Verification**:
The correct checksum can be verified by downloading the file directly:
```bash
wget https://github.com/cvc5/cvc5/releases/download/cvc5-1.3.2/cvc5-macOS-arm64-static-gpl.zip
shasum -a 256 cvc5-macOS-arm64-static-gpl.zip
# Output: 6c63ba3bd174d026be161be75f64df8d200c8a284012c49e91807f3ede5afc44
```

**Bazel Impact**:
- **Checksum Validation Failure**: Bazel 8+ strict downloader validation will reject the download with: `checksum mismatch: expected 9b00ae44..., got 6c63ba3bd...`
- **CI/CD Breakage**: Prevents `bazel mod tidy` and `bazel test` from succeeding.
- **Workaround Required**: Users must apply local patches to override the incorrect checksum, creating maintenance burden

**Impact**:
Users attempting to use TRLC with Bazel's downloader/http_archive will face checksum validation failures, requiring local patches to work around the issue.

**Fix**:
Update the SHA256 value in `MODULE.bazel` for the `cvc5_mac` http_archive rule to use the correct checksum.

---
