### PR TITLE
[sphinx] fix parallel parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ generated in the following situations:
 
 ## Changelog
 
+### 2.0.6-dev
+
+* [Sphinx] TRLC Plugin: fix parallel parsing: extension declareds parallel_read_safe -> only merge if worker actually
+  owns the document
+
 ### 2.0.5
 
 * [TRLC_RST] Render `Markup_String` `[[references]]` as Sphinx cross-references in the RST renderer.

--- a/tools/sphinx/extensions/trlc/trlc.py
+++ b/tools/sphinx/extensions/trlc/trlc.py
@@ -139,7 +139,11 @@ class RequirementsDomain(Domain):
         return []
 
     def merge_domaindata(self, docnames, otherdata):
-        self.data["requirements"].extend(otherdata["requirements"])
+        existing_anchors = {anchor for _name, _sig, _typ, _docname, anchor, _prio in self.data["requirements"]}
+        for _name, _sig, _typ, docname, anchor, _prio in otherdata["requirements"]:
+            if docname in docnames and anchor not in existing_anchors:
+                self.data["requirements"].append((_name, _sig, _typ, docname, anchor, _prio))
+                existing_anchors.add(anchor)
 
 
 def setup(app: Sphinx):


### PR DESCRIPTION
[Sphinx] TRLC Plugin: fix parallel parsing: extension declares parallel_read_safe -> only merge if worker actually owns the document