### PR TITLE
Fix Link to LRM

### DIFF
--- a/documentation/TUTORIAL-CHECKS.md
+++ b/documentation/TUTORIAL-CHECKS.md
@@ -157,8 +157,8 @@ expressions. For example you can write:
 A ** 2 + B ** 2 == C ** 2
 ```
 
-For a full reference, please see the relevant section in the [language
-reference manual](language-reference-manual/LRM.md#expressions).
+For a full reference, please see section "Expressions" in the
+[language reference manual](https://bmw-software-engineering.github.io/trlc/lrm.html).
 
 ## Null
 


### PR DESCRIPTION
the tutorial readme file on "checks" linked to the "expressions" section in the LRM, but it pointed to the `LRM.md` file, which is just an index for the different LRM versions. So we could either link to the TRLC file `language-reference-manual/lrm.trlc`, but that is hard to read for the user that is just getting started with TRLC. So instead we link to the latest LRM HTML file.