### PR TITLE
Include `bigtree` in `requirements_dev.txt`

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,6 @@
 pyvcg==1.0.9
 cvc5>=1.3.2
+bigtree
 
 # Development tools
 pycodestyle>=2.12


### PR DESCRIPTION
Fixed:
The `requirements_dev.txt` was missing the `bigtree` package.