### PR TITLE
Add VSCode folder to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ settings.json
 # OSX / VSCode ignores
 .DS_Store
 .idea
+.vscode
 
 # Build-System ignores
 bazel-*


### PR DESCRIPTION
Add the folder `.vscode` to `.gitignore`. The folder is created by Visual Studio Code at the root of the project and stores workspace settings.