### PR TITLE
Added automated TRLC to BCR release pipeline

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,0 +1,23 @@
+{
+    "homepage": "https://github.com/bmw-software-engineering/trlc",
+    "maintainers": [
+        {
+            "email": "Ambuj.Singh@bti.bmwgroup.com",
+            "github": "AAmbuj",
+            "name": "Ambuj Singh Kushwaha",
+            "github_user_id": 73685939
+        },
+        {
+            "email": "Rahul.Sutariya@bti.bmwgroup.com",
+            "github": "Rahul-Sutariya",
+            "name": "RAHUL SUTARIYA",
+            "github_user_id": 113970414
+        }
+    ],
+    "repository": [
+        "github:bmw-software-engineering/trlc"
+    ],
+    "versions": [],
+    "yanked_versions": {}
+}
+

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,0 +1,26 @@
+incompatible_flags:
+  "--incompatible_config_setting_private_default_visibility":
+    - 8.x
+  "--incompatible_disable_starlark_host_transitions":
+    - 8.x
+  "--incompatible_disable_native_repo_rules":
+    - 8.x
+  "--incompatible_strict_action_env":
+    - 8.x
+matrix:
+  platform:
+  - ubuntu2204
+  - windows
+  bazel:
+  - 8.x
+tasks:
+  verify_api_examples:
+    name: "Verify api-examples"
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - "@trlc//api-examples/..."
+    test_flags:
+    - "--@@rules_python+//python/config_settings:python_version=3.12"
+    test_targets:
+    - "@trlc//api-examples/..."

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "**leave this alone**",
+    "strip_prefix": "{REPO}-{VERSION}",
+    "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/{TAG}.tar.gz"
+}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,42 @@
+name: Publish to BCR
+
+on:
+  workflow_call:
+    inputs:
+      tag_name:
+        required: true
+        type: string
+      registry_fork:
+        required: false
+        type: string
+        default: bmw-software-engineering/bazel-central-registry
+    secrets:
+      BCR_PUBLISH_TOKEN:
+        required: true
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: Git tag being released
+        required: true
+        type: string
+      registry_fork:
+        description: GitHub fork used to open the BCR PR (owner/repo)
+        required: false
+        type: string
+        default: bmw-software-engineering/bazel-central-registry
+
+jobs:
+  publish:
+    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v1.2.0
+    with:
+      tag_name: ${{ inputs.tag_name }}
+      registry_fork: ${{ inputs.registry_fork }}
+      draft: false
+      attest: true
+      tag_prefix: "trlc-"
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    secrets:
+      publish_token: ${{ secrets.BCR_PUBLISH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: Git tag being released
+        required: true
+        type: string
+      registry_fork:
+        description: GitHub fork used to open the BCR PR (owner/repo)
+        required: false
+        type: string
+        default: bmw-software-engineering/bazel-central-registry
+  push:
+    tags:
+      - "trlc-*"
+
+permissions:
+  id-token: write
+  attestations: write
+  contents: write
+
+jobs:
+  release:
+    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.4.0
+    with:
+      release_files: archives/*.*
+      prerelease: false
+      draft: true
+      tag_name: ${{ inputs.tag_name || github.ref_name }}
+      bazel_test_command: "echo 'Tests skipped during release (run in CI workflow)'"
+      mount_bazel_caches: false
+    permissions:
+      id-token: write
+      attestations: write
+      contents: write
+    secrets: {}
+
+  publish:
+    needs: release
+    uses: ./.github/workflows/publish.yml
+    with:
+      tag_name: ${{ inputs.tag_name || github.ref_name }}
+      registry_fork: ${{ inputs.registry_fork || 'bmw-software-engineering/bazel-central-registry' }}
+    secrets:
+      BCR_PUBLISH_TOKEN: ${{ secrets.BCR_PUBLISH_TOKEN }}
+
+  finalize:
+    needs: publish
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - name: Publish draft release
+        run: gh release edit "$TAG" --draft=false --repo "$GITHUB_REPOSITORY"
+        env:
+          TAG: ${{ inputs.tag_name || github.ref_name }}
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o pipefail
+
+TAG="$1"
+# Tags use the format "trlc-X.Y.Z"; strip the prefix to get the bare version
+# matching the tag_prefix configured in publish.yml
+if [[ "$TAG" == trlc-* ]]; then
+  VERSION="${TAG#trlc-}"
+else
+  echo "ERROR: tag '${TAG}' does not match expected format 'trlc-X.Y.Z'" >&2
+  exit 1
+fi
+
+mkdir -p archives
+
+PREFIX="trlc-${VERSION}"
+ARCHIVE="archives/${TAG}.tar.gz"
+
+git archive --format=tar --prefix="${PREFIX}/" "$TAG" | gzip > "$ARCHIVE"
+
+SHA=$(sha256sum "$ARCHIVE" | awk '{print $1}')
+
+cat << EOF
+## Bzlmod
+
+Add this to your MODULE.bazel:
+
+\`\`\`starlark
+bazel_dep(name = "trlc", version = "${VERSION}")
+\`\`\`
+
+## WORKSPACE
+
+\`\`\`starlark
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+    name = "trlc",
+    sha256 = "${SHA}",
+    strip_prefix = "${PREFIX}",
+    url = "https://github.com/bmw-software-engineering/trlc/releases/download/${TAG}/${TAG}.tar.gz",
+)
+\`\`\`
+EOF

--- a/documentation/TUTORIAL-BCR-RELEASE.md
+++ b/documentation/TUTORIAL-BCR-RELEASE.md
@@ -1,0 +1,72 @@
+# Automated TRLC to BCR Release
+
+This document describes the automated release flow that publishes TRLC
+to the [Bazel Central Registry](https://github.com/bazelbuild/bazel-central-registry)
+(BCR).
+
+## How It Works
+
+Releases are automated through GitHub Actions:
+
+1. Push a release tag using the format `trlc-X.Y.Z`.
+2. Workflow [`release.yml`](../.github/workflows/release.yml) creates a draft GitHub
+   release and uploads `trlc-{TAG}.tar.gz`.
+3. Workflow [`publish.yml`](../.github/workflows/publish.yml) opens a Bazel Central
+   Registry PR through
+   [publish-to-bcr](https://github.com/bazel-contrib/publish-to-bcr).
+4. After BCR publish succeeds, the release is finalized (published),
+   which triggers [`package.yml`](../.github/workflows/package.yml) to publish wheels to
+   PyPI.
+
+## Required Repository Secret
+
+* `BCR_PUBLISH_TOKEN`: Classic PAT with `workflow` and `repo` scopes,
+  with access to your BCR fork (default fork:
+  `bmw-software-engineering/bazel-central-registry`).
+
+## BCR Template Files
+
+The [`.bcr/`](../.bcr/) directory contains template files used by the
+`publish-to-bcr` action:
+
+| File | Purpose |
+|------|---------|
+| [`presubmit.yml`](../.bcr/presubmit.yml) | Defines BCR presubmit CI: platforms, build/test targets |
+| [`source.template.json`](../.bcr/source.template.json) | Template for the source archive URL and integrity hash |
+| [`metadata.template.json`](../.bcr/metadata.template.json) | Module metadata (maintainers, homepage) |
+
+## Presubmit Platforms
+
+The BCR CI runs on platforms from the
+[Bazel CI infrastructure](https://github.com/bazelbuild/continuous-integration/blob/master/buildkite/bazelci.py).
+Currently configured: `ubuntu2204`, `windows`.
+
+## Release Preparation Script
+
+[`release_prep.sh`](../.github/workflows/release_prep.sh) is a helper that:
+
+1. Validates the tag format (`trlc-X.Y.Z`)
+2. Creates a reproducible source archive via `git archive`
+3. Computes the SHA-256 checksum
+4. Prints Markdown install snippets (Bzlmod and WORKSPACE) for release
+   notes
+
+## Triggering a Release
+
+```bash
+# Tag and push
+git tag trlc-1.2.3
+git push origin trlc-1.2.3
+```
+
+The `push: tags: ["trlc-*"]` trigger in [`release.yml`](../.github/workflows/release.yml) starts the
+pipeline automatically.
+
+## Manual Dispatch
+
+Both [`release.yml`](../.github/workflows/release.yml) and [`publish.yml`](../.github/workflows/publish.yml) support `workflow_dispatch` for
+manual re-runs from the GitHub Actions UI. You must provide:
+
+* `tag_name`: the git tag (e.g. `trlc-1.2.3`)
+* `registry_fork`: the BCR fork to push to (e.g.
+  `bmw-software-engineering/bazel-central-registry`)

--- a/documentation/TUTORIAL.md
+++ b/documentation/TUTORIAL.md
@@ -25,4 +25,6 @@
 * [Advaned tips & tricks](TUTORIAL-ADVANCED-TYPES.md): some more
   advanced tips and tricks for large organisations
 * [Python API](TUTORIAL-API.md): writing a custom check with the API
+* [Bazel Integration](TUTORIAL-BAZEL.md): using TRLC with Bazel
+* [BCR Release](TUTORIAL-BCR-RELEASE.md): automated publishing to the Bazel Central Registry
 * [CI Integration](TUTORIAL-CI.md): tips on how to integrate in your CI


### PR DESCRIPTION
This PR adds automated publishing of TRLC to the Bazel Central Registry (BCR) via the publish-to-bcr reusable workflow.

**How it works**
1. Push a release tag in the format trlc-X.Y.Z
2. release.yml creates a draft GitHub release with a source archive
3. publish.yml opens a PR against the BCR through the configured fork
4. After BCR publish succeeds, the release is finalized, triggering package.yml to publish wheels to PyPI

**Files added/changed**
- presubmit.yml — BCR presubmit CI config (platforms: ubuntu2204, windows; Python 3.12)
- source.template.json — Source archive URL template (integrity hash auto-computed by tooling)
- metadata.template.json — Module metadata (maintainers, repository)
- release.yml — Release workflow (creates draft release + triggers publish)
- publish.yml — BCR publish workflow (opens PR against BCR)
- release_prep.sh — Helper script for archive creation and release notes
- TUTORIAL-BCR-RELEASE.md — Developer documentation for the release flow
- TUTORIAL.md — Added link to BCR release docs
- README.md — Removed inline release flow section (moved to dedicated doc)

**Notes**
- MODULE.bazel keeps version = "0.0.0" as a development placeholder. The publish-to-bcr action automatically generates a module_dot_bazel_version.patch at publish time to set the correct version from the tag. This is the standard pattern used by rules_python, rules_go, and other major Bazel rulesets.
- Author/committer identity for BCR commits uses the reusable workflow defaults (the GitHub actor who triggers the workflow).
- Required setup: Add a repository secret named BCR_PUBLISH_TOKEN — a Classic PAT with repo and workflow scopes from the GitHub account that can push to the configured BCR fork (bmw-software-engineering/bazel-central-registry).