### PR TITLE
Fix RST directive handling to preserve blank separator lines

### DIFF
--- a/tools/trlc_rst/trlc_rst.py
+++ b/tools/trlc_rst/trlc_rst.py
@@ -380,9 +380,10 @@ class TRLCRST:
                 # Preserve empty lines for paragraph separation
                 processed_lines.append("")
                 prev_was_list_item = False
-                # Exit code block or directive on empty line
+                # Exit code block on empty line.
+                # Keep directive mode so blocks like ``.. list-table::`` can contain
+                # a blank separator line before their body rows.
                 in_code_block = False
-                in_directive = False
 
         return "\n".join(processed_lines)
 


### PR DESCRIPTION
## Description
Fix RST directive handling to support blank separator lines within directive bodies.

## Problem
Directives like `.. list-table::` require blank lines to separate rows, but the preprocessor was exiting directive mode on empty lines. This caused malformed RST output where directive content was not properly nested.

## Solution
Preserve directive mode when encountering blank lines while still properly exiting code block mode. The directive block remains active until indentation drops back to the base level, allowing blank separator lines to be included in the directive body.

## Changes
- Updated comment in `_preprocess_description()` to clarify behavior
- Removed unconditional `in_directive = False` assignment on empty lines
- Directive mode now only exits when indentation returns to base level

## Testing
This change improves handling of RST directives in TRLC description fields, particularly for structured content like tables with multi-row formatting.