### PR TITLE
Fix soft-wrap paragraph rendering in trlc_rst

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ generated in the following situations:
 
 ### 3.0.0-dev
 
+* [TRLC_RST] Render soft-wrapped description lines as a single RST
+  paragraph instead of splitting each line into its own paragraph.
+  Insert a blank line to start a new paragraph.
+
 * [TRLC, BAZEL] Removed the support for the CVC5 binary, and hence the
   `--use-cvc5-binary` option is no longer available.
   The option `--verify` now uses the CVC5 Python package

--- a/tools/trlc_rst/README.md
+++ b/tools/trlc_rst/README.md
@@ -60,7 +60,7 @@ The following formatting is supported in requirement `description` fields:
 | Code block | line ending with `::` followed by indented content | RST literal block |
 | Bullet list | lines starting with `-` | RST bullet list |
 | Numbered list | lines starting with `1.`, `2.`, … | RST enumerated list |
-| Line breaks | any non-empty line | separated by blank lines in RST |
+| Soft wraps | consecutive non-empty lines | joined into one RST paragraph; insert a blank line to start a new paragraph |
 
 ### Command-line Usage
 

--- a/tools/trlc_rst/tests/paragraph-breaks/output.rst
+++ b/tools/trlc_rst/tests/paragraph-breaks/output.rst
@@ -1,0 +1,10 @@
+Requirements
+============
+.. requirement:definition:: T.REQ_paragraph_breaks
+
+   The system shall do X
+   when condition Y is met.
+
+   This is a separate paragraph that
+   must not be merged with the first.
+

--- a/tools/trlc_rst/tests/paragraph-breaks/reqs.trlc
+++ b/tools/trlc_rst/tests/paragraph-breaks/reqs.trlc
@@ -1,0 +1,11 @@
+package T
+
+Requirement REQ_paragraph_breaks {
+    description = '''
+        The system shall do X
+        when condition Y is met.
+
+        This is a separate paragraph that
+        must not be merged with the first.
+    '''
+}

--- a/tools/trlc_rst/tests/paragraph-breaks/schema.rsl
+++ b/tools/trlc_rst/tests/paragraph-breaks/schema.rsl
@@ -1,0 +1,5 @@
+package T
+
+type Requirement {
+    description optional String
+}

--- a/tools/trlc_rst/tests/soft-wraps/output.rst
+++ b/tools/trlc_rst/tests/soft-wraps/output.rst
@@ -1,0 +1,8 @@
+Requirements
+============
+.. requirement:definition:: T.REQ_soft_wraps
+
+   The system shall do X
+   when condition Y is met
+   and Z is configured.
+

--- a/tools/trlc_rst/tests/soft-wraps/reqs.trlc
+++ b/tools/trlc_rst/tests/soft-wraps/reqs.trlc
@@ -1,0 +1,9 @@
+package T
+
+Requirement REQ_soft_wraps {
+    description = '''
+        The system shall do X
+        when condition Y is met
+        and Z is configured.
+    '''
+}

--- a/tools/trlc_rst/tests/soft-wraps/schema.rsl
+++ b/tools/trlc_rst/tests/soft-wraps/schema.rsl
@@ -1,0 +1,5 @@
+package T
+
+type Requirement {
+    description optional String
+}

--- a/tools/trlc_rst/trlc_rst.py
+++ b/tools/trlc_rst/trlc_rst.py
@@ -473,7 +473,8 @@ class TRLCRST:
         - RST directives: ``.. image::``, ``.. figure::``, etc. with options
         - Bullet lists: Lines starting with -
         - Numbered lists: Lines starting with 1., 2., etc.
-        - Line breaks: Preserved between all content lines"""
+        - Soft wraps: Consecutive non-empty lines are joined into a single
+          RST paragraph; insert a blank line to start a new paragraph."""
         if not description:
             return description
 
@@ -573,16 +574,6 @@ class TRLCRST:
                             code_block_base_indent = len(next_line) - len(
                                 next_line.lstrip()
                             )
-
-                    # Add blank line after non-list lines to preserve line breaks
-                    # (unless next line is empty, we're at the end, or we're in a code block)
-                    elif (
-                        not is_list_item
-                        and not in_code_block
-                        and i < len(lines) - 1
-                        and lines[i + 1].strip()
-                    ):
-                        processed_lines.append("")
 
                     prev_was_list_item = is_list_item
             else:


### PR DESCRIPTION
## Summary
- remove the blank-line injection that split soft-wrapped prose into separate RST paragraphs
- add a regression test fixture for a multi-line TRLC description that should remain one paragraph

## Testing
- bazel test //tools/trlc_rst/tests:soft-wraps //tools/trlc_rst/tests:all