### PR TITLE
Fixed cvc5.BUILD to use correct binary name on Windows

### DIFF
--- a/cvc5.BUILD
+++ b/cvc5.BUILD
@@ -1,5 +1,8 @@
 filegroup(
     name = "cvc5",
-    srcs = ["bin/cvc5"],
+    srcs = select({
+        "@bazel_tools//src/conditions:windows": ["bin/cvc5.exe"],
+        "//conditions:default": ["bin/cvc5"],
+    }),
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Windows CVC5 archive ships bin/cvc5.exe, not bin/cvc5. Use a platform-aware select() so the filegroup references the correct binary name on each OS.