### PR TITLE
Updated `CHANGELOG.md` regarding cvc5.BUILD to use platform-aware binary path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ generated in the following situations:
 
 
 
+### 2.0.5-dev
+
+* [BAZEL] Fix cvc5.BUILD to use platform-aware binary path
+  (`bin/cvc5.exe` on Windows, `bin/cvc5` elsewhere). 
+
 ### 2.0.4
 * [TRLC_RST] Add tool to convert TRLC Requirements to Sphinx RST Files
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,6 @@ generated in the following situations:
 
 ## Changelog
 
-
-### 2.0.5-dev
-
-
-
 ### 2.0.5-dev
 
 * [BAZEL] Fix cvc5.BUILD to use platform-aware binary path


### PR DESCRIPTION
(`bin/cvc5.exe` on Windows, `bin/cvc5` elsewhere).

This PR updates `CHANGELOG.md`
The feature has already been implemented in https://github.com/bmw-software-engineering/trlc/pull/182