### PR TITLE
Bazel: migrate lint/style checks to native Bazel configuration & add clean-coverage target

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,7 +1,8 @@
 common --enable_bzlmod
 
-build:lint --aspects=//tools/lint:linters.bzl%pylint,//tools/lint:linters.bzl%ty
+build:lint --aspects=//third_party/lint:linters.bzl%pylint,//third_party/lint:linters.bzl%ty
 build:lint --output_groups=+rules_lint_human
+build:lint --@aspect_rules_lint//lint:fail_on_violation
 
 # --combined_report=lcov merges per-test .dat files into one LCOV report.
 # --instrumentation_filter restricts instrumentation to the trlc library only.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -30,7 +30,8 @@ Adopt the following style over time in production code:
 - Do not use horizontal alignment for assignments, dict colons, or
   similar layout; use regular Python spacing instead.
 - Prefer smaller files and split toward one file per class where practical.
-- Format code according to Black-compatible conventions.
+- Format code according to Black-compatible conventions; enforced via Ruff
+  (`bazel run //:format.fix`) for Python and Buildifier for Starlark/BUILD files.
 - Class names shall no longer follow the Ada naming convention, but
   shall be in PascalCase (e.g., `MyClass`).
 - Function and method names shall be in snake_case (e.g., `my_function`).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,15 @@ permissions:
 
 jobs:
   lint:
-    name: PyLint
+    name: Bazel Lint
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Bazel
+        uses: bazel-contrib/setup-bazel@0.19.0
+        with:
+          bazelisk-cache: true
+          repository-cache: true
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip
@@ -22,7 +27,7 @@ jobs:
           python3 -m pip install --no-deps bmw-lobster-core bmw-lobster-tool-trlc
       - name: Executing linter
         run: |
-          make lint
+          bazel test //:lint --test_output=errors
   test:
     name: TestSuite
     needs: lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,18 +11,26 @@ permissions:
 
 jobs:
   lint:
-    name: PyLint
+    name: Bazel Lint
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Bazel
+        uses: bazel-contrib/setup-bazel@0.19.0
+        with:
+          bazelisk-cache: true
+          repository-cache: true
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install pylint==3.2.4 pycodestyle==2.12.0
+          python3 -m pip install pylint==3.3.9
           python3 -m pip install --no-deps bmw-lobster-core bmw-lobster-tool-trlc
-      - name: Executing linter
+      - name: Executing Lint (pylint + ty)
         run: |
-          make lint
+          bazel build --config=lint //trlc //:trlc_binary //:root_scripts_lib
+      - name: Format check (ruff + buildifier)
+        run: |
+          bazel run //:format.check
   test:
     name: TestSuite
     needs: lint

--- a/BUILD
+++ b/BUILD
@@ -1,4 +1,7 @@
+load("@rules_python//python:defs.bzl", "py_binary", "py_test")
 load("@rules_python//python:pip.bzl", "compile_pip_requirements")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+load("@trlc_dev_dependencies//:requirements.bzl", "requirement")
 
 # trlc.py is exposed for the test rule in trlc.bzl;
 # pyproject.toml is needed by pylint/ty via rules_lint.
@@ -56,7 +59,45 @@ alias(
 )
 
 filegroup(
-    name = "coverage",
+    name = "coverage_cfg",
     srcs = ["coverage.cfg"],
     visibility = ["//visibility:public"],
+)
+
+# LINTING & CODE QUALITY
+
+py_test(
+    name = "style",
+    size = "small",
+    srcs = glob([
+        "trlc*.py",
+        "lobster-*.py",
+    ]) + [
+        "//trlc:py_sources",
+        "//util:pycodestyle_runner.py",
+    ],
+    data = ["setup.cfg"],
+    main = "pycodestyle_runner.py",
+    deps = [requirement("pycodestyle")],
+)
+
+sh_test(
+    name = "lint-pylint",
+    size = "small",
+    srcs = ["//util:lint_check.sh"],
+    data = [
+        "pylint3.cfg",
+        "//trlc:py_sources",
+    ] + glob([
+        "trlc*.py",
+        "lobster-*.py",
+    ]),
+)
+
+test_suite(
+    name = "lint",
+    tests = [
+        ":lint-pylint",
+        ":style",
+    ],
 )

--- a/BUILD
+++ b/BUILD
@@ -1,5 +1,6 @@
 load("@rules_python//python:defs.bzl", "py_binary", "py_test")
 load("@rules_python//python:pip.bzl", "compile_pip_requirements")
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("@trlc_dev_dependencies//:requirements.bzl", "requirement")
 
@@ -68,7 +69,6 @@ filegroup(
 
 py_test(
     name = "style",
-    size = "small",
     srcs = glob([
         "trlc*.py",
         "lobster-*.py",
@@ -83,7 +83,6 @@ py_test(
 
 sh_test(
     name = "lint-pylint",
-    size = "small",
     srcs = ["//util:lint_check.sh"],
     data = [
         "pylint3.cfg",
@@ -100,4 +99,11 @@ test_suite(
         ":lint-pylint",
         ":style",
     ],
+)
+
+sh_binary(
+    name = "clean-coverage",
+    srcs = ["//util:clean_coverage.sh"],
+    tags = ["manual"],
+    visibility = ["//visibility:public"],
 )

--- a/BUILD
+++ b/BUILD
@@ -1,4 +1,6 @@
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 load("@rules_python//python:pip.bzl", "compile_pip_requirements")
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 
 # trlc.py is exposed for the test rule in trlc.bzl;
 # pyproject.toml is needed by pylint/ty via rules_lint.
@@ -59,4 +61,29 @@ filegroup(
     name = "coverage",
     srcs = ["coverage.cfg"],
     visibility = ["//visibility:public"],
+)
+
+sh_binary(
+    name = "clean-coverage",
+    srcs = ["//util:clean_coverage.sh"],
+    tags = ["manual"],
+    visibility = ["//visibility:public"],
+)
+
+# Lint-only target: covers all root-level scripts (same as `make lint`'s
+# trlc*.py and lobster-*.py globs).  trlc.py is excluded because it is
+# already linted via :trlc_binary.
+py_library(
+    name = "root_scripts_lib",
+    srcs = glob(
+        [
+            "trlc*.py",
+            "lobster-*.py",
+        ],
+        # trlc.py is already linted via :trlc_binary.
+        exclude = [
+            "trlc.py",
+        ],
+    ),
+    deps = ["//trlc"],
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,12 +1,16 @@
 module(
     name = "trlc",
-    compatibility_level = 1,
     version = "0.0.0",
+    compatibility_level = 1,
 )
 
 bazel_dep(
     name = "rules_python",
     version = "1.1.0",
+)
+bazel_dep(
+    name = "rules_shell",
+    version = "0.6.1",
 )
 
 bazel_dep(
@@ -14,7 +18,6 @@ bazel_dep(
     version = "8.2.1.1",
     dev_dependency = True,
 )
-
 bazel_dep(
     name = "aspect_rules_lint",
     version = "2.2.0",
@@ -22,16 +25,14 @@ bazel_dep(
 )
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
-
 python.toolchain(python_version = "3.9")
 python.toolchain(python_version = "3.10")
 python.toolchain(python_version = "3.11")
 python.toolchain(
+    configure_coverage_tool = True,
     is_default = True,
     python_version = "3.12",
-    configure_coverage_tool = True,
 )
-
 use_repo(python, "python_versions")
 
 pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
@@ -74,12 +75,9 @@ pip_dev = use_extension(
     "pip",
     dev_dependency = True,
 )
-
 pip_dev.parse(
     hub_name = "trlc_dev_dependencies",
     python_version = "3.12",
     requirements_lock = "//:requirements_dev_lock.txt",
 )
-
 use_repo(pip_dev, "trlc_dev_dependencies")
-

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -682,11 +682,17 @@
     "@@rules_python+//python/extensions:pip.bzl%pip": {
       "general": {
         "bzlTransitiveDigest": "Z2EwAlnWwmyPNSF4pT+ZyT3/Csf4YVbyQPmxi3fBMEQ=",
-        "usagesDigest": "NdWIbUWd8+sxdRoKNDJMBMA/5J8Byi51B38PPDpzpzI=",
+        "usagesDigest": "dI3+Lv/xnhTiVoA8OAhbWbJFTH8Ih8cQv9ackt2uIIw=",
         "recordedFileInputs": {
-          "@@//requirements_dev_lock.txt": "8bde8fed2919cb7f77d55ba8cca6642e4c28945f880767a730c1eae4df770927",
-          "@@//requirements_lock.txt": "cf537fbb9f326a91b6abc441d9bc47cc7e8cc04d8703b3a0c772df61fd9497c2",
-          "@@//tools/sphinx/requirements.txt": "d9094ed5c282d440f211c9f8eb5f8942a3c29ee134f78876e6c31f5813d7365e",
+          "@@//requirements_dev_lock.txt": "7b97180318043379e3f29d3b33d5c9234688e7b1d7f8fbf418d4fa811a4c4e7c",
+          "@@//requirements_lock_3_10.txt": "ac896df774280b0f3c8b808773a0f940d204944bd1a8f3f144bd5a6873824ebb",
+          "@@//requirements_lock_3_11.txt": "610e34dbd24ed61287a2e797e1d200c4aab172cb451dbf49cb0c401419a5d36c",
+          "@@//requirements_lock_3_12.txt": "84966575b4cd856a8c81e516237bb32b45e0a88d44cf05385bc4397a986d1641",
+          "@@//requirements_lock_3_9.txt": "b04a435e0b933093b4720d5f22b80a81af687a6b0df0c32ada785d66ce74e0ac",
+          "@@//tools/sphinx/requirements_3_10.txt": "eb537c54c2fdae4a1015695f17a09119c7893361174d65606a94ac15acdae835",
+          "@@//tools/sphinx/requirements_3_11.txt": "dc1431857f9b75037c6679ce0b8c5a6df11ec10ad32bb477de75517ef27ac048",
+          "@@//tools/sphinx/requirements_3_12.txt": "3be166ec8493304fdd9ac5a6017c5d7bea7ae4eeb373cf664da2d87d60581cd4",
+          "@@//tools/sphinx/requirements_3_9.txt": "9657868af0b7ce7fd6ceb032ea813a2f084f80f1a4217a1d37baf9c90ffe5fa9",
           "@@protobuf+//python/requirements.txt": "983be60d3cec4b319dcab6d48aeb3f5b2f7c3350f26b3a9e97486c37967c73c5",
           "@@rules_fuzzing+//fuzzing/requirements.txt": "ab04664be026b632a0d2a2446c4f65982b7654f5b6851d2f9d399a19b7242a5b",
           "@@rules_python+//tools/publish/requirements_darwin.txt": "095d4a4f3d639dce831cd493367631cd51b53665292ab20194bac2c0c6458fa8",
@@ -3490,7 +3496,7 @@
               "dep_template": "@trlc_dev_dependencies//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_12_host//:python",
               "repo": "trlc_dev_dependencies_312",
-              "requirement": "requests==2.32.5 --hash=sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6 --hash=sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf"
+              "requirement": "requests==2.33.0 --hash=sha256:3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b --hash=sha256:c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652"
             }
           },
           "trlc_dev_dependencies_312_roman_numerals": {
@@ -3580,7 +3586,7 @@
               "dep_template": "@trlc_dev_dependencies//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_12_host//:python",
               "repo": "trlc_dev_dependencies_312",
-              "requirement": "urllib3==2.6.3 --hash=sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed --hash=sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"
+              "requirement": "urllib3==2.7.0 --hash=sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"
             }
           },
           "trlc_sphinx_dependencies_310_alabaster": {
@@ -3625,7 +3631,7 @@
               "dep_template": "@trlc_sphinx_dependencies//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_10_host//:python",
               "repo": "trlc_sphinx_dependencies_310",
-              "requirement": "docutils==0.22.4 --hash=sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968 --hash=sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de"
+              "requirement": "docutils==0.21.2 --hash=sha256:3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f --hash=sha256:dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2"
             }
           },
           "trlc_sphinx_dependencies_310_idna": {
@@ -3691,15 +3697,6 @@
               "requirement": "requests==2.33.1 --hash=sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517 --hash=sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a"
             }
           },
-          "trlc_sphinx_dependencies_310_roman_numerals": {
-            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
-            "attributes": {
-              "dep_template": "@trlc_sphinx_dependencies//{name}:{target}",
-              "python_interpreter_target": "@@rules_python++python+python_3_10_host//:python",
-              "repo": "trlc_sphinx_dependencies_310",
-              "requirement": "roman-numerals==4.1.0 --hash=sha256:1af8b147eb1405d5839e78aeb93131690495fe9da5c91856cb33ad55a7f1e5b2 --hash=sha256:647ba99caddc2cc1e55a51e4360689115551bf4476d90e8162cf8c345fe233c7"
-            }
-          },
           "trlc_sphinx_dependencies_310_snowballstemmer": {
             "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
             "attributes": {
@@ -3715,7 +3712,7 @@
               "dep_template": "@trlc_sphinx_dependencies//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_10_host//:python",
               "repo": "trlc_sphinx_dependencies_310",
-              "requirement": "sphinx==9.1.0 --hash=sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb --hash=sha256:c84fdd4e782504495fe4f2c0b3413d6c2bf388589bb352d439b2a3bb99991978"
+              "requirement": "sphinx==8.1.3 --hash=sha256:09719015511837b76bf6e03e42eb7595ac8c2e41eeb9c29c5b755c6b677992a2 --hash=sha256:43c1911eecb0d3e161ad78611bc905d1ad0e523e4ddc202a58a821773dc4c927"
             }
           },
           "trlc_sphinx_dependencies_310_sphinxcontrib_applehelp": {
@@ -3770,6 +3767,15 @@
               "python_interpreter_target": "@@rules_python++python+python_3_10_host//:python",
               "repo": "trlc_sphinx_dependencies_310",
               "requirement": "sphinxcontrib-serializinghtml==2.0.0 --hash=sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331 --hash=sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d"
+            }
+          },
+          "trlc_sphinx_dependencies_310_tomli": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@trlc_sphinx_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_10_host//:python",
+              "repo": "trlc_sphinx_dependencies_310",
+              "requirement": "tomli==2.4.1 --hash=sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853 --hash=sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe --hash=sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5 --hash=sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d --hash=sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd --hash=sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26 --hash=sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54 --hash=sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6 --hash=sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c --hash=sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a --hash=sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd --hash=sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f --hash=sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5 --hash=sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9 --hash=sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662 --hash=sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9 --hash=sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1 --hash=sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585 --hash=sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e --hash=sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c --hash=sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41 --hash=sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f --hash=sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085 --hash=sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15 --hash=sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7 --hash=sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c --hash=sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36 --hash=sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076 --hash=sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac --hash=sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8 --hash=sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232 --hash=sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece --hash=sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a --hash=sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897 --hash=sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d --hash=sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4 --hash=sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917 --hash=sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396 --hash=sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a --hash=sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc --hash=sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba --hash=sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f --hash=sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257 --hash=sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30 --hash=sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf --hash=sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9 --hash=sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049"
             }
           },
           "trlc_sphinx_dependencies_310_urllib3": {
@@ -3913,7 +3919,7 @@
               "dep_template": "@trlc_sphinx_dependencies//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
               "repo": "trlc_sphinx_dependencies_311",
-              "requirement": "sphinx==9.1.0 --hash=sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb --hash=sha256:c84fdd4e782504495fe4f2c0b3413d6c2bf388589bb352d439b2a3bb99991978"
+              "requirement": "sphinx==9.0.4 --hash=sha256:594ef59d042972abbc581d8baa577404abe4e6c3b04ef61bd7fc2acbd51f3fa3 --hash=sha256:5bebc595a5e943ea248b99c13814c1c5e10b3ece718976824ffa7959ff95fffb"
             }
           },
           "trlc_sphinx_dependencies_311_sphinxcontrib_applehelp": {
@@ -4183,7 +4189,7 @@
               "dep_template": "@trlc_sphinx_dependencies//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_9_host//:python",
               "repo": "trlc_sphinx_dependencies_39",
-              "requirement": "alabaster==1.0.0 --hash=sha256:c00dca57bca26fa62a6d7d0a9fcce65f3e026e9bfe33e9c538fd3fbb2144fd9e --hash=sha256:fc6786402dc3fcb2de3cabd5fe455a2db534b371124f1f21de8731783dec828b"
+              "requirement": "alabaster==0.7.16 --hash=sha256:75a8b99c28a5dad50dd7f8ccdd447a121ddb3892da9e53d1ca5cca3106d58d65 --hash=sha256:b46733c07dce03ae4e150330b975c75737fa60f0a7c591b6c8bf4928a28e2c92"
             }
           },
           "trlc_sphinx_dependencies_39_babel": {
@@ -4210,7 +4216,7 @@
               "dep_template": "@trlc_sphinx_dependencies//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_9_host//:python",
               "repo": "trlc_sphinx_dependencies_39",
-              "requirement": "charset-normalizer==3.4.6 --hash=sha256:06a7e86163334edfc5d20fe104db92fcd666e5a5df0977cb5680a506fe26cc8e --hash=sha256:0c173ce3a681f309f31b87125fecec7a5d1347261ea11ebbb856fa6006b23c8c --hash=sha256:0e28d62a8fc7a1fa411c43bd65e346f3bce9716dc51b897fbe930c5987b402d5 --hash=sha256:0e901eb1049fdb80f5bd11ed5ea1e498ec423102f7a9b9e4645d5b8204ff2815 --hash=sha256:11afb56037cbc4b1555a34dd69151e8e069bee82e613a73bef6e714ce733585f --hash=sha256:150b8ce8e830eb7ccb029ec9ca36022f756986aaaa7956aad6d9ec90089338c0 --hash=sha256:172985e4ff804a7ad08eebec0a1640ece87ba5041d565fff23c8f99c1f389484 --hash=sha256:197c1a244a274bb016dd8b79204850144ef77fe81c5b797dc389327adb552407 --hash=sha256:1ae6b62897110aa7c79ea2f5dd38d1abca6db663687c0b1ad9aed6f6bae3d9d6 --hash=sha256:1cf0a70018692f85172348fe06d3a4b63f94ecb055e13a00c644d368eb82e5b8 --hash=sha256:1ed80ff870ca6de33f4d953fda4d55654b9a2b340ff39ab32fa3adbcd718f264 --hash=sha256:22c6f0c2fbc31e76c3b8a86fba1a56eda6166e238c29cdd3d14befdb4a4e4815 --hash=sha256:231d4da14bcd9301310faf492051bee27df11f2bc7549bc0bb41fef11b82daa2 --hash=sha256:259695e2ccc253feb2a016303543d691825e920917e31f894ca1a687982b1de4 --hash=sha256:2a24157fa36980478dd1770b585c0f30d19e18f4fb0c47c13aa568f871718579 --hash=sha256:2b1a63e8224e401cafe7739f77efd3f9e7f5f2026bda4aead8e59afab537784f --hash=sha256:2bd9d128ef93637a5d7a6af25363cf5dec3fa21cf80e68055aad627f280e8afa --hash=sha256:2e1d8ca8611099001949d1cdfaefc510cf0f212484fe7c565f735b68c78c3c95 --hash=sha256:2ef7fedc7a6ecbe99969cd09632516738a97eeb8bd7258bf8a0f23114c057dab --hash=sha256:2f7fdd9b6e6c529d6a2501a2d36b240109e78a8ceaef5687cfcfa2bbe671d297 --hash=sha256:30f445ae60aad5e1f8bdbb3108e39f6fbc09f4ea16c815c66578878325f8f15a --hash=sha256:31215157227939b4fb3d740cd23fe27be0439afef67b785a1eb78a3ae69cba9e --hash=sha256:34315ff4fc374b285ad7f4a0bf7dcbfe769e1b104230d40f49f700d4ab6bbd84 --hash=sha256:3516bbb8d42169de9e61b8520cbeeeb716f12f4ecfe3fd30a9919aa16c806ca8 --hash=sha256:3778fd7d7cd04ae8f54651f4a7a0bd6e39a0cf20f801720a4c21d80e9b7ad6b0 --hash=sha256:39f5068d35621da2881271e5c3205125cc456f54e9030d3f723288c873a71bf9 --hash=sha256:404a1e552cf5b675a87f0651f8b79f5f1e6fd100ee88dc612f89aa16abd4486f --hash=sha256:419a9d91bd238052642a51938af8ac05da5b3343becde08d5cdeab9046df9ee1 --hash=sha256:423fb7e748a08f854a08a222b983f4df1912b1daedce51a72bd24fe8f26a1843 --hash=sha256:4482481cb0572180b6fd976a4d5c72a30263e98564da68b86ec91f0fe35e8565 --hash=sha256:461598cd852bfa5a61b09cae2b1c02e2efcd166ee5516e243d540ac24bfa68a7 --hash=sha256:47955475ac79cc504ef2704b192364e51d0d473ad452caedd0002605f780101c --hash=sha256:48696db7f18afb80a068821504296eb0787d9ce239b91ca15059d1d3eaacf13b --hash=sha256:4be9f4830ba8741527693848403e2c457c16e499100963ec711b1c6f2049b7c7 --hash=sha256:4d1d02209e06550bdaef34af58e041ad71b88e624f5d825519da3a3308e22687 --hash=sha256:4f41da960b196ea355357285ad1316a00099f22d0929fe168343b99b254729c9 --hash=sha256:517ad0e93394ac532745129ceabdf2696b609ec9f87863d337140317ebce1c14 --hash=sha256:51fb3c322c81d20567019778cb5a4a6f2dc1c200b886bc0d636238e364848c89 --hash=sha256:5273b9f0b5835ff0350c0828faea623c68bfa65b792720c453e22b25cc72930f --hash=sha256:530d548084c4a9f7a16ed4a294d459b4f229db50df689bfe92027452452943a0 --hash=sha256:530e8cebeea0d76bdcf93357aa5e41336f48c3dc709ac52da2bb167c5b8271d9 --hash=sha256:54fae94be3d75f3e573c9a1b5402dc593de19377013c9a0e4285e3d402dd3a2a --hash=sha256:572d7c822caf521f0525ba1bce1a622a0b85cf47ffbdae6c9c19e3b5ac3c4389 --hash=sha256:58c948d0d086229efc484fe2f30c2d382c86720f55cd9bc33591774348ad44e0 --hash=sha256:5d11595abf8dd942a77883a39d81433739b287b6aa71620f15164f8096221b30 --hash=sha256:5f8ddd609f9e1af8c7bd6e2aca279c931aefecd148a14402d4e368f3171769fd --hash=sha256:5feb91325bbceade6afab43eb3b508c63ee53579fe896c77137ded51c6b6958e --hash=sha256:60c74963d8350241a79cb8feea80e54d518f72c26db618862a8f53e5023deaf9 --hash=sha256:613f19aa6e082cf96e17e3ffd89383343d0d589abda756b7764cf78361fd41dc --hash=sha256:659a1e1b500fac8f2779dd9e1570464e012f43e580371470b45277a27baa7532 --hash=sha256:695f5c2823691a25f17bc5d5ffe79fa90972cc34b002ac6c843bb8a1720e950d --hash=sha256:69dd852c2f0ad631b8b60cfbe25a28c0058a894de5abb566619c205ce0550eae --hash=sha256:6cceb5473417d28edd20c6c984ab6fee6c6267d38d906823ebfe20b03d607dc2 --hash=sha256:71be7e0e01753a89cf024abf7ecb6bca2c81738ead80d43004d9b5e3f1244e64 --hash=sha256:74119174722c4349af9708993118581686f343adc1c8c9c007d59be90d077f3f --hash=sha256:74a2e659c7ecbc73562e2a15e05039f1e22c75b7c7618b4b574a3ea9118d1557 --hash=sha256:7504e9b7dc05f99a9bbb4525c67a2c155073b44d720470a148b34166a69c054e --hash=sha256:79090741d842f564b1b2827c0b82d846405b744d31e84f18d7a7b41c20e473ff --hash=sha256:7a6967aaf043bceabab5412ed6bd6bd26603dae84d5cb75bf8d9a74a4959d398 --hash=sha256:7bda6eebafd42133efdca535b04ccb338ab29467b3f7bf79569883676fc628db --hash=sha256:7edbed096e4a4798710ed6bc75dcaa2a21b68b6c356553ac4823c3658d53743a --hash=sha256:7f9019c9cb613f084481bd6a100b12e1547cf2efe362d873c2e31e4035a6fa43 --hash=sha256:802168e03fba8bbc5ce0d866d589e4b1ca751d06edee69f7f3a19c5a9fe6b597 --hash=sha256:80d0a5615143c0b3225e5e3ef22c8d5d51f3f72ce0ea6fb84c943546c7b25b6c --hash=sha256:82060f995ab5003a2d6e0f4ad29065b7672b6593c8c63559beefe5b443242c3e --hash=sha256:836ab36280f21fc1a03c99cd05c6b7af70d2697e374c7af0b61ed271401a72a2 --hash=sha256:8761ac29b6c81574724322a554605608a9960769ea83d2c73e396f3df896ad54 --hash=sha256:87725cfb1a4f1f8c2fc9890ae2f42094120f4b44db9360be5d99a4c6b0e03a9e --hash=sha256:899d28f422116b08be5118ef350c292b36fc15ec2daeb9ea987c89281c7bb5c4 --hash=sha256:8bc5f0687d796c05b1e28ab0d38a50e6309906ee09375dd3aff6a9c09dd6e8f4 --hash=sha256:8bea55c4eef25b0b19a0337dc4e3f9a15b00d569c77211fa8cde38684f234fb7 --hash=sha256:8e5a94886bedca0f9b78fecd6afb6629142fd2605aa70a125d49f4edc6037ee6 --hash=sha256:90ca27cd8da8118b18a52d5f547859cc1f8354a00cd1e8e5120df3e30d6279e5 --hash=sha256:92734d4d8d187a354a556626c221cd1a892a4e0802ccb2af432a1d85ec012194 --hash=sha256:947cf925bc916d90adba35a64c82aace04fa39b46b52d4630ece166655905a69 --hash=sha256:95b52c68d64c1878818687a473a10547b3292e82b6f6fe483808fb1468e2f52f --hash=sha256:97d0235baafca5f2b09cf332cc275f021e694e8362c6bb9c96fc9a0eb74fc316 --hash=sha256:9ca4c0b502ab399ef89248a2c84c54954f77a070f28e546a85e91da627d1301e --hash=sha256:9cc4fc6c196d6a8b76629a70ddfcd4635a6898756e2d9cac5565cf0654605d73 --hash=sha256:9cc6e6d9e571d2f863fa77700701dae73ed5f78881efc8b3f9a4398772ff53e8 --hash=sha256:a056d1ad2633548ca18ffa2f85c202cfb48b68615129143915b8dc72a806a923 --hash=sha256:a26611d9987b230566f24a0a125f17fe0de6a6aff9f25c9f564aaa2721a5fb88 --hash=sha256:a4474d924a47185a06411e0064b803c68be044be2d60e50e8bddcc2649957c1f --hash=sha256:a4ea868bc28109052790eb2b52a9ab33f3aa7adc02f96673526ff47419490e21 --hash=sha256:a9e68c9d88823b274cf1e72f28cb5dc89c990edf430b0bfd3e2fb0785bfeabf4 --hash=sha256:aa9cccf4a44b9b62d8ba8b4dd06c649ba683e4bf04eea606d2e94cfc2d6ff4d6 --hash=sha256:ab30e5e3e706e3063bc6de96b118688cb10396b70bb9864a430f67df98c61ecc --hash=sha256:ac2393c73378fea4e52aa56285a3d64be50f1a12395afef9cce47772f60334c2 --hash=sha256:ad8faf8df23f0378c6d527d8b0b15ea4a2e23c89376877c598c4870d1b2c7866 --hash=sha256:b35b200d6a71b9839a46b9b7fff66b6638bb52fc9658aa58796b0326595d3021 --hash=sha256:b3694e3f87f8ac7ce279d4355645b3c878d24d1424581b46282f24b92f5a4ae2 --hash=sha256:b4ff1d35e8c5bd078be89349b6f3a845128e685e751b6ea1169cf2160b344c4d --hash=sha256:bbc8c8650c6e51041ad1be191742b8b421d05bbd3410f43fa2a00c8db87678e8 --hash=sha256:bc72863f4d9aba2e8fd9085e63548a324ba706d2ea2c83b260da08a59b9482de --hash=sha256:bf625105bb9eef28a56a943fec8c8a98aeb80e7d7db99bd3c388137e6eb2d237 --hash=sha256:c2274ca724536f173122f36c98ce188fd24ce3dad886ec2b7af859518ce008a4 --hash=sha256:c45a03a4c69820a399f1dda9e1d8fbf3562eda46e7720458180302021b08f778 --hash=sha256:c8ae56368f8cc97c7e40a7ee18e1cedaf8e780cd8bc5ed5ac8b81f238614facb --hash=sha256:c907cdc8109f6c619e6254212e794d6548373cc40e1ec75e6e3823d9135d29cc --hash=sha256:ca0276464d148c72defa8bb4390cce01b4a0e425f3b50d1435aa6d7a18107602 --hash=sha256:cd5e2801c89992ed8c0a3f0293ae83c159a60d9a5d685005383ef4caca77f2c4 --hash=sha256:d08ec48f0a1c48d75d0356cea971921848fb620fdeba805b28f937e90691209f --hash=sha256:d1a2ee9c1499fc8f86f4521f27a973c914b211ffa87322f4ee33bb35392da2c5 --hash=sha256:d5f5d1e9def3405f60e3ca8232d56f35c98fb7bf581efcc60051ebf53cb8b611 --hash=sha256:d60377dce4511655582e300dc1e5a5f24ba0cb229005a1d5c8d0cb72bb758ab8 --hash=sha256:d73beaac5e90173ac3deb9928a74763a6d230f494e4bfb422c217a0ad8e629bf --hash=sha256:d7de2637729c67d67cf87614b566626057e95c303bc0a55ffe391f5205e7003d --hash=sha256:dad6e0f2e481fffdcf776d10ebee25e0ef89f16d691f1e5dee4b586375fdc64b --hash=sha256:dda86aba335c902b6149a02a55b38e96287157e609200811837678214ba2b1db --hash=sha256:df01808ee470038c3f8dc4f48620df7225c49c2d6639e38f96e6d6ac6e6f7b0e --hash=sha256:e1f6e2f00a6b8edb562826e4632e26d063ac10307e80f7461f7de3ad8ef3f077 --hash=sha256:e25369dc110d58ddf29b949377a93e0716d72a24f62bad72b2b39f155949c1fd --hash=sha256:e3c701e954abf6fc03a49f7c579cc80c2c6cc52525340ca3186c41d3f33482ef --hash=sha256:e5bcc1a1ae744e0bb59641171ae53743760130600da8db48cbb6e4918e186e4e --hash=sha256:e68c14b04827dd76dcbd1aeea9e604e3e4b78322d8faf2f8132c7138efa340a8 --hash=sha256:e8aeb10fcbe92767f0fa69ad5a72deca50d0dca07fbde97848997d778a50c9fe --hash=sha256:e985a16ff513596f217cee86c21371b8cd011c0f6f056d0920aa2d926c544058 --hash=sha256:ecbbd45615a6885fe3240eb9db73b9e62518b611850fdf8ab08bd56de7ad2b17 --hash=sha256:ee4ec14bc1680d6b0afab9aea2ef27e26d2024f18b24a2d7155a52b60da7e833 --hash=sha256:ef5960d965e67165d75b7c7ffc60a83ec5abfc5c11b764ec13ea54fbef8b4421 --hash=sha256:f0cdaecd4c953bfae0b6bb64910aaaca5a424ad9c72d85cb88417bb9814f7550 --hash=sha256:f1ce721c8a7dfec21fcbdfe04e8f68174183cf4e8188e0645e92aa23985c57ff --hash=sha256:f50498891691e0864dc3da965f340fada0771f6142a378083dc4608f4ea513e2 --hash=sha256:f5ea69428fa1b49573eef0cc44a1d43bebd45ad0c611eb7d7eac760c7ae771bc --hash=sha256:f61aa92e4aad0be58eb6eb4e0c21acf32cf8065f4b2cae5665da756c4ceef982 --hash=sha256:f6e4333fb15c83f7d1482a76d45a0818897b3d33f00efd215528ff7c51b8e35d --hash=sha256:f820f24b09e3e779fe84c3c456cb4108a7aa639b0d1f02c28046e11bfcd088ed --hash=sha256:f98059e4fcd3e3e4e2d632b7cf81c2faae96c43c60b569e9c621468082f1d104 --hash=sha256:fcce033e4021347d80ed9c66dcf1e7b1546319834b74445f561d2e2221de5659"
+              "requirement": "charset-normalizer==3.4.9 --hash=sha256:0327fcd59a935777d83410750c50600ee9571af2846f71ce40f25b13da1ef380 --hash=sha256:03d07803992c6c7bbc976327f34b18b6160327fc81cb82c9d504720ac0be3b62 --hash=sha256:04ce310cb89c15df659582aee80a0603788732a5e017d5bd5c81158106ce249c --hash=sha256:0d861473f743244d349b50f850d10eb87aeb22bbdcc8e64f79273c94af5a8226 --hash=sha256:0e94703ec9684807f20cfb5eed95c70f67f2a8f21ad620146d7b5a13677b93e5 --hash=sha256:0fa1aec2d32bcc03c8fa0f6f1712caad1adc38509f31142112e5c9daf5b9c833 --hash=sha256:16b65ea0f2465b6fb52aa22de5eca612aa964ddfec00a912e26f4656cbef890b --hash=sha256:16d10d789dd9bcca1173c95af82c58433122564b7bc39385124be735a35cbe99 --hash=sha256:19ac87f93086ce37b86e098888555c4b4bc48102279bae3350098c0ed664b501 --hash=sha256:1d22856ffbe153a602df38e4a5464f0b748a54002e0d69ac6d2ad0a197cc99ec --hash=sha256:21e764fd1e70b6a3e205a0e46f3051701f98a8cb3fad66eeb80e48bb502f8698 --hash=sha256:231ddcbb35e2ff8973e1365db41fe0572662893b99a05deb183b68ad4c0c8bd4 --hash=sha256:253a4a220747e8b5faf57ec320c4f5efb0cef05f647420bf267143ec15dba10a --hash=sha256:280081916dc341820640489a66e4696049401ef1cf6dd672f672e70ad915aca3 --hash=sha256:2a441ea71902098ffe78c5abe6c494f44160b4af614ed16c3d9a3b1d17fd8ee2 --hash=sha256:304b13570067b2547562e308af560b3963857b1fa90bd6afd978130130fe2d6a --hash=sha256:32286a2c8d167e897177b673176c1e3e00d4057caf5d2b64eef9a3666b03018e --hash=sha256:33bdcc2a32c0a0e861f60841a512c8acc658c87c2ac59d89e3a46dacf7d866e4 --hash=sha256:375b83ed0aecfce76c16d198fbc21f3b11b337d68662bea0a995046682a11419 --hash=sha256:3c09a49d6cde137258beb3d551994a2927fd35ad5cf96aed573f61bbd67c5f84 --hash=sha256:3d92613ec25e43b05f042302531ec0f00b8445190e43325880cbd6ab7c2581da --hash=sha256:40a126142a56b2dfc0aacbad1de8310cbf60da7656db0e6b16eebd48e3e93519 --hash=sha256:416c229f77e5ea25b3dfd4b582f8d73d7e43c22320302b9ab128a2d3a0b38efe --hash=sha256:432786d3561e69aeeae6c7e8648964ce0ad05736120135601f87ac26b9c83381 --hash=sha256:43b9e366a31fdd1c87d0eb08f579b4a82b723ea54338f040d6b4e518a026ea29 --hash=sha256:440eede837960000d74978f0eba527be106b5b9aee0daf779d395276ed0b0614 --hash=sha256:45b0cc4e3556cd875e09102988d1ab8356c998b596c9fced84547c8138b487a0 --hash=sha256:476743fe6dfe14a2da12e3ac79125dc84a3b2cf8094369a47a1529b0cd8549fe --hash=sha256:4773092f8019072343a7447203308b176e10199920eb02d6195e81bbb3274c29 --hash=sha256:4b3dac63058cc36820b0dd072f89898604e2d39686fe05321729d00d8ac185a0 --hash=sha256:4d1c96a7a18b9690a4d46df09e3e3382406ae3213727cd1019ebade1c4a81917 --hash=sha256:51307f5c71007673a2bf8232ad973483d281e74cb99c8c5a990af1eefa6277d9 --hash=sha256:51447e9aa2684679af07ca5021c3db526e0284347ebf4ffcec1154c3350cfe32 --hash=sha256:58150c9f9b9a552505912d182ccdf26f6396fb6094816ceebcbb20eecabaed94 --hash=sha256:5b10cd92fc5c498b35a8635df6d5a100207f88b63a4dc1de7ef9a548e1e2cd63 --hash=sha256:5e226f6218febc71f6c1fc2fafb91c226f75bdc1d8fb12d66823716e891608fd --hash=sha256:609b3ba8fcc0fb5ab7af00719d0fb6ad0cb518e48e7712d12fd68f1327951198 --hash=sha256:60f44ade2cf573dad7a277e6f8ca9a51a21dda572b13bd7d8539bb3cd5dbedde --hash=sha256:611057cc5d5c0afc743ba8be6bd828c17e0aaa8643f9d0a9b9bb7dea80eb8012 --hash=sha256:6366a16e1a25018694d6a5d784d09b046edc9eac40ea2b54065c3052672516a1 --hash=sha256:65a7ff3f705e57d392f7261b6d0550fe137c3019477431f1c355e0db0a7d3e15 --hash=sha256:673611bbd43f0810bec0b0f028ddeaaa501190339cac411f347ac76917c3ae7b --hash=sha256:67830fc78e67501f47bb950471b2dcb9b35b140084429318e862895a8e89c993 --hash=sha256:68ce9f4d6b26d5ccbf7fd4459bf75f74a0a146677ebba80597df60cbdb20e6f4 --hash=sha256:68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5 --hash=sha256:69b157c5d3292bcd443faca052f3096f637f1e074b98212a933c074ae23dc3b8 --hash=sha256:75286256590a6320cf106a0d28970d3560aad9ee09aa7b34fb40524792436d35 --hash=sha256:78841cccf1af7b40f6f716338d50c0902dbe88d9f800b3c973b7a9a0a693a642 --hash=sha256:78fa18e436a1a0e58dbd7e02fc4473f3f32cceb12df9dfca542d075961c307d2 --hash=sha256:79580094b00d1789d1f93ea55bc43cb2f611910c72235b7657f3482ddcc1b22d --hash=sha256:7b86a2b16095d250c6f58b3d9b2eee6f4147754344f3dab0922f7c9bf7d226c9 --hash=sha256:83aed2c10721ddd90f68140685391b50811a880af20654c59af6b6c66c40513c --hash=sha256:84fd18bcc17526fc2b3c1af7d2b9217d32c9c04448c16ec693b9b4f1985c3d33 --hash=sha256:871ff67ea1aad4dfd91736464934d56b32dac49f9fbe16cddba36198a7b3a0db --hash=sha256:898f0e9068ca27d37f8e83a5b962821df851532e6c4a7d615c1c033f9da6eedf --hash=sha256:8a79d9f4d8001473a30c163556b3c3bfebec837495a412dde78b51672f6134f9 --hash=sha256:8c041122946b7ba21bb32c45b1aa57b1be35527690aeb3c5c234521085632eee --hash=sha256:90c44bc373b7687f6948b693cceaea1348ae0975d7474746559494468e3c1d84 --hash=sha256:9104ed0bd76a429d46f9ec0dbc9b08ad1d2dcdf2b00a5a0daa1c145329b35b44 --hash=sha256:920079c3f7456fa213e0829ed2073aaa727fd39d889ead5b4f35d0de5460d04f --hash=sha256:93d59d504b230e83c7a843251681959a0b6a9cd76f6e146ce1b8a80eb8739af9 --hash=sha256:9b2aff1c7b3884512b9512c3eaadd9bab39fb45042ffaaa1dd08ff2b9f8109d9 --hash=sha256:9b8e0f3107e2200b76f6054de99016eac3ee6762713587b36baaa7e4bd2ae177 --hash=sha256:9bb41182d93ea91f60b4bc8fbf4c820c69ef8a12ab2d917f3f1834f1acad07e8 --hash=sha256:9cdef90ae47919cae358d8ab15797a800ed41da7aba5d72419fb510729e2ed4b --hash=sha256:a1786910334ed46ab1dd73222f2cd1e05c2c3bb39f6dddb4f8b36fc382058a39 --hash=sha256:a4cfde78a9f2880208d16a93b795726a3017d5977e08d1e162a7a31322479c41 --hash=sha256:a4fbdde9dd4a9ce5fd52c2b3a347bb50cc89483ef783f1cb00d408c13f7a96c0 --hash=sha256:aa99adc8f081b475a12843953db36831eaf83ec33eb46a90629ca6a5de45a616 --hash=sha256:ac351b3b8014eead140e77e9717e2992c6bbe30b63bc3422422eb84865412e3d --hash=sha256:ad41ba96094304aa090f5a30cb6e4fb3b3f1c264c523394b4c39bbacc4dc92ba --hash=sha256:b5314963fce9b0b12743891de876e724997864ee22aa496f903f426c7e2fa5b2 --hash=sha256:bcf74c1df76758a395bf0af608c04c82257523f55c9868b334f06270d0f2112b --hash=sha256:bd47ba7fc3ca94896759ea0109775132d3e7ab921fbf54038e1bab2e46c313c9 --hash=sha256:c0323c9daef75ef2e5083624b4585018a0c9d5e3b40f607eed81a311270b934b --hash=sha256:c1225416b463483160e4af85d5fc3a9690ccb53fd4b1865a6437825f5ede3209 --hash=sha256:c1c948747b03be832dceed96ca815cef7360de9aa19d37c730f8e3f6101aca48 --hash=sha256:c25fe15c70c59eb7c5ce8c06a1f3fa1da0ecc5ea1e7a5922c40fd2fa9b0d5046 --hash=sha256:cc1b0fff8ead343dae06305f954eb8468ba0ec1a97881f42489d198e4ce3c632 --hash=sha256:cd6280cf040f233bd7d3407b743b4b4c74f70e8e1c4199cb112a62c941c0772a --hash=sha256:cd6c3d4b783c556fa00bf540854e42f135e2f256abd29669fcd0da0f2dec79c2 --hash=sha256:d4d6fcde76f94f5cb9e43e9e9a61f16dacefd228cbbf6f1a09bd9b219a92f1a1 --hash=sha256:ddf4af30b417d9fe16481e9b81c27ab2a7cde1ff7ba3e85653b02db7d145dc7b --hash=sha256:df115d4d83168fdf2cae48ef1ff6d1cb4c466364e30861b37121de0f3bf1b990 --hash=sha256:df7276909358e5635ae203673ab7e509ddd224225a8d6b0790bf13eb2bde1cc5 --hash=sha256:e4fd89cc178bced6ad29cb3e6dd4aa63fa5017c3524dbd0b25998fb64a87cc8b --hash=sha256:e9701d0049d92c16703a42771b98d560b95248949f23f8cf7b4eddd201814fb9 --hash=sha256:ee2f2a527e3c1a6e6411eb4209642e138b544a2d72fe5d0d76daf77b24063534 --hash=sha256:f7fb7d750cfa0a070d2c24e831fd3481019a60dd317ea2b39acbcebc08b6ed81 --hash=sha256:f840ed6d8ecba8255df8c42b87fadeda98ddfc6eeec05e2dc66e26d46dd6f58a --hash=sha256:f86c6358749bd4fda175388691e3ba8c46e24c5347d0afd20f9b7edfc9faf07d --hash=sha256:fa36ec09ef71d158186bc79e359ff5fdd6e7996fe8ab638f00d6b93139ba4fcf --hash=sha256:fe2c7201c642b7c308f1675355ad7ff7b66acfe3541625efe5a3ad38f29d6115"
             }
           },
           "trlc_sphinx_dependencies_39_docutils": {
@@ -4219,7 +4225,7 @@
               "dep_template": "@trlc_sphinx_dependencies//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_9_host//:python",
               "repo": "trlc_sphinx_dependencies_39",
-              "requirement": "docutils==0.22.4 --hash=sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968 --hash=sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de"
+              "requirement": "docutils==0.21.2 --hash=sha256:3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f --hash=sha256:dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2"
             }
           },
           "trlc_sphinx_dependencies_39_idna": {
@@ -4228,7 +4234,7 @@
               "dep_template": "@trlc_sphinx_dependencies//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_9_host//:python",
               "repo": "trlc_sphinx_dependencies_39",
-              "requirement": "idna==3.15 --hash=sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8 --hash=sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc"
+              "requirement": "idna==3.18 --hash=sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2 --hash=sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848"
             }
           },
           "trlc_sphinx_dependencies_39_imagesize": {
@@ -4237,7 +4243,16 @@
               "dep_template": "@trlc_sphinx_dependencies//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_9_host//:python",
               "repo": "trlc_sphinx_dependencies_39",
-              "requirement": "imagesize==2.0.0 --hash=sha256:5667c5bbb57ab3f1fa4bc366f4fbc971db3d5ed011fd2715fd8001f782718d96 --hash=sha256:8e8358c4a05c304f1fccf7ff96f036e7243a189e9e42e90851993c558cfe9ee3"
+              "requirement": "imagesize==1.5.0 --hash=sha256:32677681b3f434c2cb496f00e89c5a291247b35b1f527589909e008057da5899 --hash=sha256:8bfc5363a7f2133a89f0098451e0bcb1cd71aba4dc02bbcecb39d99d40e1b94f"
+            }
+          },
+          "trlc_sphinx_dependencies_39_importlib_metadata": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@trlc_sphinx_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_9_host//:python",
+              "repo": "trlc_sphinx_dependencies_39",
+              "requirement": "importlib-metadata==8.7.1 --hash=sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb --hash=sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151"
             }
           },
           "trlc_sphinx_dependencies_39_jinja2": {
@@ -4282,16 +4297,7 @@
               "dep_template": "@trlc_sphinx_dependencies//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_9_host//:python",
               "repo": "trlc_sphinx_dependencies_39",
-              "requirement": "requests==2.33.1 --hash=sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517 --hash=sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a"
-            }
-          },
-          "trlc_sphinx_dependencies_39_roman_numerals": {
-            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
-            "attributes": {
-              "dep_template": "@trlc_sphinx_dependencies//{name}:{target}",
-              "python_interpreter_target": "@@rules_python++python+python_3_9_host//:python",
-              "repo": "trlc_sphinx_dependencies_39",
-              "requirement": "roman-numerals==4.1.0 --hash=sha256:1af8b147eb1405d5839e78aeb93131690495fe9da5c91856cb33ad55a7f1e5b2 --hash=sha256:647ba99caddc2cc1e55a51e4360689115551bf4476d90e8162cf8c345fe233c7"
+              "requirement": "requests==2.32.5 --hash=sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6 --hash=sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf"
             }
           },
           "trlc_sphinx_dependencies_39_snowballstemmer": {
@@ -4309,7 +4315,7 @@
               "dep_template": "@trlc_sphinx_dependencies//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_9_host//:python",
               "repo": "trlc_sphinx_dependencies_39",
-              "requirement": "sphinx==9.1.0 --hash=sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb --hash=sha256:c84fdd4e782504495fe4f2c0b3413d6c2bf388589bb352d439b2a3bb99991978"
+              "requirement": "sphinx==7.4.7 --hash=sha256:242f92a7ea7e6c5b406fdc2615413890ba9f699114a9c09192d7dfead2ee9cfe --hash=sha256:c2419e2135d11f1951cd994d6eb18a1835bd8fdd8429f9ca375dc1f3281bd239"
             }
           },
           "trlc_sphinx_dependencies_39_sphinxcontrib_applehelp": {
@@ -4366,13 +4372,31 @@
               "requirement": "sphinxcontrib-serializinghtml==2.0.0 --hash=sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331 --hash=sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d"
             }
           },
+          "trlc_sphinx_dependencies_39_tomli": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@trlc_sphinx_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_9_host//:python",
+              "repo": "trlc_sphinx_dependencies_39",
+              "requirement": "tomli==2.4.1 --hash=sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853 --hash=sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe --hash=sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5 --hash=sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d --hash=sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd --hash=sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26 --hash=sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54 --hash=sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6 --hash=sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c --hash=sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a --hash=sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd --hash=sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f --hash=sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5 --hash=sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9 --hash=sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662 --hash=sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9 --hash=sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1 --hash=sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585 --hash=sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e --hash=sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c --hash=sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41 --hash=sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f --hash=sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085 --hash=sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15 --hash=sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7 --hash=sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c --hash=sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36 --hash=sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076 --hash=sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac --hash=sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8 --hash=sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232 --hash=sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece --hash=sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a --hash=sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897 --hash=sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d --hash=sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4 --hash=sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917 --hash=sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396 --hash=sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a --hash=sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc --hash=sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba --hash=sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f --hash=sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257 --hash=sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30 --hash=sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf --hash=sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9 --hash=sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049"
+            }
+          },
           "trlc_sphinx_dependencies_39_urllib3": {
             "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
             "attributes": {
               "dep_template": "@trlc_sphinx_dependencies//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_9_host//:python",
               "repo": "trlc_sphinx_dependencies_39",
-              "requirement": "urllib3==2.7.0 --hash=sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"
+              "requirement": "urllib3==2.6.3 --hash=sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed --hash=sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"
+            }
+          },
+          "trlc_sphinx_dependencies_39_zipp": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@trlc_sphinx_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_9_host//:python",
+              "repo": "trlc_sphinx_dependencies_39",
+              "requirement": "zipp==3.23.1 --hash=sha256:0b3596c50a5c700c9cb40ba8d86d9f2cc4807e9bedb06bcdf7fac85633e444dc --hash=sha256:32120e378d32cd9714ad503c1d024619063ec28aad2248dc6672ad13edfa5110"
             }
           },
           "pip_deps": {
@@ -4580,12 +4604,13 @@
                 "docutils": "{\"trlc_sphinx_dependencies_310_docutils\":[{\"version\":\"3.10\"}],\"trlc_sphinx_dependencies_311_docutils\":[{\"version\":\"3.11\"}],\"trlc_sphinx_dependencies_312_docutils\":[{\"version\":\"3.12\"}],\"trlc_sphinx_dependencies_39_docutils\":[{\"version\":\"3.9\"}]}",
                 "idna": "{\"trlc_sphinx_dependencies_310_idna\":[{\"version\":\"3.10\"}],\"trlc_sphinx_dependencies_311_idna\":[{\"version\":\"3.11\"}],\"trlc_sphinx_dependencies_312_idna\":[{\"version\":\"3.12\"}],\"trlc_sphinx_dependencies_39_idna\":[{\"version\":\"3.9\"}]}",
                 "imagesize": "{\"trlc_sphinx_dependencies_310_imagesize\":[{\"version\":\"3.10\"}],\"trlc_sphinx_dependencies_311_imagesize\":[{\"version\":\"3.11\"}],\"trlc_sphinx_dependencies_312_imagesize\":[{\"version\":\"3.12\"}],\"trlc_sphinx_dependencies_39_imagesize\":[{\"version\":\"3.9\"}]}",
+                "importlib_metadata": "{\"trlc_sphinx_dependencies_39_importlib_metadata\":[{\"version\":\"3.9\"}]}",
                 "jinja2": "{\"trlc_sphinx_dependencies_310_jinja2\":[{\"version\":\"3.10\"}],\"trlc_sphinx_dependencies_311_jinja2\":[{\"version\":\"3.11\"}],\"trlc_sphinx_dependencies_312_jinja2\":[{\"version\":\"3.12\"}],\"trlc_sphinx_dependencies_39_jinja2\":[{\"version\":\"3.9\"}]}",
                 "markupsafe": "{\"trlc_sphinx_dependencies_310_markupsafe\":[{\"version\":\"3.10\"}],\"trlc_sphinx_dependencies_311_markupsafe\":[{\"version\":\"3.11\"}],\"trlc_sphinx_dependencies_312_markupsafe\":[{\"version\":\"3.12\"}],\"trlc_sphinx_dependencies_39_markupsafe\":[{\"version\":\"3.9\"}]}",
                 "packaging": "{\"trlc_sphinx_dependencies_310_packaging\":[{\"version\":\"3.10\"}],\"trlc_sphinx_dependencies_311_packaging\":[{\"version\":\"3.11\"}],\"trlc_sphinx_dependencies_312_packaging\":[{\"version\":\"3.12\"}],\"trlc_sphinx_dependencies_39_packaging\":[{\"version\":\"3.9\"}]}",
                 "pygments": "{\"trlc_sphinx_dependencies_310_pygments\":[{\"version\":\"3.10\"}],\"trlc_sphinx_dependencies_311_pygments\":[{\"version\":\"3.11\"}],\"trlc_sphinx_dependencies_312_pygments\":[{\"version\":\"3.12\"}],\"trlc_sphinx_dependencies_39_pygments\":[{\"version\":\"3.9\"}]}",
                 "requests": "{\"trlc_sphinx_dependencies_310_requests\":[{\"version\":\"3.10\"}],\"trlc_sphinx_dependencies_311_requests\":[{\"version\":\"3.11\"}],\"trlc_sphinx_dependencies_312_requests\":[{\"version\":\"3.12\"}],\"trlc_sphinx_dependencies_39_requests\":[{\"version\":\"3.9\"}]}",
-                "roman_numerals": "{\"trlc_sphinx_dependencies_310_roman_numerals\":[{\"version\":\"3.10\"}],\"trlc_sphinx_dependencies_311_roman_numerals\":[{\"version\":\"3.11\"}],\"trlc_sphinx_dependencies_312_roman_numerals\":[{\"version\":\"3.12\"}],\"trlc_sphinx_dependencies_39_roman_numerals\":[{\"version\":\"3.9\"}]}",
+                "roman_numerals": "{\"trlc_sphinx_dependencies_311_roman_numerals\":[{\"version\":\"3.11\"}],\"trlc_sphinx_dependencies_312_roman_numerals\":[{\"version\":\"3.12\"}]}",
                 "snowballstemmer": "{\"trlc_sphinx_dependencies_310_snowballstemmer\":[{\"version\":\"3.10\"}],\"trlc_sphinx_dependencies_311_snowballstemmer\":[{\"version\":\"3.11\"}],\"trlc_sphinx_dependencies_312_snowballstemmer\":[{\"version\":\"3.12\"}],\"trlc_sphinx_dependencies_39_snowballstemmer\":[{\"version\":\"3.9\"}]}",
                 "sphinx": "{\"trlc_sphinx_dependencies_310_sphinx\":[{\"version\":\"3.10\"}],\"trlc_sphinx_dependencies_311_sphinx\":[{\"version\":\"3.11\"}],\"trlc_sphinx_dependencies_312_sphinx\":[{\"version\":\"3.12\"}],\"trlc_sphinx_dependencies_39_sphinx\":[{\"version\":\"3.9\"}]}",
                 "sphinxcontrib_applehelp": "{\"trlc_sphinx_dependencies_310_sphinxcontrib_applehelp\":[{\"version\":\"3.10\"}],\"trlc_sphinx_dependencies_311_sphinxcontrib_applehelp\":[{\"version\":\"3.11\"}],\"trlc_sphinx_dependencies_312_sphinxcontrib_applehelp\":[{\"version\":\"3.12\"}],\"trlc_sphinx_dependencies_39_sphinxcontrib_applehelp\":[{\"version\":\"3.9\"}]}",
@@ -4594,7 +4619,9 @@
                 "sphinxcontrib_jsmath": "{\"trlc_sphinx_dependencies_310_sphinxcontrib_jsmath\":[{\"version\":\"3.10\"}],\"trlc_sphinx_dependencies_311_sphinxcontrib_jsmath\":[{\"version\":\"3.11\"}],\"trlc_sphinx_dependencies_312_sphinxcontrib_jsmath\":[{\"version\":\"3.12\"}],\"trlc_sphinx_dependencies_39_sphinxcontrib_jsmath\":[{\"version\":\"3.9\"}]}",
                 "sphinxcontrib_qthelp": "{\"trlc_sphinx_dependencies_310_sphinxcontrib_qthelp\":[{\"version\":\"3.10\"}],\"trlc_sphinx_dependencies_311_sphinxcontrib_qthelp\":[{\"version\":\"3.11\"}],\"trlc_sphinx_dependencies_312_sphinxcontrib_qthelp\":[{\"version\":\"3.12\"}],\"trlc_sphinx_dependencies_39_sphinxcontrib_qthelp\":[{\"version\":\"3.9\"}]}",
                 "sphinxcontrib_serializinghtml": "{\"trlc_sphinx_dependencies_310_sphinxcontrib_serializinghtml\":[{\"version\":\"3.10\"}],\"trlc_sphinx_dependencies_311_sphinxcontrib_serializinghtml\":[{\"version\":\"3.11\"}],\"trlc_sphinx_dependencies_312_sphinxcontrib_serializinghtml\":[{\"version\":\"3.12\"}],\"trlc_sphinx_dependencies_39_sphinxcontrib_serializinghtml\":[{\"version\":\"3.9\"}]}",
-                "urllib3": "{\"trlc_sphinx_dependencies_310_urllib3\":[{\"version\":\"3.10\"}],\"trlc_sphinx_dependencies_311_urllib3\":[{\"version\":\"3.11\"}],\"trlc_sphinx_dependencies_312_urllib3\":[{\"version\":\"3.12\"}],\"trlc_sphinx_dependencies_39_urllib3\":[{\"version\":\"3.9\"}]}"
+                "tomli": "{\"trlc_sphinx_dependencies_310_tomli\":[{\"version\":\"3.10\"}],\"trlc_sphinx_dependencies_39_tomli\":[{\"version\":\"3.9\"}]}",
+                "urllib3": "{\"trlc_sphinx_dependencies_310_urllib3\":[{\"version\":\"3.10\"}],\"trlc_sphinx_dependencies_311_urllib3\":[{\"version\":\"3.11\"}],\"trlc_sphinx_dependencies_312_urllib3\":[{\"version\":\"3.12\"}],\"trlc_sphinx_dependencies_39_urllib3\":[{\"version\":\"3.9\"}]}",
+                "zipp": "{\"trlc_sphinx_dependencies_39_zipp\":[{\"version\":\"3.9\"}]}"
               },
               "packages": [
                 "alabaster",
@@ -4604,6 +4631,7 @@
                 "docutils",
                 "idna",
                 "imagesize",
+                "importlib_metadata",
                 "jinja2",
                 "markupsafe",
                 "packaging",
@@ -4618,7 +4646,9 @@
                 "sphinxcontrib_jsmath",
                 "sphinxcontrib_qthelp",
                 "sphinxcontrib_serializinghtml",
-                "urllib3"
+                "tomli",
+                "urllib3",
+                "zipp"
               ],
               "groups": {}
             }

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -243,6 +243,104 @@
   },
   "selectedYankedVersions": {},
   "moduleExtensions": {
+    "@@aspect_rules_js+//npm:extensions.bzl%pnpm": {
+      "general": {
+        "bzlTransitiveDigest": "jbPg/AfVpWUyCYoyNiC3rfSAQGfysV4liQyrbsYwmKQ=",
+        "usagesDigest": "ZYGEy1FrDUNPBzAzD+ujlHkMEsVPMYOvpHm9RhUexUE=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "pnpm": {
+            "repoRuleId": "@@aspect_rules_js+//npm/private:npm_import.bzl%npm_import_rule",
+            "attributes": {
+              "package": "pnpm",
+              "version": "8.6.7",
+              "root_package": "",
+              "link_workspace": "",
+              "link_packages": {},
+              "integrity": "sha512-vRIWpD/L4phf9Bk2o/O2TDR8fFoJnpYrp2TKqTIZF/qZ2/rgL3qKXzHofHgbXsinwMoSEigz28sqk3pQ+yMEQQ==",
+              "url": "",
+              "commit": "",
+              "patch_args": [
+                "-p0"
+              ],
+              "patches": [],
+              "custom_postinstall": "",
+              "npm_auth": "",
+              "npm_auth_basic": "",
+              "npm_auth_username": "",
+              "npm_auth_password": "",
+              "lifecycle_hooks": [],
+              "extra_build_content": "load(\"@aspect_rules_js//js:defs.bzl\", \"js_binary\")\njs_binary(name = \"pnpm\", data = glob([\"package/**\"]), entry_point = \"package/dist/pnpm.cjs\", visibility = [\"//visibility:public\"])",
+              "generate_bzl_library_targets": false,
+              "extract_full_archive": true
+            }
+          },
+          "pnpm__links": {
+            "repoRuleId": "@@aspect_rules_js+//npm/private:npm_import.bzl%npm_import_links",
+            "attributes": {
+              "package": "pnpm",
+              "version": "8.6.7",
+              "dev": false,
+              "root_package": "",
+              "link_packages": {},
+              "deps": {},
+              "transitive_closure": {},
+              "lifecycle_build_target": false,
+              "lifecycle_hooks_env": [],
+              "lifecycle_hooks_execution_requirements": [
+                "no-sandbox"
+              ],
+              "lifecycle_hooks_use_default_shell_env": false,
+              "bins": {},
+              "npm_translate_lock_repo": "",
+              "package_visibility": [
+                "//visibility:public"
+              ],
+              "replace_package": ""
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "aspect_bazel_lib+",
+            "bazel_skylib",
+            "bazel_skylib+"
+          ],
+          [
+            "aspect_bazel_lib+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "aspect_rules_js+",
+            "aspect_bazel_lib",
+            "aspect_bazel_lib+"
+          ],
+          [
+            "aspect_rules_js+",
+            "bazel_features",
+            "bazel_features+"
+          ],
+          [
+            "aspect_rules_js+",
+            "bazel_skylib",
+            "bazel_skylib+"
+          ],
+          [
+            "aspect_rules_js+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "bazel_features+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
     "@@aspect_tools_telemetry+//:extension.bzl%telemetry": {
       "general": {
         "bzlTransitiveDigest": "gA7tPEdJXhskzPIEUxjX9IdDrM6+WjfbgXJ8Ez47umk=",
@@ -275,6 +373,468 @@
         ]
       }
     },
+    "@@gazelle+//:extensions.bzl%go_deps": {
+      "general": {
+        "bzlTransitiveDigest": "5XiuqrLF/9AA9uua2Xe8m9Pwq+PP1kPChaZSEImEHYQ=",
+        "usagesDigest": "tfQCHJg51LFgV7hTP9SLQammcDdAISgPLeV+eH7GlJ4=",
+        "recordedFileInputs": {
+          "@@gazelle+//go.mod": "9ae159a385b2f244bbe964b9f91dbea6e7bd534e0b22e846655f241c65de2c49",
+          "@@gazelle+//go.sum": "7469786f3930030c430969cedae951e6947cb40f4a563dac94a350659c0fedc4",
+          "@@rules_buf+//go.mod": "c96e5c352880a2df5cd7294265df91c7bad4fb24ef3865ccb1b9ceb29341cf8a",
+          "@@rules_buf+//go.sum": "968d06e5d35e524686d63dda36b4fb82d5054a4c5a42a5da8214a43cc4e8edb3",
+          "@@rules_go+//go.mod": "a7143f329c2a3e0b983ce74a96c0c25b0d0c59d236d75f7e1b069aadd988d55e",
+          "@@rules_go+//go.sum": "022d36c9ebcc7b5dee1e9b85b3da9c9f3a529ee6f979946d66e4955b8d54614a"
+        },
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "com_github_bazelbuild_buildtools": {
+            "repoRuleId": "@@gazelle+//internal:go_repository.bzl%go_repository",
+            "attributes": {
+              "importpath": "github.com/bazelbuild/buildtools",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:2Gc2Q6hVR1SJ8bBI9Ybzoggp8u/ED2WkM4MfvEIn9+c=",
+              "replace": "",
+              "version": "v0.0.0-20231115204819-d4c9dccdfbb1"
+            }
+          },
+          "com_github_stretchr_testify": {
+            "repoRuleId": "@@gazelle+//internal:go_repository.bzl%go_repository",
+            "attributes": {
+              "importpath": "github.com/stretchr/testify",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=",
+              "replace": "",
+              "version": "v1.8.4"
+            }
+          },
+          "in_gopkg_yaml_v3": {
+            "repoRuleId": "@@gazelle+//internal:go_repository.bzl%go_repository",
+            "attributes": {
+              "importpath": "gopkg.in/yaml.v3",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=",
+              "replace": "",
+              "version": "v3.0.1"
+            }
+          },
+          "com_github_davecgh_go_spew": {
+            "repoRuleId": "@@gazelle+//internal:go_repository.bzl%go_repository",
+            "attributes": {
+              "importpath": "github.com/davecgh/go-spew",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=",
+              "replace": "",
+              "version": "v1.1.1"
+            }
+          },
+          "com_github_google_go_cmp": {
+            "repoRuleId": "@@gazelle+//internal:go_repository.bzl%go_repository",
+            "attributes": {
+              "importpath": "github.com/google/go-cmp",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=",
+              "replace": "",
+              "version": "v0.6.0"
+            }
+          },
+          "com_github_pmezard_go_difflib": {
+            "repoRuleId": "@@gazelle+//internal:go_repository.bzl%go_repository",
+            "attributes": {
+              "importpath": "github.com/pmezard/go-difflib",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=",
+              "replace": "",
+              "version": "v1.0.0"
+            }
+          },
+          "org_golang_x_mod": {
+            "repoRuleId": "@@gazelle+//internal:go_repository.bzl%go_repository",
+            "attributes": {
+              "importpath": "golang.org/x/mod",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:dGoOF9QVLYng8IHTm7BAyWqCqSheQ5pYWGhzW00YJr0=",
+              "replace": "",
+              "version": "v0.14.0"
+            }
+          },
+          "org_golang_x_sys": {
+            "repoRuleId": "@@gazelle+//internal:go_repository.bzl%go_repository",
+            "attributes": {
+              "importpath": "golang.org/x/sys",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:Vz7Qs629MkJkGyHxUlRHizWJRG2j8fbQKjELVSNhy7Q=",
+              "replace": "",
+              "version": "v0.14.0"
+            }
+          },
+          "org_golang_x_tools_go_vcs": {
+            "repoRuleId": "@@gazelle+//internal:go_repository.bzl%go_repository",
+            "attributes": {
+              "importpath": "golang.org/x/tools/go/vcs",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:cOIJqWBl99H1dH5LWizPa+0ImeeJq3t3cJjaeOWUAL4=",
+              "replace": "",
+              "version": "v0.1.0-deprecated"
+            }
+          },
+          "in_gopkg_check_v1": {
+            "repoRuleId": "@@gazelle+//internal:go_repository.bzl%go_repository",
+            "attributes": {
+              "importpath": "gopkg.in/check.v1",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=",
+              "replace": "",
+              "version": "v1.0.0-20201130134442-10cb98267c6c"
+            }
+          },
+          "com_github_gogo_protobuf": {
+            "repoRuleId": "@@gazelle+//internal:go_repository.bzl%go_repository",
+            "attributes": {
+              "importpath": "github.com/gogo/protobuf",
+              "build_directives": [
+                "gazelle:proto disable"
+              ],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=",
+              "replace": "",
+              "version": "v1.3.2"
+            }
+          },
+          "com_github_golang_mock": {
+            "repoRuleId": "@@gazelle+//internal:go_repository.bzl%go_repository",
+            "attributes": {
+              "importpath": "github.com/golang/mock",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=",
+              "replace": "",
+              "version": "v1.6.0"
+            }
+          },
+          "com_github_golang_protobuf": {
+            "repoRuleId": "@@gazelle+//internal:go_repository.bzl%go_repository",
+            "attributes": {
+              "importpath": "github.com/golang/protobuf",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=",
+              "replace": "",
+              "version": "v1.5.2"
+            }
+          },
+          "org_golang_google_protobuf": {
+            "repoRuleId": "@@gazelle+//internal:go_repository.bzl%go_repository",
+            "attributes": {
+              "importpath": "google.golang.org/protobuf",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=",
+              "replace": "",
+              "version": "v1.28.0"
+            }
+          },
+          "org_golang_x_net": {
+            "repoRuleId": "@@gazelle+//internal:go_repository.bzl%go_repository",
+            "attributes": {
+              "importpath": "golang.org/x/net",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:4nGaVu0QrbjT/AK2PRLuQfQuh6DJve+pELhqTdAj3x0=",
+              "replace": "",
+              "version": "v0.0.0-20210405180319-a5a99cb37ef4"
+            }
+          },
+          "org_golang_x_text": {
+            "repoRuleId": "@@gazelle+//internal:go_repository.bzl%go_repository",
+            "attributes": {
+              "importpath": "golang.org/x/text",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=",
+              "replace": "",
+              "version": "v0.3.3"
+            }
+          },
+          "org_golang_google_genproto": {
+            "repoRuleId": "@@gazelle+//internal:go_repository.bzl%go_repository",
+            "attributes": {
+              "importpath": "google.golang.org/genproto",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:+kGHl1aib/qcwaRi1CbqBZ1rk19r85MNUf8HaBghugY=",
+              "replace": "",
+              "version": "v0.0.0-20200526211855-cb27e3aa2013"
+            }
+          },
+          "org_golang_google_grpc": {
+            "repoRuleId": "@@gazelle+//internal:go_repository.bzl%go_repository",
+            "attributes": {
+              "importpath": "google.golang.org/grpc",
+              "build_directives": [
+                "gazelle:proto disable"
+              ],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:fPVVDxY9w++VjTZsYvXWqEf9Rqar/e+9zYfxKK+W+YU=",
+              "replace": "",
+              "version": "v1.50.0"
+            }
+          },
+          "org_golang_x_tools": {
+            "repoRuleId": "@@gazelle+//internal:go_repository.bzl%go_repository",
+            "attributes": {
+              "importpath": "golang.org/x/tools",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:Iey4qkscZuv0VvIt8E0neZjtPVQFSc870HQ448QgEmQ=",
+              "replace": "",
+              "version": "v0.13.0"
+            }
+          },
+          "com_github_bmatcuk_doublestar_v4": {
+            "repoRuleId": "@@gazelle+//internal:go_repository.bzl%go_repository",
+            "attributes": {
+              "importpath": "github.com/bmatcuk/doublestar/v4",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:FH9SifrbvJhnlQpztAx++wlkk70QBf0iBWDwNy7PA4I=",
+              "replace": "",
+              "version": "v4.6.1"
+            }
+          },
+          "com_github_fsnotify_fsnotify": {
+            "repoRuleId": "@@gazelle+//internal:go_repository.bzl%go_repository",
+            "attributes": {
+              "importpath": "github.com/fsnotify/fsnotify",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=",
+              "replace": "",
+              "version": "v1.7.0"
+            }
+          },
+          "org_golang_x_sync": {
+            "repoRuleId": "@@gazelle+//internal:go_repository.bzl%go_repository",
+            "attributes": {
+              "importpath": "golang.org/x/sync",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:zxkM55ReGkDlKSM+Fu41A+zmbZuaPVbGMzvvdUPznYQ=",
+              "replace": "",
+              "version": "v0.4.0"
+            }
+          },
+          "bazel_gazelle_go_repository_config": {
+            "repoRuleId": "@@gazelle+//internal/bzlmod:go_deps.bzl%_go_repository_config",
+            "attributes": {
+              "importpaths": {
+                "@gazelle+": "github.com/bazelbuild/bazel-gazelle",
+                "com_github_bazelbuild_buildtools": "github.com/bazelbuild/buildtools",
+                "@rules_go+": "github.com/bazelbuild/rules_go",
+                "com_github_stretchr_testify": "github.com/stretchr/testify",
+                "in_gopkg_yaml_v3": "gopkg.in/yaml.v3",
+                "com_github_davecgh_go_spew": "github.com/davecgh/go-spew",
+                "com_github_google_go_cmp": "github.com/google/go-cmp",
+                "com_github_pmezard_go_difflib": "github.com/pmezard/go-difflib",
+                "org_golang_x_mod": "golang.org/x/mod",
+                "org_golang_x_sys": "golang.org/x/sys",
+                "org_golang_x_tools_go_vcs": "golang.org/x/tools/go/vcs",
+                "in_gopkg_check_v1": "gopkg.in/check.v1",
+                "com_github_gogo_protobuf": "github.com/gogo/protobuf",
+                "com_github_golang_mock": "github.com/golang/mock",
+                "com_github_golang_protobuf": "github.com/golang/protobuf",
+                "org_golang_google_protobuf": "google.golang.org/protobuf",
+                "org_golang_x_net": "golang.org/x/net",
+                "org_golang_x_text": "golang.org/x/text",
+                "org_golang_google_genproto": "google.golang.org/genproto",
+                "org_golang_google_grpc": "google.golang.org/grpc",
+                "org_golang_x_tools": "golang.org/x/tools",
+                "com_github_bmatcuk_doublestar_v4": "github.com/bmatcuk/doublestar/v4",
+                "com_github_fsnotify_fsnotify": "github.com/fsnotify/fsnotify",
+                "org_golang_x_sync": "golang.org/x/sync",
+                "@rules_buf+": "github.com/bufbuild/rules_buf"
+              },
+              "module_names": {
+                "@rules_buf+": "rules_buf",
+                "@rules_go+": "rules_go",
+                "@gazelle+": "gazelle"
+              },
+              "build_naming_conventions": {}
+            }
+          }
+        },
+        "moduleExtensionMetadata": {
+          "explicitRootModuleDirectDeps": [],
+          "explicitRootModuleDirectDevDeps": [],
+          "useAllRepos": "NO",
+          "reproducible": false
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "gazelle+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@gazelle+//internal/bzlmod:non_module_deps.bzl%non_module_deps": {
+      "general": {
+        "bzlTransitiveDigest": "AjbsH9WZCj0ipLarbbkp25YBRrRhWYvO7OIiTcHyyok=",
+        "usagesDigest": "/EIHHLtjAqjZiKFavzwtqyPtUxCp0xuO4NLoiFGXgIw=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "bazel_gazelle_go_repository_cache": {
+            "repoRuleId": "@@gazelle+//internal:go_repository_cache.bzl%go_repository_cache",
+            "attributes": {
+              "go_sdk_name": "@rules_go++go_sdk+go_default_sdk",
+              "go_env": {}
+            }
+          },
+          "bazel_gazelle_go_repository_tools": {
+            "repoRuleId": "@@gazelle+//internal:go_repository_tools.bzl%go_repository_tools",
+            "attributes": {
+              "go_cache": "@@gazelle++non_module_deps+bazel_gazelle_go_repository_cache//:go.env"
+            }
+          },
+          "bazel_gazelle_is_bazel_module": {
+            "repoRuleId": "@@gazelle+//internal:is_bazel_module.bzl%is_bazel_module",
+            "attributes": {
+              "is_bazel_module": true
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "gazelle+",
+            "bazel_gazelle_go_repository_cache",
+            "gazelle++non_module_deps+bazel_gazelle_go_repository_cache"
+          ],
+          [
+            "gazelle+",
+            "go_host_compatible_sdk_label",
+            "rules_go++go_sdk+go_host_compatible_sdk_label"
+          ],
+          [
+            "rules_go++go_sdk+go_host_compatible_sdk_label",
+            "go_default_sdk",
+            "rules_go++go_sdk+go_default_sdk"
+          ]
+        ]
+      }
+    },
+    "@@pybind11_bazel+//:python_configure.bzl%extension": {
+      "general": {
+        "bzlTransitiveDigest": "c9ZWWeXeu6bctL4/SsY2otFWyeFN0JJ20+ymGyJZtWk=",
+        "usagesDigest": "fycyB39YnXIJkfWCIXLUKJMZzANcuLy9ZE73hRucjFk=",
+        "recordedFileInputs": {
+          "@@pybind11_bazel+//MODULE.bazel": "88af1c246226d87e65be78ed49ecd1e6f5e98648558c14ce99176da041dc378e"
+        },
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "local_config_python": {
+            "repoRuleId": "@@pybind11_bazel+//:python_configure.bzl%python_configure",
+            "attributes": {}
+          },
+          "pybind11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@pybind11_bazel+//:pybind11.BUILD",
+              "strip_prefix": "pybind11-2.11.1",
+              "urls": [
+                "https://github.com/pybind/pybind11/archive/v2.11.1.zip"
+              ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "pybind11_bazel+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
     "@@rules_buf+//buf:extensions.bzl%buf": {
       "general": {
         "bzlTransitiveDigest": "7lUQZIi5u5kjLotkiZrmQ3jldx7w/31P5crwGwQQnmI=",
@@ -294,6 +854,89 @@
         "recordedRepoMappingEntries": [
           [
             "rules_buf+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@rules_fuzzing+//fuzzing/private:extensions.bzl%non_module_dependencies": {
+      "general": {
+        "bzlTransitiveDigest": "WHRlQQnxW7e7XMRBhq7SARkDarLDOAbg6iLaJpk5QYM=",
+        "usagesDigest": "wy6ISK6UOcBEjj/mvJ/S3WeXoO67X+1llb9yPyFtPgc=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "platforms": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.8/platforms-0.0.8.tar.gz",
+                "https://github.com/bazelbuild/platforms/releases/download/0.0.8/platforms-0.0.8.tar.gz"
+              ],
+              "sha256": "8150406605389ececb6da07cbcb509d5637a3ab9a24bc69b1101531367d89d74"
+            }
+          },
+          "rules_python": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "d70cd72a7a4880f0000a6346253414825c19cdd40a28289bdf67b8e6480edff8",
+              "strip_prefix": "rules_python-0.28.0",
+              "url": "https://github.com/bazelbuild/rules_python/releases/download/0.28.0/rules_python-0.28.0.tar.gz"
+            }
+          },
+          "bazel_skylib": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "cd55a062e763b9349921f0f5db8c3933288dc8ba4f76dd9416aac68acee3cb94",
+              "urls": [
+                "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz",
+                "https://github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz"
+              ]
+            }
+          },
+          "com_google_absl": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/abseil/abseil-cpp/archive/refs/tags/20240116.1.zip"
+              ],
+              "strip_prefix": "abseil-cpp-20240116.1",
+              "integrity": "sha256-7capMWOvWyoYbUaHF/b+I2U6XLMaHmky8KugWvfXYuk="
+            }
+          },
+          "rules_fuzzing_oss_fuzz": {
+            "repoRuleId": "@@rules_fuzzing+//fuzzing/private/oss_fuzz:repository.bzl%oss_fuzz_repository",
+            "attributes": {}
+          },
+          "honggfuzz": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@rules_fuzzing+//:honggfuzz.BUILD",
+              "sha256": "6b18ba13bc1f36b7b950c72d80f19ea67fbadc0ac0bb297ec89ad91f2eaa423e",
+              "url": "https://github.com/google/honggfuzz/archive/2.5.zip",
+              "strip_prefix": "honggfuzz-2.5"
+            }
+          },
+          "rules_fuzzing_jazzer": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_jar",
+            "attributes": {
+              "sha256": "ee6feb569d88962d59cb59e8a31eb9d007c82683f3ebc64955fd5b96f277eec2",
+              "url": "https://repo1.maven.org/maven2/com/code-intelligence/jazzer/0.20.1/jazzer-0.20.1.jar"
+            }
+          },
+          "rules_fuzzing_jazzer_api": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_jar",
+            "attributes": {
+              "sha256": "f5a60242bc408f7fa20fccf10d6c5c5ea1fcb3c6f44642fec5af88373ae7aa1b",
+              "url": "https://repo1.maven.org/maven2/com/code-intelligence/jazzer-api/0.20.1/jazzer-api-0.20.1.jar"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_fuzzing+",
             "bazel_tools",
             "bazel_tools"
           ]
@@ -351,6 +994,225 @@
               "sdk_versions": [
                 "1.21.1"
               ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "bazel_features+",
+            "bazel_features_globals",
+            "bazel_features++version_extension+bazel_features_globals"
+          ],
+          [
+            "bazel_features+",
+            "bazel_features_version",
+            "bazel_features++version_extension+bazel_features_version"
+          ],
+          [
+            "rules_go+",
+            "bazel_features",
+            "bazel_features+"
+          ],
+          [
+            "rules_go+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@rules_go+//go/private:extensions.bzl%non_module_dependencies": {
+      "general": {
+        "bzlTransitiveDigest": "8IS/xZyXWdiCPaNtZVSLXF4crDQ3a5Vk30dDU7+rYp4=",
+        "usagesDigest": "JL1XfI3Chd9vaoVGnIlNXDdHjWcf9WYe/Lu+A1HCC74=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "bazel_skylib": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-1.4.2.tar.gz",
+                "https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-1.4.2.tar.gz"
+              ],
+              "sha256": "66ffd9315665bfaafc96b52278f57c7e2dd09f5ede279ea6d39b2be471e7e3aa",
+              "strip_prefix": ""
+            }
+          },
+          "org_golang_x_tools": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://mirror.bazel.build/github.com/golang/tools/archive/refs/tags/v0.7.0.zip",
+                "https://github.com/golang/tools/archive/refs/tags/v0.7.0.zip"
+              ],
+              "sha256": "9f20a20f29f4008d797a8be882ef82b69cf8f7f2b96dbdfe3814c57d8280fa4b",
+              "strip_prefix": "tools-0.7.0",
+              "patches": [
+                "@@rules_go+//third_party:org_golang_x_tools-deletegopls.patch",
+                "@@rules_go+//third_party:org_golang_x_tools-gazelle.patch"
+              ],
+              "patch_args": [
+                "-p1"
+              ]
+            }
+          },
+          "org_golang_x_tools_go_vcs": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://mirror.bazel.build/github.com/golang/tools/archive/refs/tags/go/vcs/v0.1.0-deprecated.zip",
+                "https://github.com/golang/tools/archive/refs/tags/go/vcs/v0.1.0-deprecated.zip"
+              ],
+              "sha256": "1b389268d126467105305ae4482df0189cc80a13aaab28d0946192b4ad0737a8",
+              "strip_prefix": "tools-go-vcs-v0.1.0-deprecated/go/vcs",
+              "patches": [
+                "@@rules_go+//third_party:org_golang_x_tools_go_vcs-gazelle.patch"
+              ],
+              "patch_args": [
+                "-p1"
+              ]
+            }
+          },
+          "org_golang_x_sys": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://mirror.bazel.build/github.com/golang/sys/archive/refs/tags/v0.12.0.zip",
+                "https://github.com/golang/sys/archive/refs/tags/v0.12.0.zip"
+              ],
+              "sha256": "229b079d23d18f5b1a0c46335020cddc6e5d543da2dae6e45b59d84b5d074e3a",
+              "strip_prefix": "sys-0.12.0",
+              "patches": [
+                "@@rules_go+//third_party:org_golang_x_sys-gazelle.patch"
+              ],
+              "patch_args": [
+                "-p1"
+              ]
+            }
+          },
+          "org_golang_x_xerrors": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://mirror.bazel.build/github.com/golang/xerrors/archive/04be3eba64a22a838cdb17b8dca15a52871c08b4.zip",
+                "https://github.com/golang/xerrors/archive/04be3eba64a22a838cdb17b8dca15a52871c08b4.zip"
+              ],
+              "sha256": "ffad2b06ef2e09d040da2ff08077865e99ab95d4d0451737fc8e33706bb01634",
+              "strip_prefix": "xerrors-04be3eba64a22a838cdb17b8dca15a52871c08b4",
+              "patches": [
+                "@@rules_go+//third_party:org_golang_x_xerrors-gazelle.patch"
+              ],
+              "patch_args": [
+                "-p1"
+              ]
+            }
+          },
+          "org_golang_google_protobuf": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "f5d1f6d0e9b836aceb715f1df2dc065083a55b07ecec3b01b5e89d039b14da02",
+              "urls": [
+                "https://mirror.bazel.build/github.com/protocolbuffers/protobuf-go/archive/refs/tags/v1.31.0.zip",
+                "https://github.com/protocolbuffers/protobuf-go/archive/refs/tags/v1.31.0.zip"
+              ],
+              "strip_prefix": "protobuf-go-1.31.0",
+              "patches": [
+                "@@rules_go+//third_party:org_golang_google_protobuf-gazelle.patch"
+              ],
+              "patch_args": [
+                "-p1"
+              ]
+            }
+          },
+          "com_github_golang_protobuf": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://mirror.bazel.build/github.com/golang/protobuf/archive/refs/tags/v1.5.3.zip",
+                "https://github.com/golang/protobuf/archive/refs/tags/v1.5.3.zip"
+              ],
+              "sha256": "2dced4544ae5372281e20f1e48ca76368355a01b31353724718c4d6e3dcbb430",
+              "strip_prefix": "protobuf-1.5.3",
+              "patches": [
+                "@@rules_go+//third_party:com_github_golang_protobuf-gazelle.patch"
+              ],
+              "patch_args": [
+                "-p1"
+              ]
+            }
+          },
+          "com_github_mwitkow_go_proto_validators": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://mirror.bazel.build/github.com/mwitkow/go-proto-validators/archive/refs/tags/v0.3.2.zip",
+                "https://github.com/mwitkow/go-proto-validators/archive/refs/tags/v0.3.2.zip"
+              ],
+              "sha256": "d8697f05a2f0eaeb65261b480e1e6035301892d9fc07ed945622f41b12a68142",
+              "strip_prefix": "go-proto-validators-0.3.2"
+            }
+          },
+          "com_github_gogo_protobuf": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://mirror.bazel.build/github.com/gogo/protobuf/archive/refs/tags/v1.3.2.zip",
+                "https://github.com/gogo/protobuf/archive/refs/tags/v1.3.2.zip"
+              ],
+              "sha256": "f89f8241af909ce3226562d135c25b28e656ae173337b3e58ede917aa26e1e3c",
+              "strip_prefix": "protobuf-1.3.2",
+              "patches": [
+                "@@rules_go+//third_party:com_github_gogo_protobuf-gazelle.patch"
+              ],
+              "patch_args": [
+                "-p1"
+              ]
+            }
+          },
+          "gogo_special_proto": {
+            "repoRuleId": "@@rules_go+//proto:gogo.bzl%gogo_special_proto",
+            "attributes": {}
+          },
+          "org_golang_google_genproto": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://mirror.bazel.build/github.com/googleapis/go-genproto/archive/007df8e322eb3e384d36c0821e2337825c203ca6.zip",
+                "https://github.com/googleapis/go-genproto/archive/007df8e322eb3e384d36c0821e2337825c203ca6.zip"
+              ],
+              "sha256": "e7d0f3faed86258ed4e8e5527a8e98ff00fbd5b1a9b379a99a4aa2f76ce8bbcc",
+              "strip_prefix": "go-genproto-007df8e322eb3e384d36c0821e2337825c203ca6",
+              "patches": [
+                "@@rules_go+//third_party:org_golang_google_genproto-gazelle.patch"
+              ],
+              "patch_args": [
+                "-p1"
+              ]
+            }
+          },
+          "com_github_golang_mock": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://mirror.bazel.build/github.com/golang/mock/archive/refs/tags/v1.7.0-rc.1.zip",
+                "https://github.com/golang/mock/archive/refs/tags/v1.7.0-rc.1.zip"
+              ],
+              "patches": [
+                "@@rules_go+//third_party:com_github_golang_mock-gazelle.patch"
+              ],
+              "patch_args": [
+                "-p1"
+              ],
+              "sha256": "5359c78b0c1649cf7beb3b48ff8b1d1aaf0243b22ea4789aba94805280075d8e",
+              "strip_prefix": "mock-1.7.0-rc.1"
+            }
+          },
+          "io_bazel_rules_nogo": {
+            "repoRuleId": "@@rules_go+//go/private:nogo.bzl%go_register_nogo",
+            "attributes": {
+              "nogo": "@io_bazel_rules_go//:default_nogo"
             }
           }
         },
@@ -684,7 +1546,7 @@
         "bzlTransitiveDigest": "Z2EwAlnWwmyPNSF4pT+ZyT3/Csf4YVbyQPmxi3fBMEQ=",
         "usagesDigest": "dI3+Lv/xnhTiVoA8OAhbWbJFTH8Ih8cQv9ackt2uIIw=",
         "recordedFileInputs": {
-          "@@//requirements_dev_lock.txt": "7b97180318043379e3f29d3b33d5c9234688e7b1d7f8fbf418d4fa811a4c4e7c",
+          "@@//requirements_dev_lock.txt": "0f541f0e9dbe5adb2e84f709dee44bb6aeedc4c1395357efad14b743022219bf",
           "@@//requirements_lock_3_10.txt": "ac896df774280b0f3c8b808773a0f940d204944bd1a8f3f144bd5a6873824ebb",
           "@@//requirements_lock_3_11.txt": "610e34dbd24ed61287a2e797e1d200c4aab172cb451dbf49cb0c401419a5d36c",
           "@@//requirements_lock_3_12.txt": "84966575b4cd856a8c81e516237bb32b45e0a88d44cf05385bc4397a986d1641",
@@ -3316,7 +4178,7 @@
               "dep_template": "@trlc_dev_dependencies//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_12_host//:python",
               "repo": "trlc_dev_dependencies_312",
-              "requirement": "astroid==4.0.4 --hash=sha256:52f39653876c7dec3e3afd4c2696920e05c83832b9737afc21928f2d2eb7a753 --hash=sha256:986fed8bcf79fb82c78b18a53352a0b287a73817d6dbcfba3162da36667c49a0"
+              "requirement": "astroid==3.3.11 --hash=sha256:1e5a5011af2920c7c67a53f65d536d65bfa7116feeaf2354d8b94f29573bb0ce --hash=sha256:54c760ae8322ece1abd213057c4b5bba7c49818853fc901ef09719a60dbf9dec"
             }
           },
           "trlc_dev_dependencies_312_babel": {
@@ -3326,6 +4188,15 @@
               "python_interpreter_target": "@@rules_python++python+python_3_12_host//:python",
               "repo": "trlc_dev_dependencies_312",
               "requirement": "babel==2.18.0 --hash=sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d --hash=sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35"
+            }
+          },
+          "trlc_dev_dependencies_312_bigtree": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@trlc_dev_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_12_host//:python",
+              "repo": "trlc_dev_dependencies_312",
+              "requirement": "bigtree==1.5.3 --hash=sha256:47879c5d80f4e0d50f2c8818d3b80fc58af24b5372608223aac25e5580ac0ed8 --hash=sha256:81169329ec92dfab7d8df9d61d85d8dea8b8512fbf073fbc95badc21eadcd14f"
             }
           },
           "trlc_dev_dependencies_312_build": {
@@ -3373,6 +4244,15 @@
               "requirement": "cvc5==1.3.2 --hash=sha256:04174c5cd3c858c972792debc96436632635db2f8c4098806cc7aa51a8de2920 --hash=sha256:13759b6b50d46aa79e3a75e8979b8f36d5eb3fbce9430c5de5ee014ab202344a --hash=sha256:1b1cee4e49db78d8053a509109cede9e768fb3353c3662f72cd28b3a2fb73762 --hash=sha256:1d8bd54142131346a127ec9eebda155c961c05489909d6f16a5c29f1b38d6030 --hash=sha256:2109a1577b9f62f79dd72f8d8eb06db9e51eb2a6b9e84abf79865e1694dd1a59 --hash=sha256:25bcf19294cb166fc4a4f4b5c77379707706f9fc215ecf581328050ada4865fc --hash=sha256:298ac4ab00d54aadde83cfd21fe886177446523bc0d4ace4bb3eb9b300f8611d --hash=sha256:29d4c28e3399244b8df7c9e5154f3f8c47fcf9720dbd2dd38b2c59abc8b40e51 --hash=sha256:2ab5ce33c38229c7c02d7190f9da4d99bf016a5d066be6d5b71d99747c334bd4 --hash=sha256:30565c03228b4eed78d21fbc86130f0b9c7b4454eec4364b0bc62f1a01f2266b --hash=sha256:31782354a51464d98bc8f64fdb2db148365e584954eee2f9e7b3eaedc5722f81 --hash=sha256:31ca0e5ba1592c85459f40e8559bc07dea1fcf7d59074a2abd07e3f2abf0ddf5 --hash=sha256:31d6f9265232fdf4d413d25a446210f14d6d08fc697f4ce5c6f2e878331cceb7 --hash=sha256:3b63586503d90628fda73f6f8f3ddabd73bebb7fb93bc369beecd4c389d999dc --hash=sha256:3baef0cef04cd4c956e91aab2c6937b0930f7c4d98454b11dc8a33f13a25e7b3 --hash=sha256:3e2a1ba179ac76d3ce3b973cf99d4a1368cf5b69ce8952163d668a08e6d76b1c --hash=sha256:40938b5a7551ec0850d3945ed54a3249cb9d00fba7a4eec360e81e2a1f5cc1e5 --hash=sha256:420e3b389d12df6650ff8781d297762edbaad35eb1946e72fdf2b713a0088ad0 --hash=sha256:43301779da3d09d5159f0950cc99e93a814dc366a5b0af913a3d4c1ffb2f54a8 --hash=sha256:4544943cbf58d7130773f2026399c27eb9410d6a739b77ce730339f82c82243e --hash=sha256:49602b38f3c9789d8052c2ff598f43f661efa226fc4487cfdb03cc05f20b95d2 --hash=sha256:4a50718aac4030e3be48744f2419a5609c17553495822c841164fa10811fd426 --hash=sha256:4c16e8238152e34a12c742a6c97909dab551f5ff775d1b6b872f2993d0192760 --hash=sha256:59fdb1c2cc84d2875de228873b38b3a8a6af13ee8e6d87a963045c1f4ca8df00 --hash=sha256:5f22deab1feb6b5c594cdff174781a8ce44a9b9061b386918eb426203cd0133c --hash=sha256:62144306406721ef1b0d1d060ecb1b31624e98d1eeb2ed886b2f1673d04d6fc4 --hash=sha256:64e9160cd89cb415bade28ec35e8521b187f698ca332c4276bf1cfdddfdc6660 --hash=sha256:7390831bd32067c263fd78485cf1413cf5ccd635df3cfc391138368c90b78356 --hash=sha256:794aca0e5b57b0bdf707ca2c6f46072e7d90cf04470685a07eeafd395bd8acb8 --hash=sha256:7af4c8cc835ed32aa6190585b888a7e49a90e491152b3229c2ba3ad1306eb7c7 --hash=sha256:7b0b2eff94641f413bbeb172b54cfd0ac2a26c2c6bb79d41d18df1bc4a8ecb0c --hash=sha256:7bbe7f1a6949aed2eb059794697d9a25afc13efbeb1a729d5c327971a45a05b9 --hash=sha256:7e2a39dc267caacfa0f1fb23844c6cc58ddeeef9b1417d7e5e3ca1f51ac68e5f --hash=sha256:878d73ccd8b7dcd17a5f5e9750bc45f4b7da5ed07dd36a77cb8369d089883540 --hash=sha256:912e4de05eda1fa86f707eda932f1bd9e8d8a6316a28458fd57334d2f8f104f9 --hash=sha256:92dc62facddffd7c08be9048f42cbc0283544918a8db770cadab04041c176b11 --hash=sha256:9534ffd384356db74b83818f41ab9da58f8c7dc7551ae81a11ad624a7f519844 --hash=sha256:9b962b21635f83b46bd9a82d4f33f5e7d960b40b8b2eabad43f82172bcaaa659 --hash=sha256:aa2ea64dd6bee47c3a3a0606de014f7f60acabb0eb5282404aa12e990910b656 --hash=sha256:b1946ebe0f5990431d4d0569839813d0165b5299c95f486e5064b0c4454f4977 --hash=sha256:c77cadfde393d7949bda2a48f3d4c2a6f572cb0bc2147159212c29913c5a8c56 --hash=sha256:c7ac86cc4e68b732a4f9f80cdcacc085c3e11bb2aeef7c3138f2eb1fbef83a09 --hash=sha256:c8d897f85d3b9014df8d5320925b2c3b19bfd11d49667660e385ae673656de8a --hash=sha256:ce5efe02238e63df935a3fc737c4f059797acfd9282b74c37d8fd01473691ebf --hash=sha256:d10a263214327f086bbb3825029135f6224c4b0498997a4817a4f7af29de2a9b --hash=sha256:d208c9eda9f0279cc31e36f5af2b7c057749b267f1766bd4a1f1c4aefe646218 --hash=sha256:d94b9f2a3c51720e60798ca0995debac8aa967d374a29d0a25e346d05429a409 --hash=sha256:d9c3e89bf650ffa2c9ab6bb63a7229d7bce8d7ba880655a73878d8a9fb3716d5 --hash=sha256:dbaa132c67daa6513aa94ab96406db258dcc41bc3fd5ce68019beebdc9fb280b --hash=sha256:f1f0209a641723c33c94c4998cd56fc085a0ae136932680cd8e1995e94430d48 --hash=sha256:f1ffd51587c2de76242e1857bc27dc482da8801391cd968f00d106de60473297 --hash=sha256:f2671232073e45c84c1f0c807b9c398b1e321b695d031a4a61f2c4ae4664c797 --hash=sha256:f37f25713d0dff3653d7e04668d1733d003855a735fc63d3666dcd2fbde0dca5 --hash=sha256:f7f410e513b4ca7c8e36cf8b3293de09841ec32825c4c073c9a802023a528108 --hash=sha256:f850dbcaffab3f3b3265ed17425db5f5dc841f9a8f5c5fa74bff02cebc198ed6 --hash=sha256:fb4146591032ff9e542f126ed51def92bc88aa1315ce400b16c0d56e773d5a7a --hash=sha256:ff41096837dbd0b09e9565bb5bf273a444bb0dff9331a1e90cb6c8876500928e"
             }
           },
+          "trlc_dev_dependencies_312_dill": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@trlc_dev_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_12_host//:python",
+              "repo": "trlc_dev_dependencies_312",
+              "requirement": "dill==0.4.1 --hash=sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d --hash=sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa"
+            }
+          },
           "trlc_dev_dependencies_312_docutils": {
             "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
             "attributes": {
@@ -3406,7 +4286,7 @@
               "dep_template": "@trlc_dev_dependencies//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_12_host//:python",
               "repo": "trlc_dev_dependencies_312",
-              "requirement": "isort==8.0.0 --hash=sha256:184916a933041c7cf718787f7e52064f3c06272aff69a5cb4dc46497bd8911d9 --hash=sha256:fddea59202f231e170e52e71e3510b99c373b6e571b55d9c7b31b679c0fed47c"
+              "requirement": "isort==6.1.0 --hash=sha256:58d8927ecce74e5087aef019f778d4081a3b6c98f15a80ba35782ca8a2097784 --hash=sha256:9b8f96a14cfee0677e78e941ff62f03769a06d412aabb9e2a90487b3b7e8d481"
             }
           },
           "trlc_dev_dependencies_312_jinja2": {
@@ -3445,6 +4325,15 @@
               "requirement": "packaging==26.0 --hash=sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4 --hash=sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529"
             }
           },
+          "trlc_dev_dependencies_312_platformdirs": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@trlc_dev_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_12_host//:python",
+              "repo": "trlc_dev_dependencies_312",
+              "requirement": "platformdirs==4.11.0 --hash=sha256:0555d18370482847566ffabcaa53ad7c6c1c29f195989ae1ed634a05f76ea1e0 --hash=sha256:360ccded2b7fce0af0ff80cc8f5942a1c5d99b0e856033acb030bfc634709e74"
+            }
+          },
           "trlc_dev_dependencies_312_pycodestyle": {
             "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
             "attributes": {
@@ -3469,7 +4358,7 @@
               "dep_template": "@trlc_dev_dependencies//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_12_host//:python",
               "repo": "trlc_dev_dependencies_312",
-              "requirement": "pylint==2.3.0 --hash=sha256:2bf4bd58d6d5d87174fbc9d1d134a9aeee852d4dc29cbd422a7015772770bc63 --hash=sha256:ee80c7af4f127b2a480d83010c9f0e97beb8eaa652b78c2837d3ed30b12e1182"
+              "requirement": "pylint==3.3.9 --hash=sha256:01f9b0462c7730f94786c283f3e52a1fbdf0494bbe0971a78d7277ef46a751e7 --hash=sha256:d312737d7b25ccf6b01cc4ac629b5dcd14a0fcf3ec392735ac70f137a9d5f83a"
             }
           },
           "trlc_dev_dependencies_312_pyproject_hooks": {
@@ -3578,6 +4467,15 @@
               "python_interpreter_target": "@@rules_python++python+python_3_12_host//:python",
               "repo": "trlc_dev_dependencies_312",
               "requirement": "sphinxcontrib-serializinghtml==2.0.0 --hash=sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331 --hash=sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d"
+            }
+          },
+          "trlc_dev_dependencies_312_tomlkit": {
+            "repoRuleId": "@@rules_python+//python/private/pypi:whl_library.bzl%whl_library",
+            "attributes": {
+              "dep_template": "@trlc_dev_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python++python+python_3_12_host//:python",
+              "repo": "trlc_dev_dependencies_312",
+              "requirement": "tomlkit==0.15.1 --hash=sha256:177a05aece5a8ca5266fd3c448abb47b8d352f09d477d3ca8332db4d89b24304 --hash=sha256:e25bbf38843005246210a12982776f27f99cb9be67160e14434d0c0d21ee1e97"
             }
           },
           "trlc_dev_dependencies_312_urllib3": {
@@ -4524,11 +5422,13 @@
                 "alabaster": "{\"trlc_dev_dependencies_312_alabaster\":[{\"version\":\"3.12\"}]}",
                 "astroid": "{\"trlc_dev_dependencies_312_astroid\":[{\"version\":\"3.12\"}]}",
                 "babel": "{\"trlc_dev_dependencies_312_babel\":[{\"version\":\"3.12\"}]}",
+                "bigtree": "{\"trlc_dev_dependencies_312_bigtree\":[{\"version\":\"3.12\"}]}",
                 "build": "{\"trlc_dev_dependencies_312_build\":[{\"version\":\"3.12\"}]}",
                 "certifi": "{\"trlc_dev_dependencies_312_certifi\":[{\"version\":\"3.12\"}]}",
                 "charset_normalizer": "{\"trlc_dev_dependencies_312_charset_normalizer\":[{\"version\":\"3.12\"}]}",
                 "coverage": "{\"trlc_dev_dependencies_312_coverage\":[{\"version\":\"3.12\"}]}",
                 "cvc5": "{\"trlc_dev_dependencies_312_cvc5\":[{\"version\":\"3.12\"}]}",
+                "dill": "{\"trlc_dev_dependencies_312_dill\":[{\"version\":\"3.12\"}]}",
                 "docutils": "{\"trlc_dev_dependencies_312_docutils\":[{\"version\":\"3.12\"}]}",
                 "idna": "{\"trlc_dev_dependencies_312_idna\":[{\"version\":\"3.12\"}]}",
                 "imagesize": "{\"trlc_dev_dependencies_312_imagesize\":[{\"version\":\"3.12\"}]}",
@@ -4537,6 +5437,7 @@
                 "markupsafe": "{\"trlc_dev_dependencies_312_markupsafe\":[{\"version\":\"3.12\"}]}",
                 "mccabe": "{\"trlc_dev_dependencies_312_mccabe\":[{\"version\":\"3.12\"}]}",
                 "packaging": "{\"trlc_dev_dependencies_312_packaging\":[{\"version\":\"3.12\"}]}",
+                "platformdirs": "{\"trlc_dev_dependencies_312_platformdirs\":[{\"version\":\"3.12\"}]}",
                 "pycodestyle": "{\"trlc_dev_dependencies_312_pycodestyle\":[{\"version\":\"3.12\"}]}",
                 "pygments": "{\"trlc_dev_dependencies_312_pygments\":[{\"version\":\"3.12\"}]}",
                 "pylint": "{\"trlc_dev_dependencies_312_pylint\":[{\"version\":\"3.12\"}]}",
@@ -4552,17 +5453,20 @@
                 "sphinxcontrib_jsmath": "{\"trlc_dev_dependencies_312_sphinxcontrib_jsmath\":[{\"version\":\"3.12\"}]}",
                 "sphinxcontrib_qthelp": "{\"trlc_dev_dependencies_312_sphinxcontrib_qthelp\":[{\"version\":\"3.12\"}]}",
                 "sphinxcontrib_serializinghtml": "{\"trlc_dev_dependencies_312_sphinxcontrib_serializinghtml\":[{\"version\":\"3.12\"}]}",
+                "tomlkit": "{\"trlc_dev_dependencies_312_tomlkit\":[{\"version\":\"3.12\"}]}",
                 "urllib3": "{\"trlc_dev_dependencies_312_urllib3\":[{\"version\":\"3.12\"}]}"
               },
               "packages": [
                 "alabaster",
                 "astroid",
                 "babel",
+                "bigtree",
                 "build",
                 "certifi",
                 "charset_normalizer",
                 "coverage",
                 "cvc5",
+                "dill",
                 "docutils",
                 "idna",
                 "imagesize",
@@ -4571,6 +5475,7 @@
                 "markupsafe",
                 "mccabe",
                 "packaging",
+                "platformdirs",
                 "pycodestyle",
                 "pygments",
                 "pylint",
@@ -4586,6 +5491,7 @@
                 "sphinxcontrib_jsmath",
                 "sphinxcontrib_qthelp",
                 "sphinxcontrib_serializinghtml",
+                "tomlkit",
                 "urllib3"
               ],
               "groups": {}
@@ -4784,6 +5690,148 @@
             "rules_python++python+pythons_hub",
             "python_3_9_host",
             "rules_python++python+python_3_9_host"
+          ]
+        ]
+      }
+    },
+    "@@rules_rust+//crate_universe/private:internal_extensions.bzl%cu_nr": {
+      "general": {
+        "bzlTransitiveDigest": "qJWVLTbrGS0P4sRwa+Qan7552cGleRsu0zQ69zc7Flo=",
+        "usagesDigest": "dQ7SQZ7uSSL3vVKSMBKRxKJUm9OVrZZA+S1/QQfT570=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "cargo_bazel_bootstrap": {
+            "repoRuleId": "@@rules_rust+//cargo/private:cargo_bootstrap.bzl%cargo_bootstrap_repository",
+            "attributes": {
+              "srcs": [
+                "@@rules_rust+//crate_universe:src/api.rs",
+                "@@rules_rust+//crate_universe:src/api/lockfile.rs",
+                "@@rules_rust+//crate_universe:src/cli.rs",
+                "@@rules_rust+//crate_universe:src/cli/generate.rs",
+                "@@rules_rust+//crate_universe:src/cli/query.rs",
+                "@@rules_rust+//crate_universe:src/cli/render.rs",
+                "@@rules_rust+//crate_universe:src/cli/splice.rs",
+                "@@rules_rust+//crate_universe:src/cli/vendor.rs",
+                "@@rules_rust+//crate_universe:src/config.rs",
+                "@@rules_rust+//crate_universe:src/context.rs",
+                "@@rules_rust+//crate_universe:src/context/crate_context.rs",
+                "@@rules_rust+//crate_universe:src/context/platforms.rs",
+                "@@rules_rust+//crate_universe:src/lib.rs",
+                "@@rules_rust+//crate_universe:src/lockfile.rs",
+                "@@rules_rust+//crate_universe:src/main.rs",
+                "@@rules_rust+//crate_universe:src/metadata.rs",
+                "@@rules_rust+//crate_universe:src/metadata/cargo_bin.rs",
+                "@@rules_rust+//crate_universe:src/metadata/cargo_tree_resolver.rs",
+                "@@rules_rust+//crate_universe:src/metadata/cargo_tree_rustc_wrapper.bat",
+                "@@rules_rust+//crate_universe:src/metadata/cargo_tree_rustc_wrapper.sh",
+                "@@rules_rust+//crate_universe:src/metadata/dependency.rs",
+                "@@rules_rust+//crate_universe:src/metadata/metadata_annotation.rs",
+                "@@rules_rust+//crate_universe:src/rendering.rs",
+                "@@rules_rust+//crate_universe:src/rendering/template_engine.rs",
+                "@@rules_rust+//crate_universe:src/rendering/templates/module_bzl.j2",
+                "@@rules_rust+//crate_universe:src/rendering/templates/partials/header.j2",
+                "@@rules_rust+//crate_universe:src/rendering/templates/partials/module/aliases_map.j2",
+                "@@rules_rust+//crate_universe:src/rendering/templates/partials/module/deps_map.j2",
+                "@@rules_rust+//crate_universe:src/rendering/templates/partials/module/repo_git.j2",
+                "@@rules_rust+//crate_universe:src/rendering/templates/partials/module/repo_http.j2",
+                "@@rules_rust+//crate_universe:src/rendering/templates/vendor_module.j2",
+                "@@rules_rust+//crate_universe:src/rendering/verbatim/alias_rules.bzl",
+                "@@rules_rust+//crate_universe:src/select.rs",
+                "@@rules_rust+//crate_universe:src/splicing.rs",
+                "@@rules_rust+//crate_universe:src/splicing/cargo_config.rs",
+                "@@rules_rust+//crate_universe:src/splicing/crate_index_lookup.rs",
+                "@@rules_rust+//crate_universe:src/splicing/splicer.rs",
+                "@@rules_rust+//crate_universe:src/test.rs",
+                "@@rules_rust+//crate_universe:src/utils.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark/glob.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark/label.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark/select.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark/select_dict.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark/select_list.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark/select_scalar.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark/select_set.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark/serialize.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark/target_compatible_with.rs",
+                "@@rules_rust+//crate_universe:src/utils/symlink.rs",
+                "@@rules_rust+//crate_universe:src/utils/target_triple.rs"
+              ],
+              "binary": "cargo-bazel",
+              "cargo_lockfile": "@@rules_rust+//crate_universe:Cargo.lock",
+              "cargo_toml": "@@rules_rust+//crate_universe:Cargo.toml",
+              "version": "1.86.0",
+              "timeout": 900,
+              "rust_toolchain_cargo_template": "@rust_host_tools//:bin/{tool}",
+              "rust_toolchain_rustc_template": "@rust_host_tools//:bin/{tool}",
+              "compressed_windows_toolchain_names": false
+            }
+          }
+        },
+        "moduleExtensionMetadata": {
+          "explicitRootModuleDirectDeps": [
+            "cargo_bazel_bootstrap"
+          ],
+          "explicitRootModuleDirectDevDeps": [],
+          "useAllRepos": "NO",
+          "reproducible": false
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "bazel_features+",
+            "bazel_features_globals",
+            "bazel_features++version_extension+bazel_features_globals"
+          ],
+          [
+            "bazel_features+",
+            "bazel_features_version",
+            "bazel_features++version_extension+bazel_features_version"
+          ],
+          [
+            "rules_cc+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_cc+",
+            "rules_cc",
+            "rules_cc+"
+          ],
+          [
+            "rules_rust+",
+            "bazel_features",
+            "bazel_features+"
+          ],
+          [
+            "rules_rust+",
+            "bazel_skylib",
+            "bazel_skylib+"
+          ],
+          [
+            "rules_rust+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_rust+",
+            "cui",
+            "rules_rust++cu+cui"
+          ],
+          [
+            "rules_rust+",
+            "rrc",
+            "rules_rust++i2+rrc"
+          ],
+          [
+            "rules_rust+",
+            "rules_cc",
+            "rules_cc+"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust",
+            "rules_rust+"
           ]
         ]
       }

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
 .PHONY: docs test style lint package
 
+# bazel equivalent: bazel test //:lint
 lint: style
 	@python3 -m pylint --rcfile=pylint3.cfg \
 		--reports=no \
 		trlc trlc*.py lobster-*.py
 
+# bazel equivalent: bazel test //:style
 style:
 	@python3 -m pycodestyle trlc trlc*.py lobster-*.py
 

--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,7 @@ tracing: report.lobster
 	lobster-html-report report.lobster --out=docs/tracing.html
 	lobster-ci-report report.lobster
 
+# bazel equivalent: bazel run //:clean-coverage
 clean-coverage:
 	@rm -rf htmlcov
 	@find . -name '.coverage*' -type f -delete

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
 .PHONY: docs test style lint package
 
+# bazel equivalent: bazel build --config=lint //trlc //:trlc_binary //:root_scripts_lib
 lint: style
 	@python3 -m pylint --rcfile=pylint3.cfg \
 		--reports=no \
 		trlc trlc*.py lobster-*.py
 
+# bazel equivalent: bazel run //:format.check
 style:
 	@python3 -m pycodestyle trlc trlc*.py lobster-*.py
 
@@ -118,6 +120,7 @@ tracing: report.lobster
 	lobster-html-report report.lobster --out=docs/tracing.html
 	lobster-ci-report report.lobster
 
+# bazel equivalent: bazel run //:clean-coverage
 clean-coverage:
 	@rm -rf htmlcov
 	@find . -name '.coverage*' -type f -delete

--- a/api-examples/filename-check/BUILD
+++ b/api-examples/filename-check/BUILD
@@ -9,7 +9,6 @@ test_suite(
     ],
 )
 
-
 # 1. Gather the RSL schema
 trlc_specification(
     name = "spec",

--- a/api-examples/filename-check/filename-2.py
+++ b/api-examples/filename-check/filename-2.py
@@ -21,8 +21,10 @@ if symbols is None:
 # Do something if there are no errors
 for obj in symbols.iter_record_objects():
     values = obj.to_python_dict()
-    if values["illustration"] is not None and \
-       not os.path.isfile(values["illustration"]):
-        print("error: %s for requirement %s is not a file" %
-              (values["illustration"],
-               obj.name))
+    if values["illustration"] is not None and not os.path.isfile(
+        values["illustration"]
+    ):
+        print(
+            "error: %s for requirement %s is not a file"
+            % (values["illustration"], obj.name)
+        )

--- a/api-examples/filename-check/filename-3.py
+++ b/api-examples/filename-check/filename-3.py
@@ -24,13 +24,15 @@ failed = False
 for obj in symbols.iter_record_objects():
     values = obj.to_python_dict()
 
-    if values["illustration"] is not None and \
-       not os.path.isfile(values["illustration"]):
-
-        mh.error(location = obj.field["illustration"].location,
-                 message  = "is not a file",
-                 fatal    = False,
-                 user     = True)
+    if values["illustration"] is not None and not os.path.isfile(
+        values["illustration"]
+    ):
+        mh.error(
+            location=obj.field["illustration"].location,
+            message="is not a file",
+            fatal=False,
+            user=True,
+        )
 
         failed = True
 

--- a/api-examples/filename-check/filename-4.py
+++ b/api-examples/filename-check/filename-4.py
@@ -20,14 +20,12 @@ if symbols is None:
     sys.exit(1)
 
 # Do something if there are no errors
-pkg_example   = symbols.lookup_assuming(
-    mh                = mh,
-    name              = "Example",
-    required_subclass = ast.Package)
+pkg_example = symbols.lookup_assuming(
+    mh=mh, name="Example", required_subclass=ast.Package
+)
 req_base_type = pkg_example.symbols.lookup_assuming(
-    mh                = mh,
-    name              = "Requirement",
-    required_subclass = ast.Record_Type)
+    mh=mh, name="Requirement", required_subclass=ast.Record_Type
+)
 
 for obj in symbols.iter_record_objects():
     values = obj.to_python_dict()
@@ -35,10 +33,12 @@ for obj in symbols.iter_record_objects():
     if not obj.n_typ.is_subclass_of(req_base_type):
         continue
 
-    if values["illustration"] is not None and \
-       not os.path.isfile(values["illustration"]):
-
-        mh.error(location = obj.field["illustration"].location,
-                 message  = "is not a file",
-                 fatal    = False,
-                 user     = True)
+    if values["illustration"] is not None and not os.path.isfile(
+        values["illustration"]
+    ):
+        mh.error(
+            location=obj.field["illustration"].location,
+            message="is not a file",
+            fatal=False,
+            user=True,
+        )

--- a/documentation/dev_setup.md
+++ b/documentation/dev_setup.md
@@ -71,8 +71,6 @@ the latest GNU make version.
 
 ## Important make targets
 
-* `make lint` to run pycodestyle and pylint.
-
 * `make test` to run most tests and show coverage analysis.
 
 * `make test-all` to run all tests. This is the same as above, except
@@ -98,7 +96,10 @@ bazel run //:format.fix
 ## Code Linting
 
 ```bash
-# Run all linters (pylint + ty) over every Python target
+# Run all linters (pylint + ty) over the trlc library, main binary, and root scripts
+bazel build --config=lint //trlc //:trlc_binary //:root_scripts_lib
+
+# Or lint everything (broader, matches all targets with lint aspects)
 bazel build --config=lint //...
 ```
 
@@ -159,6 +160,9 @@ bazel coverage //tests-system/...
 
 # Render as HTML (requires lcov / genhtml)
 genhtml "$(bazel info output_path)/_coverage/_coverage_report.dat" -o htmlcov
+
+# Remove local coverage artifacts
+bazel run //:clean-coverage
 ```
 
 The `coverage` namespace in `.bazelrc` sets `--combined_report=lcov` and

--- a/lobster-trlc-system-test.py
+++ b/lobster-trlc-system-test.py
@@ -31,7 +31,7 @@ from trlc.trlc import Source_Manager
 from trlc.errors import Message_Handler
 
 TEST_DIR = "tests-system"
-TARGET   = "system-tests.lobster"
+TARGET = "system-tests.lobster"
 
 
 def process(testname, mapping):
@@ -42,20 +42,21 @@ def process(testname, mapping):
     tag_file = os.path.join(test_dir, "tracing")
 
     item = Activity(
-        tag       = Tracing_Tag(namespace = "trlc-st",
-                                tag       = testname),
-        location  = File_Reference(filename = test_dir),
-        framework = "TRLCST",
-        kind      = "Test Directory")
+        tag=Tracing_Tag(namespace="trlc-st", tag=testname),
+        location=File_Reference(filename=test_dir),
+        framework="TRLCST",
+        kind="Test Directory",
+    )
     include_test = False
 
     if os.path.isfile(tag_file):
         include_test = True
         with open(tag_file, "r", encoding="UTF-8") as fd:
-            tags = [Tracing_Tag(namespace = "req",
-                                tag       = line.strip())
-                    for line in fd.read().splitlines()
-                    if line.strip()]
+            tags = [
+                Tracing_Tag(namespace="req", tag=line.strip())
+                for line in fd.read().splitlines()
+                if line.strip()
+            ]
         for tag in tags:
             item.add_tracing_target(tag)
 
@@ -68,12 +69,12 @@ def process(testname, mapping):
                 components.pop()
             except ValueError:
                 pass
-        requirement = mapping.get("-".join(components),
-                                  "_".join(item.capitalize()
-                                           for item in components))
+        requirement = mapping.get(
+            "-".join(components), "_".join(item.capitalize() for item in components)
+        )
         item.add_tracing_target(
-            Tracing_Tag(namespace = "req",
-                        tag       = "LRM.%s" % requirement))
+            Tracing_Tag(namespace="req", tag="LRM.%s" % requirement)
+        )
 
     if include_test:
         return [item]
@@ -83,10 +84,9 @@ def process(testname, mapping):
 
 
 def main():
-    sm = Source_Manager(mh = Message_Handler(),
-                        lint_mode   = False,
-                        parse_trlc  = True,
-                        verify_mode = False)
+    sm = Source_Manager(
+        mh=Message_Handler(), lint_mode=False, parse_trlc=True, verify_mode=False
+    )
     sm.register_directory("language-reference-manual")
     stab = sm.process()
     pkg_lrm = stab.lookup_assuming(sm.mh, "LRM")
@@ -95,8 +95,7 @@ def main():
         mapping[item.name.lower().replace("_", "-")] = item.name
 
     items = []
-    for dirent in sorted(os.scandir(TEST_DIR),
-                         key=lambda de: de.name):
+    for dirent in sorted(os.scandir(TEST_DIR), key=lambda de: de.name):
         if dirent.is_dir():
             if dirent.name == "htmlcov":
                 continue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,19 @@
 [tool.ty.rules]
 # ty is Astral's Python type checker (fast, Rust-based)
-# Add per-rule overrides here as needed, e.g.:
-#   invalid-return-type = "warn"
+# The trlc codebase uses dynamic patterns without full type annotations;
+# unresolved-attribute and invalid-assignment produce many false positives
+# on Optional/Unknown returns from unannotated AST types.
+# Suppress these checks to reduce noise in current dynamic/unannotated paths.
+unresolved-attribute = "ignore"
+invalid-assignment = "ignore"
+
+# lobster-trlc-system-test.py imports lobster which is not a Bazel dep;
+# suppress unresolved-import for that file only (same intent as the
+# existing # pylint: disable=import-error comments in the source).
+[[tool.ty.overrides]]
+include = ["lobster-trlc-system-test.py"]
+[tool.ty.overrides.rules]
+unresolved-import = "ignore"
 
 # ---------------------------------------------------------------------------
 # Pylint — migrated from pylint3.cfg

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,4 +7,4 @@ pycodestyle>=2.12
 coverage>=7.2
 sphinx>=7.0
 build>=1.2.0
-pylint<4.0
+pylint>=3,<4.0

--- a/requirements_dev_lock.txt
+++ b/requirements_dev_lock.txt
@@ -8,14 +8,18 @@ alabaster==1.0.0 \
     --hash=sha256:c00dca57bca26fa62a6d7d0a9fcce65f3e026e9bfe33e9c538fd3fbb2144fd9e \
     --hash=sha256:fc6786402dc3fcb2de3cabd5fe455a2db534b371124f1f21de8731783dec828b
     # via sphinx
-astroid==4.0.4 \
-    --hash=sha256:52f39653876c7dec3e3afd4c2696920e05c83832b9737afc21928f2d2eb7a753 \
-    --hash=sha256:986fed8bcf79fb82c78b18a53352a0b287a73817d6dbcfba3162da36667c49a0
+astroid==3.3.11 \
+    --hash=sha256:1e5a5011af2920c7c67a53f65d536d65bfa7116feeaf2354d8b94f29573bb0ce \
+    --hash=sha256:54c760ae8322ece1abd213057c4b5bba7c49818853fc901ef09719a60dbf9dec
     # via pylint
 babel==2.18.0 \
     --hash=sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d \
     --hash=sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35
     # via sphinx
+bigtree==1.5.3 \
+    --hash=sha256:47879c5d80f4e0d50f2c8818d3b80fc58af24b5372608223aac25e5580ac0ed8 \
+    --hash=sha256:81169329ec92dfab7d8df9d61d85d8dea8b8512fbf073fbc95badc21eadcd14f
+    # via -r requirements_dev.txt
 build==1.4.0 \
     --hash=sha256:6a07c1b8eb6f2b311b96fcbdbce5dab5fe637ffda0fd83c9cac622e927501596 \
     --hash=sha256:f1b91b925aa322be454f8330c6fb48b465da993d1e7e7e6fa35027ec49f3c936
@@ -306,6 +310,10 @@ cvc5==1.3.2 \
     --hash=sha256:fb4146591032ff9e542f126ed51def92bc88aa1315ce400b16c0d56e773d5a7a \
     --hash=sha256:ff41096837dbd0b09e9565bb5bf273a444bb0dff9331a1e90cb6c8876500928e
     # via -r requirements_dev.txt
+dill==0.4.1 \
+    --hash=sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d \
+    --hash=sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa
+    # via pylint
 docutils==0.22.4 \
     --hash=sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968 \
     --hash=sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de
@@ -318,9 +326,9 @@ imagesize==1.4.1 \
     --hash=sha256:0d8d18d08f840c19d0ee7ca1fd82490fdc3729b7ac93f49870406ddde8ef8d8b \
     --hash=sha256:69150444affb9cb0d5cc5a92b3676f0b2fb7cd9ae39e947a5e11a36b4497cd4a
     # via sphinx
-isort==8.0.0 \
-    --hash=sha256:184916a933041c7cf718787f7e52064f3c06272aff69a5cb4dc46497bd8911d9 \
-    --hash=sha256:fddea59202f231e170e52e71e3510b99c373b6e571b55d9c7b31b679c0fed47c
+isort==6.1.0 \
+    --hash=sha256:58d8927ecce74e5087aef019f778d4081a3b6c98f15a80ba35782ca8a2097784 \
+    --hash=sha256:9b8f96a14cfee0677e78e941ff62f03769a06d412aabb9e2a90487b3b7e8d481
     # via pylint
 jinja2==3.1.6 \
     --hash=sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d \
@@ -427,6 +435,10 @@ packaging==26.0 \
     # via
     #   build
     #   sphinx
+platformdirs==4.11.0 \
+    --hash=sha256:0555d18370482847566ffabcaa53ad7c6c1c29f195989ae1ed634a05f76ea1e0 \
+    --hash=sha256:360ccded2b7fce0af0ff80cc8f5942a1c5d99b0e856033acb030bfc634709e74
+    # via pylint
 pycodestyle==2.14.0 \
     --hash=sha256:c4b5b517d278089ff9d0abdec919cd97262a3367449ea1c8b49b91529167b783 \
     --hash=sha256:dd6bf7cb4ee77f8e016f9c8e74a35ddd9f67e1d5fd4184d86c3b98e07099f42d
@@ -435,9 +447,9 @@ pygments==2.20.0 \
     --hash=sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f \
     --hash=sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176
     # via sphinx
-pylint==2.3.0 \
-    --hash=sha256:2bf4bd58d6d5d87174fbc9d1d134a9aeee852d4dc29cbd422a7015772770bc63 \
-    --hash=sha256:ee80c7af4f127b2a480d83010c9f0e97beb8eaa652b78c2837d3ed30b12e1182
+pylint==3.3.9 \
+    --hash=sha256:01f9b0462c7730f94786c283f3e52a1fbdf0494bbe0971a78d7277ef46a751e7 \
+    --hash=sha256:d312737d7b25ccf6b01cc4ac629b5dcd14a0fcf3ec392735ac70f137a9d5f83a
     # via -r requirements_dev.txt
 pyproject-hooks==1.2.0 \
     --hash=sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8 \
@@ -487,6 +499,10 @@ sphinxcontrib-serializinghtml==2.0.0 \
     --hash=sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331 \
     --hash=sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d
     # via sphinx
+tomlkit==0.15.1 \
+    --hash=sha256:177a05aece5a8ca5266fd3c448abb47b8d352f09d477d3ca8332db4d89b24304 \
+    --hash=sha256:e25bbf38843005246210a12982776f27f99cb9be67160e14434d0c0d21ee1e97
+    # via pylint
 urllib3==2.7.0 \
     --hash=sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c \
     --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897

--- a/setup.py
+++ b/setup.py
@@ -14,20 +14,22 @@ with open("README.md", "r") as fd:
 fixes = []
 for match in re.finditer(r"\[(.*)\]\((.*)\)", long_description):
     if not match.group(2).startswith("http"):
-        fixes.append((match.span(0)[0], match.span(0)[1],
-                      "[%s](%s/blob/main/%s)" % (match.group(1),
-                                                 version.GITHUB_PROJECT,
-                                                 match.group(2))))
+        fixes.append(
+            (
+                match.span(0)[0],
+                match.span(0)[1],
+                "[%s](%s/blob/main/%s)"
+                % (match.group(1), version.GITHUB_PROJECT, match.group(2)),
+            )
+        )
 
 for begin, end, text in reversed(fixes):
-    long_description = (long_description[:begin] +
-                        text +
-                        long_description[end:])
+    long_description = long_description[:begin] + text + long_description[end:]
 
 project_urls = {
-    "Bug Tracker"   : version.BUGS_URL,
-    "Documentation" : version.DOCS_URL,
-    "Source Code"   : version.CODE_URL,
+    "Bug Tracker": version.BUGS_URL,
+    "Documentation": version.DOCS_URL,
+    "Source Code": version.CODE_URL,
 }
 
 setuptools.setup(

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -5,36 +5,37 @@
 
 import os
 import sys
-sys.path.insert(1, os.path.abspath('..'))
+
+sys.path.insert(1, os.path.abspath(".."))
 
 import trlc.version
 
 # -- General configuration ------------------------------------------------
 
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.autosummary',
-    'sphinx.ext.doctest',
-    'sphinx.ext.todo',
-    'sphinx.ext.coverage',
-    'sphinx.ext.mathjax',
-    'sphinx.ext.githubpages',
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.doctest",
+    "sphinx.ext.todo",
+    "sphinx.ext.coverage",
+    "sphinx.ext.mathjax",
+    "sphinx.ext.githubpages",
 ]
 
-templates_path = ['_templates']
-source_suffix = '.rst'
-master_doc = 'index'
+templates_path = ["_templates"]
+source_suffix = ".rst"
+master_doc = "index"
 
-project = 'TRLC'
-copyright = '2022, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)'
-author = 'Bayerische Motoren Werke Aktiengesellschaft (BMW AG)'
+project = "TRLC"
+copyright = "2022, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)"
+author = "Bayerische Motoren Werke Aktiengesellschaft (BMW AG)"
 
 version = trlc.version.TRLC_VERSION
 release = trlc.version.TRLC_VERSION
 
 language = "en"
 
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 # If true, the current module name will be prepended to all description
 # unit titles (such as .. function::).
@@ -42,7 +43,7 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # add_module_names = True
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = "sphinx"
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
@@ -50,19 +51,15 @@ todo_include_todos = True
 
 # -- Options for HTML output ----------------------------------------------
 
-html_theme = 'classic'
+html_theme = "classic"
 # html_theme_path = ['../sphinx']
-html_theme_options = {
-    "stickysidebar": True
-}
-html_sidebars = {
-    "**": ["globaltoc.html", "localtoc.html", "searchbox.html"]
-}
+html_theme_options = {"stickysidebar": True}
+html_sidebars = {"**": ["globaltoc.html", "localtoc.html", "searchbox.html"]}
 
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
 autodoc_default_options = {
-    "show-inheritance" : True,
-    "members" : True,
+    "show-inheritance": True,
+    "members": True,
     "exclude-members": "dump, evaluate",
 }

--- a/tests-system/BUILD
+++ b/tests-system/BUILD
@@ -42,8 +42,8 @@ test_suite(
 test_suite(
     name = "bzl_api",
     tests = [
-        "//tests-system/bzl-api-simple:bzl-api-simple-test",
         "//tests-system/bzl-api-deps:bzl-api-deps-test",
+        "//tests-system/bzl-api-simple:bzl-api-simple-test",
         "//tests-system/bzl-api-spec-check:bzl-api-spec-check-test",
     ],
 )

--- a/tests-system/whitespace/foo.py
+++ b/tests-system/whitespace/foo.py
@@ -3,7 +3,7 @@ with open("test.trlc", "r") as fd:
 
 txt += "\n\npackage"
 
-txt += b' \t\n\r\x0b\f'.decode("UTF-8")
+txt += b" \t\n\r\x0b\f".decode("UTF-8")
 
 txt += "Potato"
 

--- a/tests-unit/BUILD.bazel
+++ b/tests-unit/BUILD.bazel
@@ -3,19 +3,19 @@ load("@rules_python//python:defs.bzl", "py_test")
 py_test(
     name = "test_ast_bysection",
     srcs = ["test_ast_bysection.py"],
-    deps = ["//trlc:trlc"],
+    deps = ["//trlc"],
 )
 
 py_test(
     name = "test_lexer",
     srcs = ["test_lexer.py"],
-    deps = ["//trlc:trlc"],
+    deps = ["//trlc"],
 )
 
 py_test(
     name = "test_lexer_base",
     srcs = ["test_lexer_base.py"],
-    deps = ["//trlc:trlc"],
+    deps = ["//trlc"],
 )
 
 test_suite(

--- a/tests-unit/test_ast_bysection.py
+++ b/tests-unit/test_ast_bysection.py
@@ -2,39 +2,42 @@ import unittest
 from unittest.mock import patch, MagicMock
 from trlc.ast import Symbol_Table
 
+
 class TestRecordObject:
     def __init__(self, location, section):
         self.location = location
         self.section = section
 
+
 class TestSection:
     def __init__(self, name):
         self.name = name
 
-class TestIterRecordObjectsBySection(unittest.TestCase):
 
+class TestIterRecordObjectsBySection(unittest.TestCase):
     @patch("trlc.ast.Symbol_Table.iter_record_objects")
     def test_iter_record_objects_by_section(self, mock_iter_record_objects):
-        mock_location1 = MagicMock(file_name = 'file1')
-        mock_section1 = TestSection('section1')
-        mock_section2 = TestSection('section2')
-        mock_location2 = MagicMock(file_name = 'file2')
+        mock_location1 = MagicMock(file_name="file1")
+        mock_section1 = TestSection("section1")
+        mock_section2 = TestSection("section2")
+        mock_location2 = MagicMock(file_name="file2")
         record1 = TestRecordObject(mock_location1, [mock_section1, mock_section2])
         record2 = TestRecordObject(mock_location2, [])
         mock_iter_record_objects.return_value = [record1, record2]
-        
+
         results = list(Symbol_Table().iter_record_objects_by_section())
-        
+
         expected_results = [
-            'file1',
-            ('section1', 0),
-            ('section2', 1),
+            "file1",
+            ("section1", 0),
+            ("section2", 1),
             (record1, 1),
-            'file2',
-            (record2, 0)
+            "file2",
+            (record2, 0),
         ]
-        
+
         self.assertEqual(results, expected_results)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests-unit/test_lexer.py
+++ b/tests-unit/test_lexer.py
@@ -31,19 +31,20 @@ class List_Handler(Message_Handler):
 
 class Test_Lexer(unittest.TestCase):
     def setUp(self):
-        self.mh    = List_Handler()
+        self.mh = List_Handler()
         self.lexer = None
 
     def tearDown(self):
-        self.assertEqual(len(self.mh.messages),
-                         0,
-                         "unexpected messages: %s" %
-                         (", ".join(msg[2]
-                                    for msg in self.mh.messages)))
-        self.assertEqual(len(self.tokens),
-                         0,
-                         "unexpected tokens: %s" %
-                         (", ".join(map(str, self.tokens))))
+        self.assertEqual(
+            len(self.mh.messages),
+            0,
+            "unexpected messages: %s" % (", ".join(msg[2] for msg in self.mh.messages)),
+        )
+        self.assertEqual(
+            len(self.tokens),
+            0,
+            "unexpected tokens: %s" % (", ".join(map(str, self.tokens))),
+        )
 
     def input(self, content):
         assert isinstance(content, str)
@@ -64,8 +65,9 @@ class Test_Lexer(unittest.TestCase):
     def match(self, kind, value=None):
         self.assertGreater(len(self.tokens), 0)
         token, self.tokens = self.tokens[0], self.tokens[1:]
-        self.assertEqual(token.kind, kind,
-                         "%s does not have the right kind" % str(token))
+        self.assertEqual(
+            token.kind, kind, "%s does not have the right kind" % str(token)
+        )
         if value is not None:
             self.assertEqual(token.value, value)
         return token
@@ -123,7 +125,7 @@ class Test_Lexer(unittest.TestCase):
             "tuple",
             "type",
             "warning",
-            "xor"
+            "xor",
         ]
         self.input(" ".join(bullets))
         for kw in bullets:
@@ -138,8 +140,7 @@ class Test_Lexer(unittest.TestCase):
             "Boolean operators: `<` `>`",
             "Symbols: `@` `:` `;`",
         ]
-        self.input(" ".join(" ".join(re.findall(r"`(.*?)`", item))
-                            for item in bullets))
+        self.input(" ".join(" ".join(re.findall(r"`(.*?)`", item)) for item in bullets))
         self.match("BRA")
         self.match("KET")
         self.match("S_BRA")
@@ -166,10 +167,9 @@ class Test_Lexer(unittest.TestCase):
         bullets = [
             "Operators: `**`",
             "Boolean operators: `==` `<=` `>=` `!=`",
-            "Punctuation: `=>` `..`"
+            "Punctuation: `=>` `..`",
         ]
-        self.input(" ".join(" ".join(re.findall(r"`(.*?)`", item))
-                            for item in bullets))
+        self.input(" ".join(" ".join(re.findall(r"`(.*?)`", item)) for item in bullets))
         self.match("OPERATOR")
         self.match("OPERATOR")
         self.match("OPERATOR")
@@ -191,7 +191,7 @@ class Test_Lexer(unittest.TestCase):
         self.match("INTEGER", 0)
         self.match("INTEGER", 4)
         self.match("INTEGER", 10000)
-        self.match("INTEGER", 0xdeadbeef)
+        self.match("INTEGER", 0xDEADBEEF)
 
     def testIntegers2(self):
         # lobster-trace: LRM.Integers
@@ -235,14 +235,14 @@ class Test_Lexer(unittest.TestCase):
         # lobster-trace: LRM.Strings
         # lobster-trace: LRM.Simple_String_Value
         with self.assertRaises(TRLC_Error):
-            self.input('''
+            self.input("""
                "potato" "pot\\"ato" "no\\nescape"
                "foo\nbar"
-            ''')
+            """)
         self.matchError("double quoted strings cannot include newlines")
-        self.match("STRING", r'potato')
+        self.match("STRING", r"potato")
         self.match("STRING", r'pot"ato')
-        self.match("STRING", r'no\nescape')
+        self.match("STRING", r"no\nescape")
 
     def testStrings2(self):
         # lobster-trace: LRM.Strings
@@ -254,8 +254,7 @@ class Test_Lexer(unittest.TestCase):
              Potato.
           '''
         """)
-        self.match("STRING",
-                   "This is a\n  * complex\n  * string\nPotato.")
+        self.match("STRING", "This is a\n  * complex\n  * string\nPotato.")
 
     def testStrings3(self):
         # lobster-trace: LRM.Strings

--- a/tests-unit/test_lexer_base.py
+++ b/tests-unit/test_lexer_base.py
@@ -15,9 +15,8 @@ class Potato(Lexer_Base):
 
 class Test_Lexer_Base(unittest.TestCase):
     def setUp(self):
-        self.lexer = Potato(mh      = Message_Handler(),
-                            content = "")
-        self.test_range = 0xffff
+        self.lexer = Potato(mh=Message_Handler(), content="")
+        self.test_range = 0xFFFF
 
     def tearDown(self):
         pass
@@ -25,38 +24,45 @@ class Test_Lexer_Base(unittest.TestCase):
     @staticmethod
     def reference_is_alpha(char):
         assert isinstance(char, str) and len(char) == 1
-        return ord('a') <= ord(char) <= ord('z') or \
-            ord('A') <= ord(char) <= ord('Z')
+        return ord("a") <= ord(char) <= ord("z") or ord("A") <= ord(char) <= ord("Z")
 
     @staticmethod
     def reference_is_numeric(char):
         assert isinstance(char, str) and len(char) == 1
-        return ord('0') <= ord(char) <= ord('9')
+        return ord("0") <= ord(char) <= ord("9")
 
     @staticmethod
     def reference_is_alnum(char):
         assert isinstance(char, str) and len(char) == 1
-        return ord('a') <= ord(char) <= ord('z') or \
-            ord('A') <= ord(char) <= ord('Z') or \
-            ord('0') <= ord(char) <= ord('9')
+        return (
+            ord("a") <= ord(char) <= ord("z")
+            or ord("A") <= ord(char) <= ord("Z")
+            or ord("0") <= ord(char) <= ord("9")
+        )
 
     def testIsAlpha(self):
         for i in range(self.test_range):
             c = chr(i)
-            self.assertEqual(self.reference_is_alpha(c),
-                             self.lexer.is_alpha(c),
-                             "mismatch for codepoint %u (%s)" % (i, repr(c)))
+            self.assertEqual(
+                self.reference_is_alpha(c),
+                self.lexer.is_alpha(c),
+                "mismatch for codepoint %u (%s)" % (i, repr(c)),
+            )
 
     def testIsDigit(self):
         for i in range(self.test_range):
             c = chr(i)
-            self.assertEqual(self.reference_is_numeric(c),
-                             self.lexer.is_numeric(c),
-                             "mismatch for codepoint %u (%s)" % (i, repr(c)))
+            self.assertEqual(
+                self.reference_is_numeric(c),
+                self.lexer.is_numeric(c),
+                "mismatch for codepoint %u (%s)" % (i, repr(c)),
+            )
 
     def testIsAlnum(self):
         for i in range(self.test_range):
             c = chr(i)
-            self.assertEqual(self.reference_is_alnum(c),
-                             self.lexer.is_alnum(c),
-                             "mismatch for codepoint %u (%s)" % (i, repr(c)))
+            self.assertEqual(
+                self.reference_is_alnum(c),
+                self.lexer.is_alnum(c),
+                "mismatch for codepoint %u (%s)" % (i, repr(c)),
+            )

--- a/tests-unit/test_lexer_md.py
+++ b/tests-unit/test_lexer_md.py
@@ -21,7 +21,9 @@ class ListHandler(Message_Handler):
         if not isinstance(fatal, bool):
             raise TypeError(f"expected bool fatal, got {type(fatal).__name__}")
         if extrainfo is not None and not isinstance(extrainfo, str):
-            raise TypeError(f"expected str or None extrainfo, got {type(extrainfo).__name__}")
+            raise TypeError(
+                f"expected str or None extrainfo, got {type(extrainfo).__name__}"
+            )
 
         self.messages.append((location, kind, message))
 
@@ -89,7 +91,9 @@ def make_record_type(record_name="ReqType"):
         False,
     )
 
-    package.symbols.table[trlc_ast.Symbol_Table.simplified_name(record_name)] = record_type
+    package.symbols.table[trlc_ast.Symbol_Table.simplified_name(record_name)] = (
+        record_type
+    )
 
     stab = trlc_ast.Symbol_Table()
     stab.table[trlc_ast.Symbol_Table.simplified_name(package.name)] = package
@@ -118,7 +122,9 @@ class TestLexerMd(unittest.TestCase):
         self.assertTrue(MD_Lexer._is_hr("<BR/> <HR>"))
         self.assertFalse(MD_Lexer._is_hr("<hrx>"))
 
-        self.assertEqual(MD_Lexer._heading_to_identifier("  Hello, world!  "), "Hello_world")
+        self.assertEqual(
+            MD_Lexer._heading_to_identifier("  Hello, world!  "), "Hello_world"
+        )
         self.assertEqual(MD_Lexer._heading_to_identifier("A---B__C"), "A_B_C")
 
     def test_table_helpers(self):
@@ -127,7 +133,9 @@ class TestLexerMd(unittest.TestCase):
         self.assertFalse(MD_Lexer._is_separator_row("| value |"))
 
         self.assertEqual(MD_Lexer._parse_table_row("| key | value |"), ("key", "value"))
-        self.assertEqual(MD_Lexer._parse_table_row("| key | value | extra |"), ("key", "value"))
+        self.assertEqual(
+            MD_Lexer._parse_table_row("| key | value | extra |"), ("key", "value")
+        )
         self.assertIsNone(MD_Lexer._parse_table_row("not a row"))
 
     def test_scalar_value_inference(self):
@@ -174,7 +182,9 @@ class TestLexerMd(unittest.TestCase):
 
     def test_array_value_and_bracket_error(self):
         lexer = MD_Lexer(self.mh, "test", "")
-        lexer._emit_value("DemoPkg.item_a @ 1 <br> DemoPkg.item_b via 2", Location("test"))
+        lexer._emit_value(
+            "DemoPkg.item_a @ 1 <br> DemoPkg.item_b via 2", Location("test")
+        )
         self.assertEqual(
             token_pairs(lexer),
             [
@@ -198,7 +208,10 @@ class TestLexerMd(unittest.TestCase):
         lexer._emit_value("[DemoPkg.item_a @ 1, DemoPkg.item_b @ 2]", Location("test"))
         self.assertEqual(token_pairs(lexer), [])
         self.assertEqual(len(self.mh.messages), 1)
-        self.assertEqual(self.mh.pop_message()[2], "bracket notation for tuple-reference arrays is not supported")
+        self.assertEqual(
+            self.mh.pop_message()[2],
+            "bracket notation for tuple-reference arrays is not supported",
+        )
 
     def test_type_aware_field_emission(self):
         _stab, record_type = make_record_type()
@@ -207,7 +220,12 @@ class TestLexerMd(unittest.TestCase):
         # Tuple-array field: fully qualified references
         lexer = MD_Lexer(self.mh, "test", "")
         lexer._emit_field_value("Hello there", Location("test"), record_type, "notes")
-        lexer._emit_field_value("DemoPkg.item_a @ 1, DemoPkg.item_b @ 2", Location("test"), record_type, "refs")
+        lexer._emit_field_value(
+            "DemoPkg.item_a @ 1, DemoPkg.item_b @ 2",
+            Location("test"),
+            record_type,
+            "refs",
+        )
         self.assertEqual(
             token_pairs(lexer),
             [
@@ -230,7 +248,9 @@ class TestLexerMd(unittest.TestCase):
 
         # Tuple-array field: unqualified (same-package) references
         lexer = MD_Lexer(self.mh, "test", "")
-        lexer._emit_field_value("item_a @ 1, item_b @ 2", Location("test"), record_type, "refs")
+        lexer._emit_field_value(
+            "item_a @ 1, item_b @ 2", Location("test"), record_type, "refs"
+        )
         self.assertEqual(
             token_pairs(lexer),
             [
@@ -248,7 +268,9 @@ class TestLexerMd(unittest.TestCase):
 
         # Tuple-array field: mixed array (qualified + unqualified)
         lexer = MD_Lexer(self.mh, "test", "")
-        lexer._emit_field_value("item_a @ 1, OtherPkg.item_b @ 2", Location("test"), record_type, "refs")
+        lexer._emit_field_value(
+            "item_a @ 1, OtherPkg.item_b @ 2", Location("test"), record_type, "refs"
+        )
         self.assertEqual(
             token_pairs(lexer),
             [

--- a/third_party/lint/BUILD.bazel
+++ b/third_party/lint/BUILD.bazel
@@ -5,6 +5,7 @@ load("@rules_python//python/entry_points:py_console_script_binary.bzl", "py_cons
 py_console_script_binary(
     name = "pylint",
     pkg = "@trlc_dev_dependencies//pylint:pkg",
+    visibility = ["//visibility:public"],
     deps = [
         "@trlc_dev_dependencies//astroid:pkg",
         "@trlc_dev_dependencies//dill:pkg",
@@ -13,5 +14,4 @@ py_console_script_binary(
         "@trlc_dev_dependencies//platformdirs:pkg",
         "@trlc_dev_dependencies//tomlkit:pkg",
     ],
-    visibility = ["//visibility:public"],
 )

--- a/tools/sphinx/extensions/trlc/trlc.py
+++ b/tools/sphinx/extensions/trlc/trlc.py
@@ -139,10 +139,15 @@ class RequirementsDomain(Domain):
         return []
 
     def merge_domaindata(self, docnames, otherdata):
-        existing_anchors = {anchor for _name, _sig, _typ, _docname, anchor, _prio in self.data["requirements"]}
+        existing_anchors = {
+            anchor
+            for _name, _sig, _typ, _docname, anchor, _prio in self.data["requirements"]
+        }
         for _name, _sig, _typ, docname, anchor, _prio in otherdata["requirements"]:
             if docname in docnames and anchor not in existing_anchors:
-                self.data["requirements"].append((_name, _sig, _typ, docname, anchor, _prio))
+                self.data["requirements"].append(
+                    (_name, _sig, _typ, docname, anchor, _prio)
+                )
                 existing_anchors.add(anchor)
 
 

--- a/tools/trlc_rst/trlc_rst.py
+++ b/tools/trlc_rst/trlc_rst.py
@@ -61,7 +61,9 @@ class TRLCRST:
         return field_name.replace("_", " ").strip().title()
 
     @classmethod
-    def _normalize_fields(cls, fields: list[str] | dict[str, str]) -> list[tuple[str, str]]:
+    def _normalize_fields(
+        cls, fields: list[str] | dict[str, str]
+    ) -> list[tuple[str, str]]:
         """Convert a field spec to ``[(field_name, label), ...]``.
 
         Accepts:
@@ -187,7 +189,9 @@ class TRLCRST:
                 "Requirements tree not built. Call convert_symbols_to_tree() first."
             )
 
-        normalized = self._normalize_fields(fields if fields is not None else _DEFAULT_FIELDS)
+        normalized = self._normalize_fields(
+            fields if fields is not None else _DEFAULT_FIELDS
+        )
 
         with open(output_path, "w", newline="", encoding="utf-8") as file:
             if title:
@@ -220,7 +224,9 @@ class TRLCRST:
                 else:
                     trlc_obj = getattr(node, "trlc_obj", None)
                     file.write(
-                        "\n".join(self._render_record_block(node.name, trlc_obj, normalized))
+                        "\n".join(
+                            self._render_record_block(node.name, trlc_obj, normalized)
+                        )
                     )
                     file.write("\n")
 
@@ -242,13 +248,18 @@ class TRLCRST:
         if trlc_obj is None:
             return None
         field_node = trlc_obj.field.get(field_name)
-        if isinstance(field_node, trlc.ast.String_Literal) and field_node.has_references:
+        if (
+            isinstance(field_node, trlc.ast.String_Literal)
+            and field_node.has_references
+        ):
             return TRLCRST._resolve_markup_references(
                 field_node.value, field_node.references
             )
         return trlc_obj.to_python_dict().get(field_name)
 
-    def _render_record_block(self, fqn: str, trlc_obj, fields: list[tuple[str, str]]) -> list:
+    def _render_record_block(
+        self, fqn: str, trlc_obj, fields: list[tuple[str, str]]
+    ) -> list:
         """Render one record as a ``requirement:definition`` directive block.
 
         Scalar ``String``/``Markup_String`` fields are rendered as preprocessed
@@ -302,7 +313,9 @@ class TRLCRST:
 
     def _objects_by_fqn(self, records: set[str] | None = None) -> dict:
         """Return ``{fully_qualified_name: trlc_obj}`` for all filtered records."""
-        return {o.fully_qualified_name(): o for o in self._iter_filtered_objects(records)}
+        return {
+            o.fully_qualified_name(): o for o in self._iter_filtered_objects(records)
+        }
 
     def objects_by_fqn(self, records: set[str] | None = None) -> dict:
         """Public access to ``{fqn: trlc_obj}`` for callers needing raw TRLC objects."""
@@ -362,7 +375,9 @@ class TRLCRST:
         Returns:
             RST string ending with a newline.
         """
-        normalized = self._normalize_fields(fields if fields is not None else _DEFAULT_FIELDS)
+        normalized = self._normalize_fields(
+            fields if fields is not None else _DEFAULT_FIELDS
+        )
         obj_map = self._objects_by_fqn(records)
         if fqns is None:
             objs = list(self._iter_filtered_objects(records))
@@ -404,7 +419,10 @@ class TRLCRST:
         normalized = self._normalize_fields(columns)
         obj_map = self._objects_by_fqn(records)
         if fqns is None:
-            objs = [(o.fully_qualified_name(), o) for o in self._iter_filtered_objects(records)]
+            objs = [
+                (o.fully_qualified_name(), o)
+                for o in self._iter_filtered_objects(records)
+            ]
         else:
             objs = [(f, obj_map[f]) for f in fqns if f in obj_map]
 
@@ -451,9 +469,7 @@ class TRLCRST:
                 if ref.target is not None:
                     fqn = ref.target.fully_qualified_name()
                     short = ref.target.name
-                    parts.append(
-                        f":requirement:upstream-ref:`{short} <{fqn}>`"
-                    )
+                    parts.append(f":requirement:upstream-ref:`{short} <{fqn}>`")
                 else:
                     parts.append(match.group(0))
             return ", ".join(parts)
@@ -522,7 +538,9 @@ class TRLCRST:
                     # relative_indent = 20-16 = 4, resulting in 6 base + 4 = 10 total spaces
                     original_indent = len(line) - len(line.lstrip())
                     relative_indent = original_indent - code_block_base_indent
-                    processed_lines.append(" " * (indent + 3) + " " * relative_indent + stripped)
+                    processed_lines.append(
+                        " " * (indent + 3) + " " * relative_indent + stripped
+                    )
                     skip_normal = True
                 elif in_directive:
                     original_indent = len(line) - len(line.lstrip())
@@ -530,7 +548,9 @@ class TRLCRST:
                         # Directive option or body content — preserve relative indentation
                         # so that e.g. ``:width: 50%`` stays indented under ``.. image::``.
                         relative_indent = original_indent - directive_base_indent
-                        processed_lines.append(" " * indent + " " * relative_indent + stripped)
+                        processed_lines.append(
+                            " " * indent + " " * relative_indent + stripped
+                        )
                         prev_was_list_item = False
                         skip_normal = True
                     else:

--- a/trlc-lrm-generator.py
+++ b/trlc-lrm-generator.py
@@ -40,11 +40,11 @@ from trlc import ast
 
 BMW_BLUE_1 = "#0066B1"
 BMW_BLUE_2 = "#003D78"
-BMW_RED    = "#E22718"
-BMW_GREY   = "#6f6f6f"
+BMW_RED = "#E22718"
+BMW_GREY = "#6f6f6f"
 BMW_SILVER = "#d6d6d6"
 
-CODE_BG    = "#f6f8fa"
+CODE_BG = "#f6f8fa"
 
 EMACS_STRING = "#8d2153"
 
@@ -53,15 +53,18 @@ URL_BASE = "https://bmw-software-engineering.github.io/trlc"
 
 class BNF_Token:
     KIND = (
-        "NONTERMINAL",     # foo   foo_NAME
-        "TERMINAL",        # FOO   FOO_name
-        "PRODUCTION",      # ::=
-        "ALTERNATIVE",     # |
-        "SYMBOL",          # 'potato'
-        "S_BRA", "S_KET",  # []
-        "C_BRA", "C_KET",  # {}
-        "BRA", "KET",      # ()
-        "RULE_END",        # two or more newlines
+        "NONTERMINAL",  # foo   foo_NAME
+        "TERMINAL",  # FOO   FOO_name
+        "PRODUCTION",  # ::=
+        "ALTERNATIVE",  # |
+        "SYMBOL",  # 'potato'
+        "S_BRA",
+        "S_KET",  # []
+        "C_BRA",
+        "C_KET",  # {}
+        "BRA",
+        "KET",  # ()
+        "RULE_END",  # two or more newlines
     )
 
     def __init__(self, kind, value, start, end, location):
@@ -70,11 +73,11 @@ class BNF_Token:
         assert isinstance(end, int) and start <= end
         assert isinstance(location, Source_Reference)
 
-        self.kind     = kind
-        self.value    = value
+        self.kind = kind
+        self.value = value
         self.location = location
-        self.start    = start
-        self.end      = end
+        self.start = start
+        self.end = end
 
     def __repr__(self):
         return "BNF_Token(%s, %s, <loc>)" % (self.kind, self.value)
@@ -85,14 +88,14 @@ class BNF_Lexer:
         assert isinstance(mh, Message_Handler)
         assert isinstance(fragment, str)
         assert isinstance(original_location, Source_Reference)
-        self.mh                = mh
-        self.fragment          = fragment
+        self.mh = mh
+        self.fragment = fragment
         self.original_location = original_location
-        self.fragment_length   = len(self.fragment)
+        self.fragment_length = len(self.fragment)
 
-        self.lexpos  = -2
+        self.lexpos = -2
         self.line_no = 0
-        self.col_no  = 0
+        self.col_no = 0
         self.cc = None
         self.nc = None
         self.eof_token_generated = False
@@ -107,16 +110,18 @@ class BNF_Lexer:
         if self.nc is not None:
             self.col_no += 1
         self.cc = self.nc
-        self.nc = (self.fragment[self.lexpos + 1]
-                   if self.lexpos + 1 < self.fragment_length
-                   else None)
+        self.nc = (
+            self.fragment[self.lexpos + 1]
+            if self.lexpos + 1 < self.fragment_length
+            else None
+        )
 
     def token(self):
         # Skip whitespace and comments
         num_nl = 0
-        start_pos  = self.lexpos
+        start_pos = self.lexpos
         start_line = self.line_no
-        start_col  = self.col_no
+        start_col = self.col_no
         while self.nc and self.nc.isspace():
             self.advance()
             if self.cc == "\n":
@@ -127,31 +132,33 @@ class BNF_Lexer:
         if self.cc is None:
             if not self.eof_token_generated:
                 self.eof_token_generated = True
-                return BNF_Token(kind     = "RULE_END",
-                                 value    = None,
-                                 start    = self.lexpos,
-                                 end      = self.lexpos,
-                                 location = self.mk_location(start_line,
-                                                             start_col,
-                                                             self.lexpos,
-                                                             self.lexpos))
+                return BNF_Token(
+                    kind="RULE_END",
+                    value=None,
+                    start=self.lexpos,
+                    end=self.lexpos,
+                    location=self.mk_location(
+                        start_line, start_col, self.lexpos, self.lexpos
+                    ),
+                )
             return None
 
         # If we have more than one empty line then this is the end of
         # a rule.
         if num_nl >= 2:
-            return BNF_Token(kind     = "RULE_END",
-                             value    = None,
-                             start    = start_pos,
-                             end      = self.lexpos,
-                             location = self.mk_location(self.line_no,
-                                                         start_col,
-                                                         start_pos,
-                                                         self.lexpos))
+            return BNF_Token(
+                kind="RULE_END",
+                value=None,
+                start=start_pos,
+                end=self.lexpos,
+                location=self.mk_location(
+                    self.line_no, start_col, start_pos, self.lexpos
+                ),
+            )
 
-        start_pos  = self.lexpos
+        start_pos = self.lexpos
         start_line = self.line_no
-        start_col  = self.col_no
+        start_col = self.col_no
 
         if self.cc == "[":
             kind = "S_BRA"
@@ -206,8 +213,8 @@ class BNF_Lexer:
         else:
             self.lex_error("unexpected character %s" % self.cc)
 
-        end_pos  = self.lexpos
-        raw_text = self.fragment[start_pos:end_pos + 1]
+        end_pos = self.lexpos
+        raw_text = self.fragment[start_pos : end_pos + 1]
 
         # pylint: disable=possibly-used-before-assignment
 
@@ -249,30 +256,31 @@ class BNF_Lexer:
         else:
             value = None
 
-        return BNF_Token(kind     = kind,
-                         value    = value,
-                         start    = start_pos,
-                         end      = end_pos,
-                         location = self.mk_location(start_line,
-                                                     start_col,
-                                                     start_pos,
-                                                     end_pos))
+        return BNF_Token(
+            kind=kind,
+            value=value,
+            start=start_pos,
+            end=end_pos,
+            location=self.mk_location(start_line, start_col, start_pos, end_pos),
+        )
 
     def mk_location(self, start_line, start_col, start_pos, end_pos):
         sref = Source_Reference(
-            lexer      = self.original_location.lexer,
-            start_line = self.original_location.line_no + (start_line - 1),
-            start_col  = (self.original_location.col_no + 3
-                          if start_line == 1
-                          else start_col),
-            start_pos  = self.original_location.start_pos + 3 + start_pos,
-            end_pos    = self.original_location.start_pos + 3 + end_pos)
+            lexer=self.original_location.lexer,
+            start_line=self.original_location.line_no + (start_line - 1),
+            start_col=(
+                self.original_location.col_no + 3 if start_line == 1 else start_col
+            ),
+            start_pos=self.original_location.start_pos + 3 + start_pos,
+            end_pos=self.original_location.start_pos + 3 + end_pos,
+        )
         return sref
 
     def lex_error(self, message):
-        self.mh.error(self.mk_location(self.line_no, self.col_no,
-                                       self.lexpos, self.lexpos),
-                      message)
+        self.mh.error(
+            self.mk_location(self.line_no, self.col_no, self.lexpos, self.lexpos),
+            message,
+        )
 
 
 class BNF_AST_Node:
@@ -288,15 +296,13 @@ class BNF_Expansion(BNF_AST_Node):
 class BNF_Literal(BNF_Expansion):
     def __init__(self, location, kind, value, name=None):
         super().__init__(location)
-        assert kind in ("TERMINAL",
-                        "NONTERMINAL",
-                        "SYMBOL")
+        assert kind in ("TERMINAL", "NONTERMINAL", "SYMBOL")
         assert isinstance(value, str)
         assert isinstance(name, str) or name is None
 
-        self.kind  = kind
+        self.kind = kind
         self.value = value
-        self.name  = name
+        self.name = name
 
     def __str__(self):
         return self.value
@@ -326,6 +332,7 @@ class BNF_Zero_Or_More(BNF_Expansion):
 
 class BNF_Group(BNF_Expansion):
     """Parenthesised grouping: ( expansion )"""
+
     def __init__(self, location, expansion):
         super().__init__(location)
         assert isinstance(expansion, BNF_Expansion)
@@ -370,14 +377,14 @@ class BNF_Parser:
 
         # Lexer state
         self.current_lexer = None
-        self.ct            = None
-        self.nt            = None
+        self.ct = None
+        self.nt = None
 
         # Symbol table
         self.token_kinds = {}
-        self.terminals   = set()
+        self.terminals = set()
         self.productions = {}
-        self.bundles     = {}
+        self.bundles = {}
 
     def advance(self):
         assert self.current_lexer is not None
@@ -402,8 +409,9 @@ class BNF_Parser:
         if self.nt is None:
             self.error(self.ct, "expected %s, encountered EOS instead" % kind)
         elif self.nt.kind != kind:
-            self.error(self.nt, "expected %s, encountered %s instead" %
-                       (kind, self.nt.kind))
+            self.error(
+                self.nt, "expected %s, encountered %s instead" % (kind, self.nt.kind)
+            )
 
         self.advance()
 
@@ -419,13 +427,10 @@ class BNF_Parser:
     def sem_expansion(self, n_exp):
         assert isinstance(n_exp, BNF_Expansion)
 
-        if isinstance(n_exp, (BNF_Zero_Or_More,
-                              BNF_Optional,
-                              BNF_Group)):
+        if isinstance(n_exp, (BNF_Zero_Or_More, BNF_Optional, BNF_Group)):
             self.sem_expansion(n_exp.expansion)
 
-        elif isinstance(n_exp, (BNF_String,
-                                BNF_Alternatives)):
+        elif isinstance(n_exp, (BNF_String, BNF_Alternatives)):
             for n_member in n_exp.members:
                 self.sem_expansion(n_member)
 
@@ -437,26 +442,28 @@ class BNF_Parser:
 
         if n_literal.kind == "SYMBOL":
             if n_literal.value not in self.terminals:
-                self.mh.warning(n_literal.location,
-                                "unknown terminal '%s'" % n_literal.value)
+                self.mh.warning(
+                    n_literal.location, "unknown terminal '%s'" % n_literal.value
+                )
 
         elif n_literal.kind == "TERMINAL":
             if n_literal.value not in self.token_kinds:
-                self.mh.warning(n_literal.location,
-                                "unknown terminal %s" % n_literal.value)
+                self.mh.warning(
+                    n_literal.location, "unknown terminal %s" % n_literal.value
+                )
 
         else:
             assert n_literal.kind == "NONTERMINAL"
             if n_literal.value not in self.productions:
-                self.mh.warning(n_literal.location,
-                                "unknown production %s" % n_literal.value)
+                self.mh.warning(
+                    n_literal.location, "unknown production %s" % n_literal.value
+                )
 
     def register_terminal(self, obj):
         assert isinstance(obj, ast.String_Literal)
 
         if obj.value in self.terminals:
-            self.mh.error(obj.location,
-                          "duplicate definition of terminal")
+            self.mh.error(obj.location, "duplicate definition of terminal")
         self.terminals.add(obj.value)
 
     def register_backtick_terminals(self, obj):
@@ -466,14 +473,13 @@ class BNF_Parser:
             terminal = match.group(1)
             if terminal:
                 if terminal in self.terminals:
-                    self.mh.error(obj.location,
-                                  "duplicate definition of terminal '%s'" %
-                                  terminal)
+                    self.mh.error(
+                        obj.location, "duplicate definition of terminal '%s'" % terminal
+                    )
                 else:
                     self.terminals.add(terminal)
             else:
-                self.mh.error(obj.location,
-                              "empty terminal is not permitted")
+                self.mh.error(obj.location, "empty terminal is not permitted")
 
     def register_token(self, obj, examples):
         assert isinstance(obj, ast.String_Literal)
@@ -481,28 +487,24 @@ class BNF_Parser:
 
         match = re.match("([A-Z_]+) *::= *(.*)", obj.value)
         if match is None:
-            self.mh.error(obj.location,
-                          "malformed token definition")
+            self.mh.error(obj.location, "malformed token definition")
 
         if match.group(1) in self.token_kinds:
-            self.mh.error(obj.location,
-                          "duplicate definition of %s" % match.group(1))
+            self.mh.error(obj.location, "duplicate definition of %s" % match.group(1))
 
         try:
             pattern = re.compile(match.group(2), re.DOTALL)
         except re.error as err:
-            self.mh.error(obj.location,
-                          err.msg)
+            self.mh.error(obj.location, err.msg)
 
         for example in examples.value:
             ex_match = pattern.match(example.value)
             if ex_match is None:
-                self.mh.error(example.location,
-                              "does not match %s" % match.group(2))
+                self.mh.error(example.location, "does not match %s" % match.group(2))
             elif ex_match.group(0) != example.value:
-                self.mh.error(example.location,
-                              "only %s is matched" %
-                              (ex_match.group(0)))
+                self.mh.error(
+                    example.location, "only %s is matched" % (ex_match.group(0))
+                )
 
         self.token_kinds[match.group(1)] = match.group(2)
 
@@ -515,14 +517,11 @@ class BNF_Parser:
         # simplifications)
         orig_text = obj.field["bnf"].location.text()
         if not (orig_text.startswith("'''") or orig_text.startswith('"""')):
-            self.mh.error(obj.field["bnf"].location,
-                          "BNF text must use ''' strings")
+            self.mh.error(obj.field["bnf"].location, "BNF text must use ''' strings")
         orig_text = orig_text[3:-3]
 
         # Create nested lexer
-        self.current_lexer = BNF_Lexer(self.mh,
-                                       orig_text,
-                                       obj.field["bnf"].location)
+        self.current_lexer = BNF_Lexer(self.mh, orig_text, obj.field["bnf"].location)
         self.ct = None
         self.nt = self.current_lexer.token()
 
@@ -532,8 +531,8 @@ class BNF_Parser:
             self.match("RULE_END")
 
         self.current_lexer = None
-        self.ct            = None
-        self.nt            = None
+        self.ct = None
+        self.nt = None
 
     def parse_production(self):
         # production ::= expansion
@@ -569,10 +568,14 @@ class BNF_Parser:
 
     def parse_string(self):
         rv = [self.parse_fragment()]
-        while self.nt.kind in ("C_BRA", "S_BRA", "BRA",
-                               "TERMINAL",
-                               "NONTERMINAL",
-                               "SYMBOL"):
+        while self.nt.kind in (
+            "C_BRA",
+            "S_BRA",
+            "BRA",
+            "TERMINAL",
+            "NONTERMINAL",
+            "SYMBOL",
+        ):
             rv.append(self.parse_fragment())
 
         if len(rv) == 1:
@@ -603,29 +606,22 @@ class BNF_Parser:
 
         elif self.peek("TERMINAL"):
             self.match("TERMINAL")
-            return BNF_Literal(loc,
-                               self.ct.kind,
-                               self.ct.value[0],
-                               self.ct.value[1])
+            return BNF_Literal(loc, self.ct.kind, self.ct.value[0], self.ct.value[1])
 
         elif self.peek("NONTERMINAL"):
             self.match("NONTERMINAL")
-            return BNF_Literal(loc,
-                               self.ct.kind,
-                               self.ct.value[0],
-                               self.ct.value[1])
+            return BNF_Literal(loc, self.ct.kind, self.ct.value[0], self.ct.value[1])
 
         elif self.peek("SYMBOL"):
             self.match("SYMBOL")
             return BNF_Literal(loc, self.ct.kind, self.ct.value)
 
-        self.error(self.nt,
-                   "expected bnf fragment")
+        self.error(self.nt, "expected bnf fragment")
 
 
 def write_heading(fd, name, depth, anchor=None):
     if anchor:
-        fd.write("<h%u class=\"autosection\" id=\"%s\">" % (depth, anchor))
+        fd.write('<h%u class="autosection" id="%s">' % (depth, anchor))
     else:
         fd.write("<h%u>" % depth)
     fd.write(html.escape(name))
@@ -634,18 +630,18 @@ def write_heading(fd, name, depth, anchor=None):
 
 def write_header(fd, obj_version, obj_license):
     ver = obj_version.to_python_dict()
-    title = "TRLC Language Reference Manual, Version %u.%u" % (ver["major"],
-                                                               ver["minor"])
+    title = "TRLC Language Reference Manual, Version %u.%u" % (
+        ver["major"],
+        ver["minor"],
+    )
     short_title = "TRLC %u.%u LRM" % (ver["major"], ver["minor"])
 
     fd.write("<!DOCTYPE html>\n")
-    fd.write("<html lang=\"en\">\n")
+    fd.write('<html lang="en">\n')
     fd.write("<head>\n")
     fd.write("<title>%s</title>\n" % short_title)
-    fd.write("<link rel=\"icon\" type=\"image/x-icon\""
-             " href=\"bmw_favicon.ico\">")
-    fd.write("<meta name=\"viewport\" "
-             "content=\"width=device-width, initial-scale=1.0\">\n")
+    fd.write('<link rel="icon" type="image/x-icon" href="bmw_favicon.ico">')
+    fd.write('<meta name="viewport" content="width=device-width, initial-scale=1.0">\n')
     fd.write("<style>\n")
     fd.write("body {\n")
     fd.write("  font-family: sans;\n")
@@ -663,7 +659,7 @@ def write_header(fd, obj_version, obj_license):
     fd.write("}\n")
     fd.write("h2.autosection:before {\n")
     fd.write("  counter-increment: section;\n")
-    fd.write("  content: counter(section) \". \";\n")
+    fd.write('  content: counter(section) ". ";\n')
     fd.write("}\n")
     fd.write("h2 {\n")
     fd.write("  border-bottom: 0.1em solid %s;\n" % BMW_BLUE_2)
@@ -685,7 +681,7 @@ def write_header(fd, obj_version, obj_license):
     fd.write("  padding: 1em;\n")
     fd.write("}\n")
     fd.write(".cls-Note:before {\n")
-    fd.write("  content: \"Non-normative: \";\n")
+    fd.write('  content: "Non-normative: ";\n')
     fd.write("}\n")
     fd.write("div.cls-Note {\n")
     fd.write("  background-color: %s;\n" % CODE_BG)
@@ -738,10 +734,12 @@ def write_header(fd, obj_version, obj_license):
     write_heading(fd, title, 1)
     lic = obj_license.to_python_dict()
     fd.write("<div>\n")
-    fd.write("Permission is granted to copy, distribute and/or"
-             " modify this document under the terms of the GNU Free"
-             " Documentation License, Version 1.3 or any later version"
-             " published by the Free SoftwareFoundation;")
+    fd.write(
+        "Permission is granted to copy, distribute and/or"
+        " modify this document under the terms of the GNU Free"
+        " Documentation License, Version 1.3 or any later version"
+        " published by the Free SoftwareFoundation;"
+    )
     if not lic["invariant_sections"]:
         fd.write(" with no Invariant Sections,")
     else:
@@ -755,22 +753,27 @@ def write_header(fd, obj_version, obj_license):
     else:
         fd.write(" and no Back-Cover Texts.")
     fd.write("\n")
-    fd.write("A copy of the license is included in the section"
-             " entitled \"Appendix A: GNU Free Documentation License\".\n")
+    fd.write(
+        "A copy of the license is included in the section"
+        ' entitled "Appendix A: GNU Free Documentation License".\n'
+    )
     fd.write("</div>\n")
 
 
 def write_footer(fd, script_name):
     write_heading(fd, "Appendix A: GNU Free Documentation License", 1)
-    with open("language-reference-manual/LICENSE.html_fragment", "r",
-              encoding="UTF-8") as fd_lic:
+    with open(
+        "language-reference-manual/LICENSE.html_fragment", "r", encoding="UTF-8"
+    ) as fd_lic:
         fd.write(fd_lic.read())
     fd.write("<hr>\n")
     fd.write("<footer>\n")
     gh_root = "https://github.com/bmw-software-engineering"
     gh_project = "trlc"
-    fd.write("Generated by the <a href=\"%s/%s/blob/main/%s\">" %
-             (gh_root, gh_project, script_name))
+    fd.write(
+        'Generated by the <a href="%s/%s/blob/main/%s">'
+        % (gh_root, gh_project, script_name)
+    )
     fd.write("TRLC LRM Generator</a>\n")
     fd.write("</footer>\n")
     fd.write("</body>\n")
@@ -829,9 +832,9 @@ def write_text_object(fd, mh, obj, context, bnf_parser):
     data = obj.to_python_dict()
 
     # Close merged grammar section
-    if context["in_grammar"] and (obj.n_typ.name != "Grammar" or
-                                  data["text"] or
-                                  data["bullets"]):
+    if context["in_grammar"] and (
+        obj.n_typ.name != "Grammar" or data["text"] or data["bullets"]
+    ):
         context["in_grammar"] = False
         fd.write("</pre>\n")
         fd.write("</div>\n")
@@ -839,20 +842,15 @@ def write_text_object(fd, mh, obj, context, bnf_parser):
     # Build current section
     if obj.section:
         new_section = section_list(obj.section[-1])
-        new_hashes  = section_hashes(obj.section[-1])
+        new_hashes = section_hashes(obj.section[-1])
     else:
         new_section = []
 
-    if obj.n_typ.name in ("Text", "Grammar",
-                          "Terminal",
-                          "Keywords",
-                          "Punctuation"):
+    if obj.n_typ.name in ("Text", "Grammar", "Terminal", "Keywords", "Punctuation"):
         pass
     elif obj.n_typ.name == "Note":
         new_section = context["old_section"]
-    elif obj.n_typ.name in ("Semantics",
-                            "Static_Semantics",
-                            "Dynamic_Semantics"):
+    elif obj.n_typ.name in ("Semantics", "Static_Semantics", "Dynamic_Semantics"):
         new_section.append(data["kind"] + " Semantics")
     elif obj.n_typ.name == "Name_Resolution":
         new_section.append("Name resolution")
@@ -891,8 +889,7 @@ def write_text_object(fd, mh, obj, context, bnf_parser):
 
     # Emit
     if data["text"] or data["bullets"]:
-        fd.write("<div id='lrm-%s' class='cls-%s'>\n" % (obj.name,
-                                                         obj.n_typ.name))
+        fd.write("<div id='lrm-%s' class='cls-%s'>\n" % (obj.name, obj.n_typ.name))
         if data["text"]:
             fd.write(fmt_text(data["text"]) + "\n")
         if data["bullets"]:
@@ -914,16 +911,15 @@ def write_text_object(fd, mh, obj, context, bnf_parser):
     if obj.n_typ.name == "Terminal":
         match = re.match("([A-Z_]+) *::= *(.*)", data["def"])
         fd.write("<div class='code'>\n")
-        fd.write("<code id=\"bnf-%s\">%s</code>\n" %
-                 (match.group(1),
-                  html.escape(data["def"])))
+        fd.write(
+            '<code id="bnf-%s">%s</code>\n' % (match.group(1), html.escape(data["def"]))
+        )
         fd.write("</div>\n")
         fd.write("<div>\n")
         fd.write("Examples:")
         fd.write("<ul>\n")
         for item in data["examples"]:
-            fd.write("  <li>%s</li>\n" %
-                     html.escape(item).replace("\n", "<br>"))
+            fd.write("  <li>%s</li>\n" % html.escape(item).replace("\n", "<br>"))
         fd.write("</ul>\n")
         fd.write("</div>\n")
 
@@ -948,27 +944,34 @@ class Nested_Lexer(TRLC_Lexer):
     def __init__(self, string_literal):
         assert isinstance(string_literal, ast.String_Literal)
         mh = string_literal.location.lexer.mh
-        if not (string_literal.location.text().startswith("'''") or
-                string_literal.location.text().startswith('"""')):
-            mh.error(string_literal.location,
-                     "only ''' strings are supported for examples")
+        if not (
+            string_literal.location.text().startswith("'''")
+            or string_literal.location.text().startswith('"""')
+        ):
+            mh.error(
+                string_literal.location, "only ''' strings are supported for examples"
+            )
         super().__init__(
-            mh           = mh,
-            file_name    = string_literal.location.lexer.file_name,
-            file_content = string_literal.location.text()[3:-3])
+            mh=mh,
+            file_name=string_literal.location.lexer.file_name,
+            file_content=string_literal.location.text()[3:-3],
+        )
         self.base = string_literal.location
 
     def token(self):
         tok = super().token()
         if tok:
             sref = Source_Reference(
-                lexer      = self.base.lexer,
-                start_line = self.base.line_no + (tok.location.line_no - 1),
-                start_col  = (self.base.col_no + 3
-                              if tok.location.line_no == 1
-                              else tok.location.col_no),
-                start_pos  = self.base.start_pos + 3 + tok.location.start_pos,
-                end_pos    = self.base.start_pos + 3 + tok.location.end_pos)
+                lexer=self.base.lexer,
+                start_line=self.base.line_no + (tok.location.line_no - 1),
+                start_col=(
+                    self.base.col_no + 3
+                    if tok.location.line_no == 1
+                    else tok.location.col_no
+                ),
+                start_pos=self.base.start_pos + 3 + tok.location.start_pos,
+                end_pos=self.base.start_pos + 3 + tok.location.end_pos,
+            )
             tok.location = sref
         return tok
 
@@ -976,9 +979,8 @@ class Nested_Lexer(TRLC_Lexer):
 class Token_Buffer(TRLC_Lexer):
     def __init__(self, lexer):
         assert isinstance(lexer, TRLC_Lexer)
-        super().__init__(mh        = lexer.mh,
-                         file_name = lexer.file_name)
-        self.lexer  = lexer
+        super().__init__(mh=lexer.mh, file_name=lexer.file_name)
+        self.lexer = lexer
         self.tokens = []
 
     def token(self):
@@ -1005,7 +1007,7 @@ class Token_Buffer(TRLC_Lexer):
             spaces = tok.location.col_no - cc
             rv += " " * spaces
             cc += spaces
-            rv += "<span class=\"TRLC_%s\">" % tok.kind
+            rv += '<span class="TRLC_%s">' % tok.kind
             rv += html.escape(tok.location.text())
             rv += "</span>"
             cc += len(tok.location.text())
@@ -1018,11 +1020,10 @@ class Chained_Lexer(TRLC_Lexer):
         assert isinstance(literals, list) and len(literals) >= 1
         for literal in literals:
             assert isinstance(literal, ast.String_Literal)
-        self.lexers  = list(map(Token_Buffer, map(Nested_Lexer, literals)))
+        self.lexers = list(map(Token_Buffer, map(Nested_Lexer, literals)))
         self.current = self.lexers[0]
-        self.future  = self.lexers[1:]
-        super().__init__(literals[0].location.lexer.mh,
-                         literals[0].location.file_name)
+        self.future = self.lexers[1:]
+        super().__init__(literals[0].location.lexer.mh, literals[0].location.file_name)
 
     def token(self):
         while self.current:
@@ -1031,7 +1032,7 @@ class Chained_Lexer(TRLC_Lexer):
                 return tok
             elif self.future:
                 self.current = self.future[0]
-                self.future  = self.future[1:]
+                self.future = self.future[1:]
             else:
                 self.current = None
         return None
@@ -1052,12 +1053,14 @@ def write_example(fd, mh, obj):
         rsl_sources.append(obj.field["rsl"])
     rsl_lexers = Chained_Lexer(rsl_sources)
     try:
-        rsl_parser = Parser(mh             = mh,
-                            stab           = stab,
-                            file_name      = obj.location.file_name,
-                            lint_mode      = False,
-                            error_recovery = False,
-                            lexer          = rsl_lexers)
+        rsl_parser = Parser(
+            mh=mh,
+            stab=stab,
+            file_name=obj.location.file_name,
+            lint_mode=False,
+            error_recovery=False,
+            lexer=rsl_lexers,
+        )
         rsl_parser.parse_preamble("rsl")
         rsl_parser.cu.resolve_imports(mh, stab)
         rsl_parser.parse_rsl_file()
@@ -1073,12 +1076,14 @@ def write_example(fd, mh, obj):
     if trlc_sources and valid_example:
         trlc_lexers = Chained_Lexer(trlc_sources)
         try:
-            trlc_parser = Parser(mh             = mh,
-                                 stab           = stab,
-                                 file_name      = obj.location.file_name,
-                                 lint_mode      = False,
-                                 error_recovery = False,
-                                 lexer          = trlc_lexers)
+            trlc_parser = Parser(
+                mh=mh,
+                stab=stab,
+                file_name=obj.location.file_name,
+                lint_mode=False,
+                error_recovery=False,
+                lexer=trlc_lexers,
+            )
             trlc_parser.parse_preamble("trlc")
             trlc_parser.parse_trlc_file()
         except TRLC_Error:
@@ -1101,8 +1106,7 @@ def write_example(fd, mh, obj):
 
 def write_production(fd, production, bnf_parser):
     # Write indicator with anchor
-    fd.write("<span id=\"bnf-%s\">%s</span> ::= " %
-             (production, production))
+    fd.write('<span id="bnf-%s">%s</span> ::= ' % (production, production))
     n_exp = bnf_parser.productions[production]
     alt_offset = len(production) + 3
 
@@ -1175,13 +1179,15 @@ def write_expansion(fd, n_exp, bnf_parser):
 
         elif n_exp.kind == "TERMINAL":
             if n_exp.value in bnf_parser.token_kinds:
-                fd.write("<span class=\"tooltip\">")
-                fd.write("<a href=\"#bnf-%s\">" % html.escape(n_exp.value))
+                fd.write('<span class="tooltip">')
+                fd.write('<a href="#bnf-%s">' % html.escape(n_exp.value))
             fd.write(n_exp.value)
             if n_exp.value in bnf_parser.token_kinds:
                 fd.write("</a>")
-                fd.write("<span class=\"tooltiptext\">%s</span>" %
-                         html.escape(bnf_parser.token_kinds[n_exp.value]))
+                fd.write(
+                    '<span class="tooltiptext">%s</span>'
+                    % html.escape(bnf_parser.token_kinds[n_exp.value])
+                )
                 fd.write("</span>")
             if n_exp.name:
                 fd.write("<i>_%s</i>" % n_exp.name)
@@ -1195,15 +1201,16 @@ def write_expansion(fd, n_exp, bnf_parser):
             else:
                 tooltip_text = None
             if tooltip_text:
-                fd.write("<span class=\"tooltip\">")
+                fd.write('<span class="tooltip">')
             if n_exp.value in bnf_parser.productions:
-                fd.write("<a href=\"#bnf-%s\">" % html.escape(n_exp.value))
+                fd.write('<a href="#bnf-%s">' % html.escape(n_exp.value))
             fd.write(n_exp.value)
             if n_exp.value in bnf_parser.productions:
                 fd.write("</a>")
             if tooltip_text:
-                fd.write("<span class=\"tooltiptext\">%s</span>" %
-                         html.escape(tooltip_text))
+                fd.write(
+                    '<span class="tooltiptext">%s</span>' % html.escape(tooltip_text)
+                )
                 fd.write("</span>")
             if n_exp.name:
                 fd.write("<i>_%s</i>" % n_exp.name)
@@ -1216,9 +1223,11 @@ def write_toc_section(fd, tree, level):
     indent = " " * (4 * (level - 1))
     fd.write(indent + "<ol>\n")
     for item in tree.values():
-        fd.write(indent + "  <li><a href=\"#sec:%s\">%s</a>\n" %
-                 (section_hash(item["obj"]),
-                  item["name"]))
+        fd.write(
+            indent
+            + '  <li><a href="#sec:%s">%s</a>\n'
+            % (section_hash(item["obj"]), item["name"])
+        )
         write_toc_section(fd, item["sub"], level + 1)
         fd.write(indent + "  </li>\n")
     fd.write(indent + "</ol>\n")
@@ -1248,9 +1257,9 @@ def write_toc(fd, pkg_lrm):
         for section in sections:
             if section.name not in ptr:
                 ptr[section.name] = {
-                    "name" : section.name,
-                    "obj"  : section,
-                    "sub"  : OrderedDict()
+                    "name": section.name,
+                    "obj": section,
+                    "sub": OrderedDict(),
                 }
             ptr = ptr[section.name]["sub"]
 
@@ -1259,14 +1268,9 @@ def write_toc(fd, pkg_lrm):
 
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument("--tag",
-                    action="store_true",
-                    default=False)
-    ap.add_argument("--update-index",
-                    action="store_true",
-                    default=False)
-    ap.add_argument("--lrm_dir",
-                    default="language-reference-manual")
+    ap.add_argument("--tag", action="store_true", default=False)
+    ap.add_argument("--update-index", action="store_true", default=False)
+    ap.add_argument("--lrm_dir", default="language-reference-manual")
 
     options = ap.parse_args()
 
@@ -1279,20 +1283,13 @@ def main():
         sys.exit(1)
 
     pkg_lrm = symbols.lookup_assuming(mh, "LRM", ast.Package)
-    obj_license = pkg_lrm.symbols.lookup_assuming(mh,
-                                                  "License",
-                                                  ast.Record_Object)
-    obj_version = pkg_lrm.symbols.lookup_assuming(mh,
-                                                  "Version",
-                                                  ast.Record_Object)
+    obj_license = pkg_lrm.symbols.lookup_assuming(mh, "License", ast.Record_Object)
+    obj_version = pkg_lrm.symbols.lookup_assuming(mh, "Version", ast.Record_Object)
     typ_text = pkg_lrm.symbols.lookup_assuming(mh, "Text", ast.Record_Type)
     typ_gram = pkg_lrm.symbols.lookup_assuming(mh, "Grammar", ast.Record_Type)
-    typ_kword = pkg_lrm.symbols.lookup_assuming(mh, "Keywords",
-                                                ast.Record_Type)
-    typ_punct = pkg_lrm.symbols.lookup_assuming(mh, "Punctuation",
-                                                ast.Record_Type)
-    typ_terminal = pkg_lrm.symbols.lookup_assuming(mh, "Terminal",
-                                                   ast.Record_Type)
+    typ_kword = pkg_lrm.symbols.lookup_assuming(mh, "Keywords", ast.Record_Type)
+    typ_punct = pkg_lrm.symbols.lookup_assuming(mh, "Punctuation", ast.Record_Type)
+    typ_terminal = pkg_lrm.symbols.lookup_assuming(mh, "Terminal", ast.Record_Type)
 
     # Process grammer
     parser = BNF_Parser(mh)
@@ -1325,10 +1322,7 @@ def main():
         return
 
     version = obj_version.to_python_dict()
-    context = {
-        "old_section" : None,
-        "in_grammar"  : False
-    }
+    context = {"old_section": None, "in_grammar": False}
 
     with open("docs/lrm.html", "w", encoding="UTF-8") as fd:
         write_header(fd, obj_version, obj_license)
@@ -1347,33 +1341,36 @@ def main():
         write_footer(fd, os.path.relpath(__file__))
 
     if options.tag:
-        shutil.copyfile("docs/lrm.html",
-                        "docs/lrm-%u.%u.html" % (version["major"],
-                                                 version["minor"]))
+        shutil.copyfile(
+            "docs/lrm.html",
+            "docs/lrm-%u.%u.html" % (version["major"], version["minor"]),
+        )
 
     if not options.update_index:
         return
 
-    lrm_versions = [tuple(map(int,
-                              re.match(r"docs/lrm-([0-9]+)\.([0-9]+)\.html",
-                                       filename).groups()))
-                    for filename in glob.glob("docs/lrm-*.*.html")]
+    lrm_versions = [
+        tuple(
+            map(int, re.match(r"docs/lrm-([0-9]+)\.([0-9]+)\.html", filename).groups())
+        )
+        for filename in glob.glob("docs/lrm-*.*.html")
+    ]
 
     with open("documentation/LRM.md", "w", encoding="UTF-8") as fd:
         fd.write("# TRLC LRM\n\n")
         first = True
         for major, minor in reversed(sorted(lrm_versions)):
-            if first and (major != version["major"] or
-                          minor != version["minor"]):
+            if first and (major != version["major"] or minor != version["minor"]):
                 if not options.tag:
-                    fd.write("* [Version %u.%u](%s/lrm.html) (Development)\n" %
-                             (version["major"],
-                              version["minor"],
-                              URL_BASE))
+                    fd.write(
+                        "* [Version %u.%u](%s/lrm.html) (Development)\n"
+                        % (version["major"], version["minor"], URL_BASE)
+                    )
 
-            fd.write("* [Version %u.%u](%s/lrm-%u.%u.html)" % ((major, minor,
-                                                                URL_BASE,
-                                                                major, minor)))
+            fd.write(
+                "* [Version %u.%u](%s/lrm-%u.%u.html)"
+                % ((major, minor, URL_BASE, major, minor))
+            )
             if first:
                 fd.write(" (Current Stable)")
                 first = False

--- a/trlc/BUILD
+++ b/trlc/BUILD
@@ -1,4 +1,11 @@
+load("@rules_python//python:defs.bzl", "py_library")
 load("@trlc_dependencies//:requirements.bzl", "requirement")
+
+filegroup(
+    name = "py_sources",
+    srcs = glob(["*.py"]),
+    visibility = ["//visibility:public"],
+)
 
 py_library(
     name = "trlc",

--- a/trlc/ast.py
+++ b/trlc/ast.py
@@ -47,6 +47,7 @@ from trlc import math
 # Valuations
 ##############################################################################
 
+
 class Value:
     # lobster-trace: LRM.Boolean_Values
     # lobster-trace: LRM.Integer_Values
@@ -67,23 +68,28 @@ class Value:
     :attribute typ: type of the value (or None for null values)
     :type: Type
     """
+
     def __init__(self, location, value, typ):
         assert isinstance(location, Location)
-        assert value is None or \
-            isinstance(value, (str,
-                               int,
-                               bool,
-                               list,  # for arrays
-                               dict,  # for tuples
-                               Fraction,
-                               Record_Reference,
-                               Enumeration_Literal_Spec))
+        assert value is None or isinstance(
+            value,
+            (
+                str,
+                int,
+                bool,
+                list,  # for arrays
+                dict,  # for tuples
+                Fraction,
+                Record_Reference,
+                Enumeration_Literal_Spec,
+            ),
+        )
         assert typ is None or isinstance(typ, Type)
         assert (typ is None) == (value is None)
 
         self.location = location
-        self.value    = value
-        self.typ      = typ
+        self.value = value
+        self.typ = typ
 
     def __eq__(self, other):
         return self.typ == other.typ and self.value == other.value
@@ -102,12 +108,14 @@ class Value:
 # AST Nodes
 ##############################################################################
 
+
 class Node(metaclass=ABCMeta):
     """Base class for all AST items.
 
     :attribute location: source location
     :type: Location
     """
+
     def __init__(self, location):
         # lobster-exclude: Constructor only declares variables
         assert isinstance(location, Location)
@@ -184,11 +192,12 @@ class Check_Block(Node):
     :type: list[Check]
 
     """
+
     def __init__(self, location, n_typ):
         # lobster-trace: LRM.Check_Block
         super().__init__(location)
         assert isinstance(n_typ, Composite_Type)
-        self.n_typ  = n_typ
+        self.n_typ = n_typ
         self.checks = []
 
     def add_check(self, n_check):
@@ -217,13 +226,14 @@ class Compilation_Unit(Node):
     :type: list[Node]
 
     """
+
     def __init__(self, file_name):
         # lobster-exclude: Constructor only declares variables
         super().__init__(Location(file_name))
-        self.package       = None
-        self.imports       = None
-        self.raw_imports   = []
-        self.items         = []
+        self.package = None
+        self.imports = None
+        self.raw_imports = []
+        self.items = []
 
     def dump(self, indent=0):  # pragma: no cover
         # lobster-exclude: Debugging feature
@@ -246,14 +256,16 @@ class Compilation_Unit(Node):
         assert t_import.kind == "IDENTIFIER"
 
         if t_import.value == self.package.name:
-            mh.error(t_import.location,
-                     "package %s cannot import itself" % self.package.name)
+            mh.error(
+                t_import.location, "package %s cannot import itself" % self.package.name
+            )
 
         # Skip duplicates
         for t_previous in self.raw_imports:
             if t_previous.value == t_import.value:
-                mh.warning(t_import.location,
-                           "duplicate import of package %s" % t_import.value)
+                mh.warning(
+                    t_import.location, "duplicate import of package %s" % t_import.value
+                )
                 return
 
         self.raw_imports.append(t_import)
@@ -282,10 +294,9 @@ class Compilation_Unit(Node):
     def add_item(self, node):
         # lobster-trace: LRM.RSL_File
         # lobster-trace: LRM.TRLC_File
-        assert isinstance(node, (Concrete_Type,
-                                 Check_Block,
-                                 Record_Object)), \
+        assert isinstance(node, (Concrete_Type, Check_Block, Record_Object)), (
             "trying to add %s to a compilation unit" % node.__class__.__name__
+        )
         self.items.append(node)
 
 
@@ -315,13 +326,8 @@ class Check(Node):
     :attribute message: the user-supplied message (see 3)
     :type: str
     """
-    def __init__(self,
-                 n_type,
-                 n_expr,
-                 n_anchor,
-                 severity,
-                 t_message,
-                 extrainfo):
+
+    def __init__(self, n_type, n_expr, n_anchor, severity, t_message, extrainfo):
         # lobster-trace: LRM.Check_Block
         assert isinstance(n_type, Composite_Type)
         assert isinstance(n_expr, Expression)
@@ -332,15 +338,15 @@ class Check(Node):
         assert isinstance(extrainfo, str) or extrainfo is None
         super().__init__(t_message.location)
 
-        self.n_type    = n_type
-        self.n_expr    = n_expr
-        self.n_anchor  = n_anchor
-        self.severity  = severity
+        self.n_type = n_type
+        self.n_expr = n_expr
+        self.n_anchor = n_anchor
+        self.severity = severity
         # lobster-trace: LRM.No_Newlines_In_Message
         # This is the error recovery strategy if we find newlines in
         # the short error messages: we just remove them. The error
         # raised is non-fatal.
-        self.message   = t_message.value.replace("\n", " ")
+        self.message = t_message.value.replace("\n", " ")
         self.extrainfo = extrainfo
         self._uses_field_access = None
 
@@ -377,8 +383,7 @@ class Check(Node):
 
     def get_real_location(self, composite_object):
         # lobster-exclude: LRM.Anchoring
-        assert isinstance(composite_object, (Record_Object,
-                                             Tuple_Aggregate))
+        assert isinstance(composite_object, (Record_Object, Tuple_Aggregate))
         if isinstance(composite_object, Record_Object):
             fields = composite_object.field
         else:
@@ -393,43 +398,44 @@ class Check(Node):
         # lobster-trace: LRM.Check_Messages
         # lobster-trace: LRM.Check_Severity
         assert isinstance(mh, Message_Handler)
-        assert isinstance(composite_object, (Record_Object,
-                                             Tuple_Aggregate))
+        assert isinstance(composite_object, (Record_Object, Tuple_Aggregate))
         assert isinstance(gstab, Symbol_Table)
 
         if isinstance(composite_object, Record_Object):
-            result = self.n_expr.evaluate(mh,
-                                          copy(composite_object.field),
-                                          gstab)
+            result = self.n_expr.evaluate(mh, copy(composite_object.field), gstab)
         else:
-            result = self.n_expr.evaluate(mh,
-                                          copy(composite_object.value),
-                                          gstab)
+            result = self.n_expr.evaluate(mh, copy(composite_object.value), gstab)
         if result.value is None:
             loc = self.get_real_location(composite_object)
-            mh.error(loc,
-                     "check %s (%s) evaluates to null" %
-                     (self.n_expr.to_string(),
-                      mh.cross_file_reference(self.location)))
+            mh.error(
+                loc,
+                "check %s (%s) evaluates to null"
+                % (self.n_expr.to_string(), mh.cross_file_reference(self.location)),
+            )
 
         assert isinstance(result.value, bool)
 
         if not result.value:
             loc = self.get_real_location(composite_object)
             if self.severity == "warning":
-                mh.warning(location    = loc,
-                           message     = self.message,
-                           explanation = self.extrainfo,
-                           user        = True)
+                mh.warning(
+                    location=loc,
+                    message=self.message,
+                    explanation=self.extrainfo,
+                    user=True,
+                )
             else:
-                mh.error(location    = loc,
-                         message     = self.message,
-                         explanation = self.extrainfo,
-                         fatal       = self.severity == "fatal",
-                         user        = True)
+                mh.error(
+                    location=loc,
+                    message=self.message,
+                    explanation=self.extrainfo,
+                    fatal=self.severity == "fatal",
+                    user=True,
+                )
                 return False
 
         return True
+
 
 ##############################################################################
 # AST Nodes (Expressions)
@@ -438,43 +444,43 @@ class Check(Node):
 
 class Unary_Operator(Enum):
     # lobster-exclude: Utility enumeration for unary operators
-    MINUS          = auto()
-    PLUS           = auto()
-    LOGICAL_NOT    = auto()
+    MINUS = auto()
+    PLUS = auto()
+    LOGICAL_NOT = auto()
     ABSOLUTE_VALUE = auto()
 
-    STRING_LENGTH  = auto()
-    ARRAY_LENGTH   = auto()
+    STRING_LENGTH = auto()
+    ARRAY_LENGTH = auto()
 
-    CONVERSION_TO_INT     = auto()
+    CONVERSION_TO_INT = auto()
     CONVERSION_TO_DECIMAL = auto()
 
 
 class Binary_Operator(Enum):
     # lobster-exclude: Utility enumeration for binary operators
-    LOGICAL_AND     = auto()    # Short-circuit
-    LOGICAL_OR      = auto()    # Short-circuit
-    LOGICAL_XOR     = auto()
-    LOGICAL_IMPLIES = auto()    # Short-circuit
+    LOGICAL_AND = auto()  # Short-circuit
+    LOGICAL_OR = auto()  # Short-circuit
+    LOGICAL_XOR = auto()
+    LOGICAL_IMPLIES = auto()  # Short-circuit
 
-    COMP_EQ  = auto()
+    COMP_EQ = auto()
     COMP_NEQ = auto()
-    COMP_LT  = auto()
+    COMP_LT = auto()
     COMP_LEQ = auto()
-    COMP_GT  = auto()
+    COMP_GT = auto()
     COMP_GEQ = auto()
 
-    STRING_CONTAINS   = auto()
+    STRING_CONTAINS = auto()
     STRING_STARTSWITH = auto()
-    STRING_ENDSWITH   = auto()
-    STRING_REGEX      = auto()
+    STRING_ENDSWITH = auto()
+    STRING_REGEX = auto()
 
     ARRAY_CONTAINS = auto()
 
-    PLUS      = auto()
-    MINUS     = auto()
-    TIMES     = auto()
-    DIVIDE    = auto()
+    PLUS = auto()
+    MINUS = auto()
+    TIMES = auto()
+    DIVIDE = auto()
     REMAINDER = auto()
 
     POWER = auto()
@@ -488,6 +494,7 @@ class Expression(Node, metaclass=ABCMeta):
     :attribute typ: The type of this expression (or None for null values)
     :type: Type
     """
+
     def __init__(self, location, typ):
         # lobster-exclude: Constructor only declares variables
         super().__init__(location)
@@ -518,13 +525,11 @@ class Expression(Node, metaclass=ABCMeta):
         assert isinstance(mh, Message_Handler)
         assert context is None or isinstance(context, dict)
         assert gstab is None or isinstance(gstab, Symbol_Table)
-        assert False, "evaluate not implemented for %s" % \
-            self.__class__.__name__
+        assert False, "evaluate not implemented for %s" % self.__class__.__name__
 
     @abstractmethod
     def to_string(self):  # pragma: no cover
-        assert False, "to_string not implemented for %s" % \
-            self.__class__.__name__
+        assert False, "to_string not implemented for %s" % self.__class__.__name__
 
     def ensure_type(self, mh, typ):
         # lobster-trace: LRM.Restricted_Null
@@ -532,18 +537,19 @@ class Expression(Node, metaclass=ABCMeta):
 
         assert isinstance(typ, (type, Type))
         if self.typ is None:
-            mh.error(self.location,
-                     "null is not permitted here")
+            mh.error(self.location, "null is not permitted here")
         elif isinstance(typ, type) and not isinstance(self.typ, typ):
-            mh.error(self.location,
-                     "expected expression of type %s, got %s instead" %
-                     (typ.__name__,
-                      self.typ.__class__.__name__))
+            mh.error(
+                self.location,
+                "expected expression of type %s, got %s instead"
+                % (typ.__name__, self.typ.__class__.__name__),
+            )
         elif isinstance(typ, Type) and self.typ != typ:
-            mh.error(self.location,
-                     "expected expression of type %s, got %s instead" %
-                     (typ.name,
-                      self.typ.name))
+            mh.error(
+                self.location,
+                "expected expression of type %s, got %s instead"
+                % (typ.name, self.typ.name),
+            )
 
     def resolve_references(self, mh):
         assert isinstance(mh, Message_Handler)
@@ -562,8 +568,7 @@ class Expression(Node, metaclass=ABCMeta):
         :rtype: bool
 
         """
-        assert False, "can_be_null not implemented for %s" % \
-            self.__class__.__name__
+        assert False, "can_be_null not implemented for %s" % self.__class__.__name__
 
     def uses_field_access(self):
         """Test if this expression contains a field access on a record or
@@ -608,10 +613,10 @@ class Implicit_Null(Expression):
     that can appear in check expressions.
 
     """
+
     def __init__(self, composite_object, composite_component):
         # lobster-trace: LRM.Unspecified_Optional_Components
-        assert isinstance(composite_object, (Record_Object,
-                                             Tuple_Aggregate))
+        assert isinstance(composite_object, (Record_Object, Tuple_Aggregate))
         assert isinstance(composite_component, Composite_Component)
         super().__init__(composite_object.location, None)
 
@@ -646,6 +651,7 @@ class Literal(Expression, metaclass=ABCMeta):
       isinstance(my_expression, Literal)
 
     """
+
     @abstractmethod
     def to_python_object(self):
         assert False
@@ -664,6 +670,7 @@ class Null_Literal(Literal):
     values that appear in record objects.
 
     """
+
     def __init__(self, token):
         assert isinstance(token, Token)
         assert token.kind == "KEYWORD"
@@ -710,6 +717,7 @@ class Integer_Literal(Literal):
     :attribute value: the non-negative integer value
     :type: int
     """
+
     def __init__(self, token, typ):
         assert isinstance(token, Token)
         assert token.kind == "INTEGER"
@@ -758,6 +766,7 @@ class Decimal_Literal(Literal):
     :attribute value: the non-negative decimal value
     :type: fractions.Fraction
     """
+
     def __init__(self, token, typ):
         assert isinstance(token, Token)
         assert token.kind == "DECIMAL"
@@ -805,15 +814,16 @@ class String_Literal(Literal):
     :type: list[Record_Reference]
 
     """
+
     def __init__(self, token, typ):
         assert isinstance(token, Token)
         assert token.kind == "STRING"
         assert isinstance(typ, Builtin_String)
         super().__init__(token.location, typ)
 
-        self.value          = token.value
+        self.value = token.value
         self.has_references = isinstance(typ, Builtin_Markup_String)
-        self.references     = []
+        self.references = []
 
     def dump(self, indent=0):  # pragma: no cover
         self.write_indent(indent, f"String Literal {repr(self.value)}")
@@ -851,6 +861,7 @@ class Boolean_Literal(Literal):
     :attribute value: the boolean value
     :type: bool
     """
+
     def __init__(self, token, typ):
         assert isinstance(token, Token)
         assert token.kind == "KEYWORD"
@@ -899,6 +910,7 @@ class Enumeration_Literal(Literal):
     :type: Enumeration_Literal_Spec
 
     """
+
     def __init__(self, location, literal):
         # lobster-exclude: Constructor only declares variables
         assert isinstance(literal, Enumeration_Literal_Spec)
@@ -908,8 +920,9 @@ class Enumeration_Literal(Literal):
 
     def dump(self, indent=0):  # pragma: no cover
         # lobster-exclude: Debugging feature
-        self.write_indent(indent,
-                          f"Enumeration Literal {self.typ.name}.{self.value.name}")
+        self.write_indent(
+            indent, f"Enumeration Literal {self.typ.name}.{self.value.name}"
+        )
 
     def to_string(self):
         return self.typ.name + "." + self.value.name
@@ -946,6 +959,7 @@ class Array_Aggregate(Expression):
     :type: list[Expression]
 
     """
+
     def __init__(self, location, typ):
         # lobster-trace: LRM.Record_Object_Declaration
 
@@ -959,11 +973,16 @@ class Array_Aggregate(Expression):
             n_value.dump(indent + 1)
 
     def append(self, value):
-        assert isinstance(value, (Literal,
-                                  Unary_Expression,
-                                  Array_Aggregate,
-                                  Tuple_Aggregate,
-                                  Record_Reference))
+        assert isinstance(
+            value,
+            (
+                Literal,
+                Unary_Expression,
+                Array_Aggregate,
+                Tuple_Aggregate,
+                Record_Reference,
+            ),
+        )
         self.value.append(value)
 
     def to_string(self):
@@ -973,10 +992,11 @@ class Array_Aggregate(Expression):
         assert isinstance(mh, Message_Handler)
         assert context is None or isinstance(context, dict)
         assert gstab is None or isinstance(gstab, Symbol_Table)
-        return Value(self.location,
-                     list(element.evaluate(mh, context, gstab)
-                          for element in self.value),
-                     self.typ)
+        return Value(
+            self.location,
+            list(element.evaluate(mh, context, gstab) for element in self.value),
+            self.typ,
+        )
 
     def resolve_references(self, mh):
         assert isinstance(mh, Message_Handler)
@@ -1015,21 +1035,22 @@ class Tuple_Aggregate(Expression):
     :type: dict[str, Expression]
 
     """
+
     def __init__(self, location, typ):
         # lobster-trace: LRM.Unspecified_Optional_Components
         # lobster-trace: LRM.Record_Object_Declaration
 
         super().__init__(location, typ)
-        self.value = {n_field.name : Implicit_Null(self, n_field)
-                      for n_field in self.typ.components.values()}
+        self.value = {
+            n_field.name: Implicit_Null(self, n_field)
+            for n_field in self.typ.components.values()
+        }
 
     def assign(self, field, value):
         assert isinstance(field, str)
-        assert isinstance(value, (Literal,
-                                  Unary_Expression,
-                                  Tuple_Aggregate,
-                                  Record_Reference)), \
-                "value is %s" % value.__class__.__name__
+        assert isinstance(
+            value, (Literal, Unary_Expression, Tuple_Aggregate, Record_Reference)
+        ), "value is %s" % value.__class__.__name__
         assert field in self.typ.components
 
         self.value[field] = value
@@ -1068,10 +1089,14 @@ class Tuple_Aggregate(Expression):
         assert isinstance(mh, Message_Handler)
         assert context is None or isinstance(context, dict)
         assert gstab is None or isinstance(gstab, Symbol_Table)
-        return Value(self.location,
-                     {name : element.evaluate(mh, context, gstab)
-                      for name, element in self.value.items()},
-                     self.typ)
+        return Value(
+            self.location,
+            {
+                name: element.evaluate(mh, context, gstab)
+                for name, element in self.value.items()
+            },
+            self.typ,
+        )
 
     def resolve_references(self, mh):
         assert isinstance(mh, Message_Handler)
@@ -1080,15 +1105,13 @@ class Tuple_Aggregate(Expression):
             val.resolve_references(mh)
 
     def to_python_object(self):
-        return {name: value.to_python_object()
-                for name, value in self.value.items()}
+        return {name: value.to_python_object() for name, value in self.value.items()}
 
     def can_be_null(self):
         return False
 
     def uses_field_access(self):
-        return any(expr.uses_field_access()
-                   for expr in self.value.values())
+        return any(expr.uses_field_access() for expr in self.value.values())
 
 
 class Record_Reference(Expression):
@@ -1122,6 +1145,7 @@ class Record_Reference(Expression):
     :type: Package
 
     """
+
     def __init__(self, location, name, typ, package):
         # lobster-exclude: Constructor only declares variables
         assert isinstance(location, Location)
@@ -1130,15 +1154,14 @@ class Record_Reference(Expression):
         assert isinstance(package, Package)
         super().__init__(location, typ)
 
-        self.name    = name
-        self.target  = None
+        self.name = name
+        self.target = None
         self.package = package
 
     def dump(self, indent=0):  # pragma: no cover
         # lobster-exclude: Debugging feature
         self.write_indent(indent, f"Record Reference {self.name}")
-        self.write_indent(indent + 1,
-                          f"Resolved: {self.target is not None}")
+        self.write_indent(indent + 1, f"Resolved: {self.target is not None}")
 
     def to_string(self):
         return self.name
@@ -1155,26 +1178,27 @@ class Record_Reference(Expression):
         assert isinstance(mh, Message_Handler)
 
         self.target = self.package.symbols.lookup_direct(
-            mh                = mh,
-            name              = self.name,
-            error_location    = self.location,
-            required_subclass = Record_Object)
+            mh=mh,
+            name=self.name,
+            error_location=self.location,
+            required_subclass=Record_Object,
+        )
         if self.typ is None:
             self.typ = self.target.n_typ
         elif isinstance(self.typ, Union_Type):
             if not self.typ.is_compatible(self.target.n_typ):
-                mh.error(self.location,
-                         "expected reference of type %s,"
-                         " but %s is of type %s" %
-                         (self.typ.name,
-                          self.target.name,
-                          self.target.n_typ.name))
+                mh.error(
+                    self.location,
+                    "expected reference of type %s,"
+                    " but %s is of type %s"
+                    % (self.typ.name, self.target.name, self.target.n_typ.name),
+                )
         elif not self.target.n_typ.is_subclass_of(self.typ):
-            mh.error(self.location,
-                     "expected reference of type %s, but %s is of type %s" %
-                     (self.typ.name,
-                      self.target.name,
-                      self.target.n_typ.name))
+            mh.error(
+                self.location,
+                "expected reference of type %s, but %s is of type %s"
+                % (self.typ.name, self.target.name, self.target.n_typ.name),
+            )
 
     def to_python_object(self):
         return self.target.fully_qualified_name()
@@ -1205,9 +1229,9 @@ class Name_Reference(Expression):
     :attribute entity: the entity named here
     :type: Composite_Component, Quantified_Variable
     """
+
     def __init__(self, location, entity):
-        assert isinstance(entity, (Composite_Component,
-                                   Quantified_Variable))
+        assert isinstance(entity, (Composite_Component, Quantified_Variable))
         super().__init__(location, entity.n_typ)
         self.entity = entity
 
@@ -1223,8 +1247,7 @@ class Name_Reference(Expression):
         assert gstab is None or isinstance(gstab, Symbol_Table)
 
         if context is None:
-            mh.error(self.location,
-                     "cannot be used in a static context")
+            mh.error(self.location, "cannot be used in a static context")
 
         assert self.entity.name in context
         return context[self.entity.name].evaluate(mh, context, gstab)
@@ -1262,6 +1285,7 @@ class Unary_Expression(Expression):
     :type: Expression
 
     """
+
     def __init__(self, mh, location, typ, operator, n_operand):
         # lobster-trace: LRM.Simple_Expression
         # lobster-trace: LRM.Relation
@@ -1273,12 +1297,14 @@ class Unary_Expression(Expression):
         assert isinstance(mh, Message_Handler)
         assert isinstance(operator, Unary_Operator)
         assert isinstance(n_operand, Expression)
-        self.operator  = operator
+        self.operator = operator
         self.n_operand = n_operand
 
-        if operator in (Unary_Operator.MINUS,
-                        Unary_Operator.PLUS,
-                        Unary_Operator.ABSOLUTE_VALUE):
+        if operator in (
+            Unary_Operator.MINUS,
+            Unary_Operator.PLUS,
+            Unary_Operator.ABSOLUTE_VALUE,
+        ):
             self.n_operand.ensure_type(mh, Builtin_Numeric_Type)
         elif operator == Unary_Operator.LOGICAL_NOT:
             self.n_operand.ensure_type(mh, Builtin_Boolean)
@@ -1291,30 +1317,30 @@ class Unary_Expression(Expression):
         elif operator == Unary_Operator.CONVERSION_TO_DECIMAL:
             self.n_operand.ensure_type(mh, Builtin_Numeric_Type)
         else:
-            mh.ice_loc(self.location,
-                       "unexpected unary operation %s" % operator)
+            mh.ice_loc(self.location, "unexpected unary operation %s" % operator)
 
     def to_string(self):
         prefix_operators = {
-            Unary_Operator.MINUS          : "-",
-            Unary_Operator.PLUS           : "+",
-            Unary_Operator.ABSOLUTE_VALUE : "abs ",
-            Unary_Operator.LOGICAL_NOT    : "not ",
+            Unary_Operator.MINUS: "-",
+            Unary_Operator.PLUS: "+",
+            Unary_Operator.ABSOLUTE_VALUE: "abs ",
+            Unary_Operator.LOGICAL_NOT: "not ",
         }
         function_calls = {
-            Unary_Operator.STRING_LENGTH         : "len",
-            Unary_Operator.ARRAY_LENGTH          : "len",
-            Unary_Operator.CONVERSION_TO_INT     : "Integer",
-            Unary_Operator.CONVERSION_TO_DECIMAL : "Decimal"
+            Unary_Operator.STRING_LENGTH: "len",
+            Unary_Operator.ARRAY_LENGTH: "len",
+            Unary_Operator.CONVERSION_TO_INT: "Integer",
+            Unary_Operator.CONVERSION_TO_DECIMAL: "Decimal",
         }
 
         if self.operator in prefix_operators:
-            return prefix_operators[self.operator] + \
-                self.n_operand.to_string()
+            return prefix_operators[self.operator] + self.n_operand.to_string()
 
         elif self.operator in function_calls:
-            return "%s(%s)" % (function_calls[self.operator],
-                               self.n_operand.to_string())
+            return "%s(%s)" % (
+                function_calls[self.operator],
+                self.n_operand.to_string(),
+            )
 
         else:
             assert False
@@ -1339,53 +1365,51 @@ class Unary_Expression(Expression):
 
         v_operand = self.n_operand.evaluate(mh, context, gstab)
         if v_operand.value is None:
-            mh.error(v_operand.location,
-                     "input to unary expression %s (%s) must not be null" %
-                     (self.to_string(),
-                      mh.cross_file_reference(self.location)))
+            mh.error(
+                v_operand.location,
+                "input to unary expression %s (%s) must not be null"
+                % (self.to_string(), mh.cross_file_reference(self.location)),
+            )
 
         if self.operator == Unary_Operator.MINUS:
-            return Value(location = self.location,
-                         value    = -v_operand.value,
-                         typ      = self.typ)
+            return Value(location=self.location, value=-v_operand.value, typ=self.typ)
         elif self.operator == Unary_Operator.PLUS:
-            return Value(location = self.location,
-                         value    = +v_operand.value,
-                         typ      = self.typ)
+            return Value(location=self.location, value=+v_operand.value, typ=self.typ)
         elif self.operator == Unary_Operator.LOGICAL_NOT:
-            return Value(location = self.location,
-                         value    = not v_operand.value,
-                         typ      = self.typ)
+            return Value(
+                location=self.location, value=not v_operand.value, typ=self.typ
+            )
         elif self.operator == Unary_Operator.ABSOLUTE_VALUE:
-            return Value(location = self.location,
-                         value    = abs(v_operand.value),
-                         typ      = self.typ)
-        elif self.operator in (Unary_Operator.STRING_LENGTH,
-                               Unary_Operator.ARRAY_LENGTH):
-            return Value(location = self.location,
-                         value    = len(v_operand.value),
-                         typ      = self.typ)
+            return Value(
+                location=self.location, value=abs(v_operand.value), typ=self.typ
+            )
+        elif self.operator in (
+            Unary_Operator.STRING_LENGTH,
+            Unary_Operator.ARRAY_LENGTH,
+        ):
+            return Value(
+                location=self.location, value=len(v_operand.value), typ=self.typ
+            )
         elif self.operator == Unary_Operator.CONVERSION_TO_INT:
             if isinstance(v_operand.value, Fraction):
                 return Value(
-                    location = self.location,
-                    value    = math.round_nearest_away(v_operand.value),
-                    typ      = self.typ)
+                    location=self.location,
+                    value=math.round_nearest_away(v_operand.value),
+                    typ=self.typ,
+                )
             else:
-                return Value(location = self.location,
-                             value    = v_operand.value,
-                             typ      = self.typ)
+                return Value(
+                    location=self.location, value=v_operand.value, typ=self.typ
+                )
         elif self.operator == Unary_Operator.CONVERSION_TO_DECIMAL:
-            return Value(location = self.location,
-                         value    = Fraction(v_operand.value),
-                         typ      = self.typ)
+            return Value(
+                location=self.location, value=Fraction(v_operand.value), typ=self.typ
+            )
         else:
-            mh.ice_loc(self.location,
-                       "unexpected unary operation %s" % self.operator)
+            mh.ice_loc(self.location, "unexpected unary operation %s" % self.operator)
 
     def to_python_object(self):
-        assert self.operator in (Unary_Operator.MINUS,
-                                 Unary_Operator.PLUS)
+        assert self.operator in (Unary_Operator.MINUS, Unary_Operator.PLUS)
         val = self.n_operand.to_python_object()
         if self.operator == Unary_Operator.MINUS:
             return -val
@@ -1442,6 +1466,7 @@ class Binary_Expression(Expression):
     :type: Expression
 
     """
+
     def __init__(self, mh, location, typ, operator, n_lhs, n_rhs):
         # lobster-trace: LRM.Expression
         # lobster-trace: LRM.Relation
@@ -1457,73 +1482,86 @@ class Binary_Expression(Expression):
         assert isinstance(n_lhs, Expression)
         assert isinstance(n_rhs, Expression)
         self.operator = operator
-        self.n_lhs    = n_lhs
-        self.n_rhs    = n_rhs
+        self.n_lhs = n_lhs
+        self.n_rhs = n_rhs
 
-        if operator in (Binary_Operator.LOGICAL_AND,
-                        Binary_Operator.LOGICAL_OR,
-                        Binary_Operator.LOGICAL_XOR,
-                        Binary_Operator.LOGICAL_IMPLIES):
+        if operator in (
+            Binary_Operator.LOGICAL_AND,
+            Binary_Operator.LOGICAL_OR,
+            Binary_Operator.LOGICAL_XOR,
+            Binary_Operator.LOGICAL_IMPLIES,
+        ):
             self.n_lhs.ensure_type(mh, Builtin_Boolean)
             self.n_rhs.ensure_type(mh, Builtin_Boolean)
 
-        elif operator in (Binary_Operator.COMP_EQ,
-                          Binary_Operator.COMP_NEQ):
+        elif operator in (Binary_Operator.COMP_EQ, Binary_Operator.COMP_NEQ):
             # lobster-trace: LRM.Union_Type_Equality
             # lobster-trace: LRM.Union_Type_Equality_Domain
             if (self.n_lhs.typ is None) or (self.n_rhs.typ is None):
                 # We can compary anything to null (including itself)
                 pass
-            elif isinstance(self.n_lhs.typ, Union_Type) or \
-                 isinstance(self.n_rhs.typ, Union_Type):
+            elif isinstance(self.n_lhs.typ, Union_Type) or isinstance(
+                self.n_rhs.typ, Union_Type
+            ):
                 # For union types, we allow comparison if both
                 # sides are record-like (Record_Type or Union_Type)
-                lhs_is_record = isinstance(self.n_lhs.typ,
-                                           (Record_Type, Union_Type))
-                rhs_is_record = isinstance(self.n_rhs.typ,
-                                           (Record_Type, Union_Type))
+                lhs_is_record = isinstance(self.n_lhs.typ, (Record_Type, Union_Type))
+                rhs_is_record = isinstance(self.n_rhs.typ, (Record_Type, Union_Type))
                 if not (lhs_is_record and rhs_is_record):
-                    mh.error(self.location,
-                             "type mismatch: %s and %s do not match" %
-                             (self.n_lhs.typ.name,
-                              self.n_rhs.typ.name))
+                    mh.error(
+                        self.location,
+                        "type mismatch: %s and %s do not match"
+                        % (self.n_lhs.typ.name, self.n_rhs.typ.name),
+                    )
                 else:
                     # Check that there is at least one pair of member
                     # types (one from each side) where one is a subtype
                     # of the other. This implements Equality_Domain for
                     # union types: an unrelated record type is rejected.
-                    lhs_members = (self.n_lhs.typ.types
-                                   if isinstance(self.n_lhs.typ, Union_Type)
-                                   else [self.n_lhs.typ])
-                    rhs_members = (self.n_rhs.typ.types
-                                   if isinstance(self.n_rhs.typ, Union_Type)
-                                   else [self.n_rhs.typ])
-                    if not any(lm.is_subclass_of(rm) or rm.is_subclass_of(lm)
-                               for lm in lhs_members
-                               for rm in rhs_members):
-                        mh.error(self.location,
-                                 "type mismatch: %s and %s do not match" %
-                                 (self.n_lhs.typ.name,
-                                  self.n_rhs.typ.name))
+                    lhs_members = (
+                        self.n_lhs.typ.types
+                        if isinstance(self.n_lhs.typ, Union_Type)
+                        else [self.n_lhs.typ]
+                    )
+                    rhs_members = (
+                        self.n_rhs.typ.types
+                        if isinstance(self.n_rhs.typ, Union_Type)
+                        else [self.n_rhs.typ]
+                    )
+                    if not any(
+                        lm.is_subclass_of(rm) or rm.is_subclass_of(lm)
+                        for lm in lhs_members
+                        for rm in rhs_members
+                    ):
+                        mh.error(
+                            self.location,
+                            "type mismatch: %s and %s do not match"
+                            % (self.n_lhs.typ.name, self.n_rhs.typ.name),
+                        )
             elif self.n_lhs.typ != self.n_rhs.typ:
                 # Otherwise we can compare anything, as long as the
                 # types match
-                mh.error(self.location,
-                         "type mismatch: %s and %s do not match" %
-                         (self.n_lhs.typ.name,
-                          self.n_rhs.typ.name))
+                mh.error(
+                    self.location,
+                    "type mismatch: %s and %s do not match"
+                    % (self.n_lhs.typ.name, self.n_rhs.typ.name),
+                )
 
-        elif operator in (Binary_Operator.COMP_LT,
-                          Binary_Operator.COMP_LEQ,
-                          Binary_Operator.COMP_GT,
-                          Binary_Operator.COMP_GEQ):
+        elif operator in (
+            Binary_Operator.COMP_LT,
+            Binary_Operator.COMP_LEQ,
+            Binary_Operator.COMP_GT,
+            Binary_Operator.COMP_GEQ,
+        ):
             self.n_lhs.ensure_type(mh, Builtin_Numeric_Type)
             self.n_rhs.ensure_type(mh, self.n_lhs.typ)
 
-        elif operator in (Binary_Operator.STRING_CONTAINS,
-                          Binary_Operator.STRING_STARTSWITH,
-                          Binary_Operator.STRING_ENDSWITH,
-                          Binary_Operator.STRING_REGEX):
+        elif operator in (
+            Binary_Operator.STRING_CONTAINS,
+            Binary_Operator.STRING_STARTSWITH,
+            Binary_Operator.STRING_ENDSWITH,
+            Binary_Operator.STRING_REGEX,
+        ):
             self.n_lhs.ensure_type(mh, Builtin_String)
             self.n_rhs.ensure_type(mh, Builtin_String)
 
@@ -1538,9 +1576,11 @@ class Binary_Expression(Expression):
                 self.n_lhs.ensure_type(mh, Builtin_String)
                 self.n_rhs.ensure_type(mh, Builtin_String)
 
-        elif operator in (Binary_Operator.MINUS,
-                          Binary_Operator.TIMES,
-                          Binary_Operator.DIVIDE):
+        elif operator in (
+            Binary_Operator.MINUS,
+            Binary_Operator.TIMES,
+            Binary_Operator.DIVIDE,
+        ):
             self.n_lhs.ensure_type(mh, Builtin_Numeric_Type)
             self.n_rhs.ensure_type(mh, self.n_lhs.typ)
 
@@ -1557,8 +1597,7 @@ class Binary_Expression(Expression):
             self.n_rhs.ensure_type(mh, Builtin_Integer)
 
         else:
-            mh.ice_loc(self.location,
-                       "unexpected binary operation %s" % operator)
+            mh.ice_loc(self.location, "unexpected binary operation %s" % operator)
 
     def dump(self, indent=0):  # pragma: no cover
         # lobster-exclude: Debugging feature
@@ -1569,44 +1608,47 @@ class Binary_Expression(Expression):
 
     def to_string(self):
         infix_operators = {
-            Binary_Operator.LOGICAL_AND     : "and",
-            Binary_Operator.LOGICAL_OR      : "or",
-            Binary_Operator.LOGICAL_XOR     : "xor",
-            Binary_Operator.LOGICAL_IMPLIES : "implies",
-            Binary_Operator.COMP_EQ         : "==",
-            Binary_Operator.COMP_NEQ        : "!=",
-            Binary_Operator.COMP_LT         : "<",
-            Binary_Operator.COMP_LEQ        : "<=",
-            Binary_Operator.COMP_GT         : ">",
-            Binary_Operator.COMP_GEQ        : ">=",
-            Binary_Operator.STRING_CONTAINS : "in",
-            Binary_Operator.ARRAY_CONTAINS  : "in",
-            Binary_Operator.PLUS            : "+",
-            Binary_Operator.MINUS           : "-",
-            Binary_Operator.TIMES           : "*",
-            Binary_Operator.DIVIDE          : "/",
-            Binary_Operator.REMAINDER       : "%",
-            Binary_Operator.POWER           : "**",
+            Binary_Operator.LOGICAL_AND: "and",
+            Binary_Operator.LOGICAL_OR: "or",
+            Binary_Operator.LOGICAL_XOR: "xor",
+            Binary_Operator.LOGICAL_IMPLIES: "implies",
+            Binary_Operator.COMP_EQ: "==",
+            Binary_Operator.COMP_NEQ: "!=",
+            Binary_Operator.COMP_LT: "<",
+            Binary_Operator.COMP_LEQ: "<=",
+            Binary_Operator.COMP_GT: ">",
+            Binary_Operator.COMP_GEQ: ">=",
+            Binary_Operator.STRING_CONTAINS: "in",
+            Binary_Operator.ARRAY_CONTAINS: "in",
+            Binary_Operator.PLUS: "+",
+            Binary_Operator.MINUS: "-",
+            Binary_Operator.TIMES: "*",
+            Binary_Operator.DIVIDE: "/",
+            Binary_Operator.REMAINDER: "%",
+            Binary_Operator.POWER: "**",
         }
         string_functions = {
-            Binary_Operator.STRING_STARTSWITH : "startswith",
-            Binary_Operator.STRING_ENDSWITH   : "endswith",
-            Binary_Operator.STRING_REGEX      : "matches",
+            Binary_Operator.STRING_STARTSWITH: "startswith",
+            Binary_Operator.STRING_ENDSWITH: "endswith",
+            Binary_Operator.STRING_REGEX: "matches",
         }
 
         if self.operator in infix_operators:
-            return "%s %s %s" % (self.n_lhs.to_string(),
-                                 infix_operators[self.operator],
-                                 self.n_rhs.to_string())
+            return "%s %s %s" % (
+                self.n_lhs.to_string(),
+                infix_operators[self.operator],
+                self.n_rhs.to_string(),
+            )
 
         elif self.operator in string_functions:
-            return "%s(%s, %s)" % (string_functions[self.operator],
-                                   self.n_lhs.to_string(),
-                                   self.n_rhs.to_string())
+            return "%s(%s, %s)" % (
+                string_functions[self.operator],
+                self.n_lhs.to_string(),
+                self.n_rhs.to_string(),
+            )
 
         elif self.operator == Binary_Operator.INDEX:
-            return "%s[%s]" % (self.n_lhs.to_string(),
-                               self.n_rhs.to_string())
+            return "%s[%s]" % (self.n_lhs.to_string(), self.n_rhs.to_string())
 
         else:
             assert False
@@ -1625,13 +1667,15 @@ class Binary_Expression(Expression):
         assert gstab is None or isinstance(gstab, Symbol_Table)
 
         v_lhs = self.n_lhs.evaluate(mh, context, gstab)
-        if v_lhs.value is None and \
-           self.operator not in (Binary_Operator.COMP_EQ,
-                                 Binary_Operator.COMP_NEQ):
-            mh.error(v_lhs.location,
-                     "lhs of check %s (%s) must not be null" %
-                     (self.to_string(),
-                      mh.cross_file_reference(self.location)))
+        if v_lhs.value is None and self.operator not in (
+            Binary_Operator.COMP_EQ,
+            Binary_Operator.COMP_NEQ,
+        ):
+            mh.error(
+                v_lhs.location,
+                "lhs of check %s (%s) must not be null"
+                % (self.to_string(), mh.cross_file_reference(self.location)),
+            )
 
         # Check for the short-circuit operators first
         if self.operator == Binary_Operator.LOGICAL_AND:
@@ -1653,185 +1697,209 @@ class Binary_Expression(Expression):
             if v_lhs.value:
                 return self.n_rhs.evaluate(mh, context, gstab)
             else:
-                return Value(location = self.location,
-                             value    = True,
-                             typ      = self.typ)
+                return Value(location=self.location, value=True, typ=self.typ)
 
         # Otherwise, evaluate RHS and do the operation
         v_rhs = self.n_rhs.evaluate(mh, context, gstab)
-        if v_rhs.value is None and \
-           self.operator not in (Binary_Operator.COMP_EQ,
-                                 Binary_Operator.COMP_NEQ):
-            mh.error(v_rhs.location,
-                     "rhs of check %s (%s) must not be null" %
-                     (self.to_string(),
-                      mh.cross_file_reference(self.location)))
+        if v_rhs.value is None and self.operator not in (
+            Binary_Operator.COMP_EQ,
+            Binary_Operator.COMP_NEQ,
+        ):
+            mh.error(
+                v_rhs.location,
+                "rhs of check %s (%s) must not be null"
+                % (self.to_string(), mh.cross_file_reference(self.location)),
+            )
 
         if self.operator == Binary_Operator.LOGICAL_XOR:
             assert isinstance(v_lhs.value, bool)
             assert isinstance(v_rhs.value, bool)
-            return Value(location = self.location,
-                         value    = v_lhs.value ^ v_rhs.value,
-                         typ      = self.typ)
+            return Value(
+                location=self.location, value=v_lhs.value ^ v_rhs.value, typ=self.typ
+            )
 
         elif self.operator == Binary_Operator.COMP_EQ:
-            return Value(location = self.location,
-                         value    = v_lhs.value == v_rhs.value,
-                         typ      = self.typ)
+            return Value(
+                location=self.location, value=v_lhs.value == v_rhs.value, typ=self.typ
+            )
 
         elif self.operator == Binary_Operator.COMP_NEQ:
-            return Value(location = self.location,
-                         value    = v_lhs.value != v_rhs.value,
-                         typ      = self.typ)
-
-        elif self.operator in (Binary_Operator.COMP_LT,
-                               Binary_Operator.COMP_LEQ,
-                               Binary_Operator.COMP_GT,
-                               Binary_Operator.COMP_GEQ):
             return Value(
-                location = self.location,
-                value    = {
-                    Binary_Operator.COMP_LT  : lambda lhs, rhs: lhs < rhs,
-                    Binary_Operator.COMP_LEQ : lambda lhs, rhs: lhs <= rhs,
-                    Binary_Operator.COMP_GT  : lambda lhs, rhs: lhs > rhs,
-                    Binary_Operator.COMP_GEQ : lambda lhs, rhs: lhs >= rhs,
+                location=self.location, value=v_lhs.value != v_rhs.value, typ=self.typ
+            )
+
+        elif self.operator in (
+            Binary_Operator.COMP_LT,
+            Binary_Operator.COMP_LEQ,
+            Binary_Operator.COMP_GT,
+            Binary_Operator.COMP_GEQ,
+        ):
+            return Value(
+                location=self.location,
+                value={
+                    Binary_Operator.COMP_LT: lambda lhs, rhs: lhs < rhs,
+                    Binary_Operator.COMP_LEQ: lambda lhs, rhs: lhs <= rhs,
+                    Binary_Operator.COMP_GT: lambda lhs, rhs: lhs > rhs,
+                    Binary_Operator.COMP_GEQ: lambda lhs, rhs: lhs >= rhs,
                 }[self.operator](v_lhs.value, v_rhs.value),
-                typ      = self.typ)
+                typ=self.typ,
+            )
 
         elif self.operator == Binary_Operator.STRING_CONTAINS:
             assert isinstance(v_lhs.value, str)
             assert isinstance(v_rhs.value, str)
 
-            return Value(location = self.location,
-                         value    = v_lhs.value in v_rhs.value,
-                         typ      = self.typ)
+            return Value(
+                location=self.location, value=v_lhs.value in v_rhs.value, typ=self.typ
+            )
 
         elif self.operator == Binary_Operator.STRING_STARTSWITH:
             assert isinstance(v_lhs.value, str)
             assert isinstance(v_rhs.value, str)
-            return Value(location = self.location,
-                         value    = v_lhs.value.startswith(v_rhs.value),
-                         typ      = self.typ)
+            return Value(
+                location=self.location,
+                value=v_lhs.value.startswith(v_rhs.value),
+                typ=self.typ,
+            )
 
         elif self.operator == Binary_Operator.STRING_ENDSWITH:
             assert isinstance(v_lhs.value, str)
             assert isinstance(v_rhs.value, str)
-            return Value(location = self.location,
-                         value    = v_lhs.value.endswith(v_rhs.value),
-                         typ      = self.typ)
+            return Value(
+                location=self.location,
+                value=v_lhs.value.endswith(v_rhs.value),
+                typ=self.typ,
+            )
 
         elif self.operator == Binary_Operator.STRING_REGEX:
             assert isinstance(v_lhs.value, str)
             assert isinstance(v_rhs.value, str)
-            return Value(location = self.location,
-                         value    = re.match(v_rhs.value,
-                                             v_lhs.value) is not None,
-                         typ      = self.typ)
+            return Value(
+                location=self.location,
+                value=re.match(v_rhs.value, v_lhs.value) is not None,
+                typ=self.typ,
+            )
 
         elif self.operator == Binary_Operator.ARRAY_CONTAINS:
             assert isinstance(v_rhs.value, list)
 
-            return Value(location = self.location,
-                         value    = v_lhs in v_rhs.value,
-                         typ      = self.typ)
+            return Value(
+                location=self.location, value=v_lhs in v_rhs.value, typ=self.typ
+            )
 
         elif self.operator == Binary_Operator.PLUS:
             assert isinstance(v_lhs.value, (int, str, Fraction))
             assert isinstance(v_rhs.value, (int, str, Fraction))
-            return Value(location = self.location,
-                         value    = v_lhs.value + v_rhs.value,
-                         typ      = self.typ)
+            return Value(
+                location=self.location, value=v_lhs.value + v_rhs.value, typ=self.typ
+            )
 
         elif self.operator == Binary_Operator.MINUS:
             assert isinstance(v_lhs.value, (int, Fraction))
             assert isinstance(v_rhs.value, (int, Fraction))
-            return Value(location = self.location,
-                         value    = v_lhs.value - v_rhs.value,
-                         typ      = self.typ)
+            return Value(
+                location=self.location, value=v_lhs.value - v_rhs.value, typ=self.typ
+            )
 
         elif self.operator == Binary_Operator.TIMES:
             assert isinstance(v_lhs.value, (int, Fraction))
             assert isinstance(v_rhs.value, (int, Fraction))
-            return Value(location = self.location,
-                         value    = v_lhs.value * v_rhs.value,
-                         typ      = self.typ)
+            return Value(
+                location=self.location, value=v_lhs.value * v_rhs.value, typ=self.typ
+            )
 
         elif self.operator == Binary_Operator.DIVIDE:
             assert isinstance(v_lhs.value, (int, Fraction))
             assert isinstance(v_rhs.value, (int, Fraction))
 
             if v_rhs.value == 0:
-                mh.error(v_rhs.location,
-                         "division by zero in %s (%s)" %
-                         (self.to_string(),
-                          mh.cross_file_reference(self.location)))
+                mh.error(
+                    v_rhs.location,
+                    "division by zero in %s (%s)"
+                    % (self.to_string(), mh.cross_file_reference(self.location)),
+                )
 
             if isinstance(v_lhs.value, int):
-                return Value(location = self.location,
-                             value    = v_lhs.value // v_rhs.value,
-                             typ      = self.typ)
+                return Value(
+                    location=self.location,
+                    value=v_lhs.value // v_rhs.value,
+                    typ=self.typ,
+                )
             else:
-                return Value(location = self.location,
-                             value    = v_lhs.value / v_rhs.value,
-                             typ      = self.typ)
+                return Value(
+                    location=self.location,
+                    value=v_lhs.value / v_rhs.value,
+                    typ=self.typ,
+                )
 
         elif self.operator == Binary_Operator.REMAINDER:
             assert isinstance(v_lhs.value, int)
             assert isinstance(v_rhs.value, int)
 
             if v_rhs.value == 0:
-                mh.error(v_rhs.location,
-                         "division by zero in %s (%s)" %
-                         (self.to_string(),
-                          mh.cross_file_reference(self.location)))
+                mh.error(
+                    v_rhs.location,
+                    "division by zero in %s (%s)"
+                    % (self.to_string(), mh.cross_file_reference(self.location)),
+                )
 
-            return Value(location = self.location,
-                         value    = math.remainder(v_lhs.value, v_rhs.value),
-                         typ      = self.typ)
+            return Value(
+                location=self.location,
+                value=math.remainder(v_lhs.value, v_rhs.value),
+                typ=self.typ,
+            )
 
         elif self.operator == Binary_Operator.POWER:
             assert isinstance(v_lhs.value, (int, Fraction))
             assert isinstance(v_rhs.value, int)
-            return Value(location = self.location,
-                         value    = v_lhs.value ** v_rhs.value,
-                         typ      = self.typ)
+            return Value(
+                location=self.location, value=v_lhs.value**v_rhs.value, typ=self.typ
+            )
 
         elif self.operator == Binary_Operator.INDEX:
             assert isinstance(v_lhs.value, list)
             assert isinstance(v_rhs.value, int)
 
             if v_rhs.value < 0:
-                mh.error(v_rhs.location,
-                         "index cannot be less than zero in %s (%s)" %
-                         (self.to_string(),
-                          mh.cross_file_reference(self.location)))
-            elif v_lhs.typ.upper_bound is not None and \
-                 v_rhs.value > v_lhs.typ.upper_bound:
-                mh.error(v_rhs.location,
-                         "index cannot be more than %u in %s (%s)" %
-                         (v_lhs.typ.upper_bound,
-                          self.to_string(),
-                          mh.cross_file_reference(self.location)))
+                mh.error(
+                    v_rhs.location,
+                    "index cannot be less than zero in %s (%s)"
+                    % (self.to_string(), mh.cross_file_reference(self.location)),
+                )
+            elif (
+                v_lhs.typ.upper_bound is not None
+                and v_rhs.value > v_lhs.typ.upper_bound
+            ):
+                mh.error(
+                    v_rhs.location,
+                    "index cannot be more than %u in %s (%s)"
+                    % (
+                        v_lhs.typ.upper_bound,
+                        self.to_string(),
+                        mh.cross_file_reference(self.location),
+                    ),
+                )
             elif v_rhs.value > len(v_lhs.value):
-                mh.error(v_lhs.location,
-                         "array is not big enough in %s (%s)" %
-                         (self.to_string(),
-                          mh.cross_file_reference(self.location)))
+                mh.error(
+                    v_lhs.location,
+                    "array is not big enough in %s (%s)"
+                    % (self.to_string(), mh.cross_file_reference(self.location)),
+                )
 
-            return Value(location = self.location,
-                         value    = v_lhs.value[v_rhs.value].value,
-                         typ      = self.typ)
+            return Value(
+                location=self.location,
+                value=v_lhs.value[v_rhs.value].value,
+                typ=self.typ,
+            )
 
         else:
-            mh.ice_loc(self.location,
-                       "unexpected binary operator %s" % self.operator)
+            mh.ice_loc(self.location, "unexpected binary operator %s" % self.operator)
 
     def can_be_null(self):
         return False
 
     def uses_field_access(self):
-        return (self.n_lhs.uses_field_access() or
-                self.n_rhs.uses_field_access())
+        return self.n_lhs.uses_field_access() or self.n_rhs.uses_field_access()
 
 
 class Field_Access_Expression(Expression):
@@ -1856,8 +1924,10 @@ class Field_Access_Expression(Expression):
     :type: bool
 
     """
-    def __init__(self, mh, location, n_prefix, n_field,
-                 is_union_access=False, is_universal=True):
+
+    def __init__(
+        self, mh, location, n_prefix, n_field, is_union_access=False, is_universal=True
+    ):
         # lobster-trace: LRM.Union_Type_Field_Access
         assert isinstance(mh, Message_Handler)
         assert isinstance(n_prefix, Expression)
@@ -1865,10 +1935,10 @@ class Field_Access_Expression(Expression):
         assert isinstance(is_union_access, bool)
         assert isinstance(is_universal, bool)
         super().__init__(location, n_field.n_typ)
-        self.n_prefix        = n_prefix
-        self.n_field         = n_field
+        self.n_prefix = n_prefix
+        self.n_field = n_field
         self.is_union_access = is_union_access
-        self.is_universal    = is_universal
+        self.is_universal = is_universal
 
         if not is_union_access:
             self.n_prefix.ensure_type(mh, self.n_field.member_of)
@@ -1886,13 +1956,10 @@ class Field_Access_Expression(Expression):
         assert context is None or isinstance(context, dict)
         assert gstab is None or isinstance(gstab, Symbol_Table)
 
-        v_prefix = self.n_prefix.evaluate(mh,
-                                          context,
-                                          gstab).value
+        v_prefix = self.n_prefix.evaluate(mh, context, gstab).value
         if v_prefix is None:
             # lobster-trace: LRM.Dereference
-            mh.error(self.n_prefix.location,
-                     "null dereference")
+            mh.error(self.n_prefix.location, "null dereference")
 
         # lobster-trace: LRM.Union_Type_Partial_Field_Access
         # lobster-trace: LRM.Union_Type_Partial_Field_Null
@@ -1940,6 +2007,7 @@ class Range_Test(Expression):
     :type: Expression
 
     """
+
     def __init__(self, mh, location, typ, n_lhs, n_lower, n_upper):
         # lobster-trace: LRM.Relation
         super().__init__(location, typ)
@@ -1947,7 +2015,7 @@ class Range_Test(Expression):
         assert isinstance(n_lhs, Expression)
         assert isinstance(n_lower, Expression)
         assert isinstance(n_upper, Expression)
-        self.n_lhs   = n_lhs
+        self.n_lhs = n_lhs
         self.n_lower = n_lower
         self.n_upper = n_upper
 
@@ -1956,9 +2024,11 @@ class Range_Test(Expression):
         self.n_upper.ensure_type(mh, self.n_lhs.typ)
 
     def to_string(self):
-        return "%s in %s .. %s" % (self.n_lhs.to_string(),
-                                   self.n_lower.to_string(),
-                                   self.n_upper.to_string())
+        return "%s in %s .. %s" % (
+            self.n_lhs.to_string(),
+            self.n_lower.to_string(),
+            self.n_upper.to_string(),
+        )
 
     def dump(self, indent=0):  # pragma: no cover
         # lobster-exclude: Debugging feature
@@ -1976,36 +2046,43 @@ class Range_Test(Expression):
 
         v_lhs = self.n_lhs.evaluate(mh, context, gstab)
         if v_lhs.value is None:
-            mh.error(v_lhs.location,
-                     "lhs of range check %s (%s) see must not be null" %
-                     (self.to_string(),
-                      mh.cross_file_reference(self.location)))
+            mh.error(
+                v_lhs.location,
+                "lhs of range check %s (%s) see must not be null"
+                % (self.to_string(), mh.cross_file_reference(self.location)),
+            )
 
         v_lower = self.n_lower.evaluate(mh, context, gstab)
         if v_lower.value is None:
-            mh.error(v_lower.location,
-                     "lower bound of range check %s (%s) must not be null" %
-                     (self.to_string(),
-                      mh.cross_file_reference(self.location)))
+            mh.error(
+                v_lower.location,
+                "lower bound of range check %s (%s) must not be null"
+                % (self.to_string(), mh.cross_file_reference(self.location)),
+            )
 
         v_upper = self.n_upper.evaluate(mh, context, gstab)
         if v_upper.value is None:
-            mh.error(v_upper.location,
-                     "upper bound of range check %s (%s) must not be null" %
-                     (self.to_string(),
-                      mh.cross_file_reference(self.location)))
+            mh.error(
+                v_upper.location,
+                "upper bound of range check %s (%s) must not be null"
+                % (self.to_string(), mh.cross_file_reference(self.location)),
+            )
 
-        return Value(location = self.location,
-                     value    = v_lower.value <= v_lhs.value <= v_upper.value,
-                     typ      = self.typ)
+        return Value(
+            location=self.location,
+            value=v_lower.value <= v_lhs.value <= v_upper.value,
+            typ=self.typ,
+        )
 
     def can_be_null(self):
         return False
 
     def uses_field_access(self):
-        return (self.n_lhs.uses_field_access() or
-                self.n_lower.uses_field_access() or
-                self.n_upper.uses_field_access())
+        return (
+            self.n_lhs.uses_field_access()
+            or self.n_lower.uses_field_access()
+            or self.n_upper.uses_field_access()
+        )
 
 
 class OneOf_Expression(Expression):
@@ -2019,22 +2096,23 @@ class OneOf_Expression(Expression):
     :attribute choices: a list of boolean expressions to test
     :type: list[Expression]
     """
+
     def __init__(self, mh, location, typ, choices):
         # lobster-trace: LRM.Signature_OneOf
         super().__init__(location, typ)
         assert isinstance(typ, Builtin_Boolean)
         assert isinstance(mh, Message_Handler)
         assert isinstance(choices, list)
-        assert all(isinstance(item, Expression)
-                   for item in choices)
+        assert all(isinstance(item, Expression) for item in choices)
         self.choices = choices
 
         for n_choice in choices:
             n_choice.ensure_type(mh, Builtin_Boolean)
 
     def to_string(self):
-        return "oneof(%s)" % ", ".join(n_choice.to_string()
-                                       for n_choice in self.choices)
+        return "oneof(%s)" % ", ".join(
+            n_choice.to_string() for n_choice in self.choices
+        )
 
     def dump(self, indent=0):  # pragma: no cover
         # lobster-exclude: Debugging feature
@@ -2049,12 +2127,13 @@ class OneOf_Expression(Expression):
         assert context is None or isinstance(context, dict)
         assert gstab is None or isinstance(gstab, Symbol_Table)
 
-        v_choices = [n_choice.evaluate(mh, context, gstab).value
-                     for n_choice in self.choices]
+        v_choices = [
+            n_choice.evaluate(mh, context, gstab).value for n_choice in self.choices
+        ]
 
-        return Value(location = self.location,
-                     value    = v_choices.count(True) == 1,
-                     typ      = self.typ)
+        return Value(
+            location=self.location, value=v_choices.count(True) == 1, typ=self.typ
+        )
 
     def can_be_null(self):
         return False
@@ -2086,6 +2165,7 @@ class Action(Node):
     :type: Expression
 
     """
+
     def __init__(self, mh, t_kind, n_condition, n_expression):
         # lobster-trace: LRM.Conditional_Expression
         assert isinstance(mh, Message_Handler)
@@ -2095,7 +2175,7 @@ class Action(Node):
         assert isinstance(n_condition, Expression)
         assert isinstance(n_expression, Expression)
         super().__init__(t_kind.location)
-        self.kind   = t_kind.value
+        self.kind = t_kind.value
         self.n_cond = n_condition
         self.n_expr = n_expression
         # lobster-trace: LRM.Conditional_Expression_Types
@@ -2110,9 +2190,11 @@ class Action(Node):
         self.n_expr.dump(indent + 2)
 
     def to_string(self):
-        return "%s %s then %s" % (self.kind,
-                                  self.n_cond.to_string(),
-                                  self.n_expr.to_string())
+        return "%s %s then %s" % (
+            self.kind,
+            self.n_cond.to_string(),
+            self.n_expr.to_string(),
+        )
 
 
 class Conditional_Expression(Expression):
@@ -2139,12 +2221,13 @@ class Conditional_Expression(Expression):
     :type: Expression
 
     """
+
     def __init__(self, location, if_action):
         # lobster-trace: LRM.Conditional_Expression
         assert isinstance(if_action, Action)
         assert if_action.kind == "if"
         super().__init__(location, if_action.n_expr.typ)
-        self.actions   = [if_action]
+        self.actions = [if_action]
         self.else_expr = None
 
     def add_elsif(self, mh, n_action):
@@ -2175,8 +2258,7 @@ class Conditional_Expression(Expression):
         self.else_expr.dump(indent + 2)
 
     def to_string(self):
-        rv = "(" + " ".join(action.to_string()
-                            for action in self.actions)
+        rv = "(" + " ".join(action.to_string() for action in self.actions)
         rv += " else %s" % self.else_expr.to_string()
         rv += ")"
         return rv
@@ -2192,10 +2274,11 @@ class Conditional_Expression(Expression):
         for action in self.actions:
             v_cond = action.n_cond.evaluate(mh, context, gstab)
             if v_cond.value is None:
-                mh.error(v_cond.location,
-                         "condition of %s (%s) must not be null" %
-                         (action.to_string(),
-                          mh.cross_file_reference(self.location)))
+                mh.error(
+                    v_cond.location,
+                    "condition of %s (%s) must not be null"
+                    % (action.to_string(), mh.cross_file_reference(self.location)),
+                )
             if v_cond.value:
                 return action.n_expr.evaluate(mh, context, gstab)
 
@@ -2205,15 +2288,13 @@ class Conditional_Expression(Expression):
         if self.else_expr and self.else_expr.can_be_null():
             return True
 
-        return any(action.n_expr.can_be_null()
-                   for action in self.actions)
+        return any(action.n_expr.can_be_null() for action in self.actions)
 
     def uses_field_access(self):
-        return (any(action.n_cond.uses_field_access() or
-                    action.n_expr.uses_field_access()
-                    for action in self.actions) or
-                (self.else_expr is not None and
-                 self.else_expr.uses_field_access()))
+        return any(
+            action.n_cond.uses_field_access() or action.n_expr.uses_field_access()
+            for action in self.actions
+        ) or (self.else_expr is not None and self.else_expr.uses_field_access())
 
 
 class Quantified_Expression(Expression):
@@ -2242,12 +2323,8 @@ class Quantified_Expression(Expression):
     :type: Boolean
 
     """
-    def __init__(self, mh, location,
-                 typ,
-                 universal,
-                 n_variable,
-                 n_source,
-                 n_expr):
+
+    def __init__(self, mh, location, typ, universal, n_variable, n_source, n_expr):
         # lobster-trace: LRM.Quantified_Expression
         # lobster-trace: LRM.Quantification_Type
         super().__init__(location, typ)
@@ -2257,9 +2334,9 @@ class Quantified_Expression(Expression):
         assert isinstance(n_expr, Expression)
         assert isinstance(n_source, Name_Reference)
         self.universal = universal
-        self.n_var     = n_variable
-        self.n_expr    = n_expr
-        self.n_source  = n_source
+        self.n_var = n_variable
+        self.n_expr = n_expr
+        self.n_source = n_source
         self.n_expr.ensure_type(mh, Builtin_Boolean)
 
     def dump(self, indent=0):  # pragma: no cover
@@ -2272,12 +2349,12 @@ class Quantified_Expression(Expression):
         self.n_expr.dump(indent + 1)
 
     def to_string(self):
-        return "(%s %s in %s => %s)" % ("forall"
-                                        if self.universal
-                                        else "exists",
-                                        self.n_var.name,
-                                        self.n_source.to_string(),
-                                        self.n_expr.to_string())
+        return "(%s %s in %s => %s)" % (
+            "forall" if self.universal else "exists",
+            self.n_var.name,
+            self.n_source.to_string(),
+            self.n_expr.to_string(),
+        )
 
     def evaluate(self, mh, context, gstab):
         # lobster-trace: LRM.Null_Is_Invalid
@@ -2298,45 +2375,47 @@ class Quantified_Expression(Expression):
         assert isinstance(self.n_source.entity, Composite_Component)
         array_values = context[self.n_source.entity.name]
         if isinstance(array_values, Implicit_Null):
-            mh.error(array_values.location,
-                     "%s in quantified expression %s (%s) "
-                     "must not be null" %
-                     (self.n_source.to_string(),
-                      self.to_string(),
-                      mh.cross_file_reference(self.location)))
+            mh.error(
+                array_values.location,
+                "%s in quantified expression %s (%s) "
+                "must not be null"
+                % (
+                    self.n_source.to_string(),
+                    self.to_string(),
+                    mh.cross_file_reference(self.location),
+                ),
+            )
         else:
             assert isinstance(array_values, Array_Aggregate)
 
-        rv  = self.universal
+        rv = self.universal
         loc = self.location
         for binding in array_values.value:
             new_ctx[self.n_var.name] = binding
             result = self.n_expr.evaluate(mh, new_ctx, gstab)
             assert isinstance(result.value, bool)
             if self.universal and not result.value:
-                rv  = False
+                rv = False
                 loc = binding.location
                 break
             elif not self.universal and result.value:
-                rv  = True
+                rv = True
                 loc = binding.location
                 break
 
-        return Value(location = loc,
-                     value    = rv,
-                     typ      = self.typ)
+        return Value(location=loc, value=rv, typ=self.typ)
 
     def can_be_null(self):
         return False
 
     def uses_field_access(self):
-        return (self.n_source.uses_field_access() or
-                self.n_expr.uses_field_access())
+        return self.n_source.uses_field_access() or self.n_expr.uses_field_access()
 
 
 ##############################################################################
 # AST Nodes (Entities)
 ##############################################################################
+
 
 class Entity(Node, metaclass=ABCMeta):
     """Base class for all entities.
@@ -2349,6 +2428,7 @@ class Entity(Node, metaclass=ABCMeta):
     :type: str
 
     """
+
     def __init__(self, name, location):
         # lobster-trace: LRM.Described_Name_Equality
         super().__init__(location)
@@ -2367,6 +2447,7 @@ class Typed_Entity(Entity, metaclass=ABCMeta):
     :type: Type
 
     """
+
     def __init__(self, name, location, n_typ):
         # lobster-exclude: Constructor only declares variables
         super().__init__(name, location)
@@ -2390,6 +2471,7 @@ class Quantified_Variable(Typed_Entity):
     :type: Type
 
     """
+
     def dump(self, indent=0):  # pragma: no cover
         # lobster-exclude: Debugging feature
         self.write_indent(indent, f"Quantified Variable {self.name}")
@@ -2397,9 +2479,8 @@ class Quantified_Variable(Typed_Entity):
 
 
 class Type(Entity, metaclass=ABCMeta):
-    """Abstract base class for all types.
+    """Abstract base class for all types."""
 
-    """
     def perform_type_checks(self, mh, value, gstab):
         assert isinstance(mh, Message_Handler)
         assert isinstance(value, Expression)
@@ -2418,6 +2499,7 @@ class Concrete_Type(Type, metaclass=ABCMeta):
     :attribute n_package: package where this type was declared
     :type: Package
     """
+
     def __init__(self, name, location, n_package):
         super().__init__(name, location)
         assert isinstance(n_package, Package)
@@ -2435,16 +2517,14 @@ class Concrete_Type(Type, metaclass=ABCMeta):
         return hash((self.n_package.name, self.name))
 
     def __repr__(self):
-        return "%s<%s>" % (self.__class__.__name__,
-                           self.fully_qualified_name())
+        return "%s<%s>" % (self.__class__.__name__, self.fully_qualified_name())
 
 
 class Builtin_Type(Type, metaclass=ABCMeta):
     # lobster-trace: LRM.Builtin_Types
-    """Abstract base class for all builtin types.
+    """Abstract base class for all builtin types."""
 
-    """
-    LOCATION = Location(file_name = "<builtin>")
+    LOCATION = Location(file_name="<builtin>")
 
     def __init__(self, name):
         super().__init__(name, Builtin_Type.LOCATION)
@@ -2455,9 +2535,8 @@ class Builtin_Type(Type, metaclass=ABCMeta):
 
 class Builtin_Numeric_Type(Builtin_Type, metaclass=ABCMeta):
     # lobster-trace: LRM.Builtin_Types
-    """Abstract base class for all builtin numeric types.
+    """Abstract base class for all builtin numeric types."""
 
-    """
     def dump(self, indent=0):  # pragma: no cover
         self.write_indent(indent, self.__class__.__name__)
 
@@ -2475,14 +2554,15 @@ class Builtin_Function(Entity):
     :type: bool
 
     """
-    LOCATION = Location(file_name = "<builtin>")
+
+    LOCATION = Location(file_name="<builtin>")
 
     def __init__(self, name, arity, arity_at_least=False):
         super().__init__(name, Builtin_Function.LOCATION)
         assert isinstance(arity, int)
         assert isinstance(arity_at_least, bool)
         assert arity >= 0
-        self.arity          = arity
+        self.arity = arity
         self.arity_at_least = arity_at_least
 
     def dump(self, indent=0):  # pragma: no cover
@@ -2514,13 +2594,10 @@ class Array_Type(Type):
     :type: Type
 
     """
-    def __init__(self,
-                 location,
-                 element_type,
-                 loc_lower,
-                 lower_bound,
-                 loc_upper,
-                 upper_bound):
+
+    def __init__(
+        self, location, element_type, loc_lower, lower_bound, loc_upper, upper_bound
+    ):
         # lobster-exclude: Constructor only declares variables
         assert isinstance(element_type, Type) or element_type is None
         assert isinstance(lower_bound, int)
@@ -2536,20 +2613,20 @@ class Array_Type(Type):
             if lower_bound == 0:
                 name = "array of %s" % element_type.name
             else:
-                name = "array of at least %u %s" % (lower_bound,
-                                                    element_type.name)
+                name = "array of at least %u %s" % (lower_bound, element_type.name)
         elif lower_bound == upper_bound:
-            name = "array of %u %s" % (lower_bound,
-                                       element_type.name)
+            name = "array of %u %s" % (lower_bound, element_type.name)
         else:
-            name = "array of %u to %u %s" % (lower_bound,
-                                             upper_bound,
-                                             element_type.name)
+            name = "array of %u to %u %s" % (
+                lower_bound,
+                upper_bound,
+                element_type.name,
+            )
         super().__init__(name, location)
-        self.lower_bound  = lower_bound
-        self.loc_lower    = loc_lower
-        self.upper_bound  = upper_bound
-        self.loc_upper    = loc_upper
+        self.lower_bound = lower_bound
+        self.loc_lower = loc_lower
+        self.upper_bound = upper_bound
+        self.loc_upper = loc_upper
         self.element_type = element_type
 
     def dump(self, indent=0):  # pragma: no cover
@@ -2567,8 +2644,9 @@ class Array_Type(Type):
         assert isinstance(gstab, Symbol_Table)
 
         if isinstance(value, Array_Aggregate):
-            return all(self.element_type.perform_type_checks(mh, v, gstab)
-                       for v in value.value)
+            return all(
+                self.element_type.perform_type_checks(mh, v, gstab) for v in value.value
+            )
         else:
             assert isinstance(value, Implicit_Null)
             return True
@@ -2594,6 +2672,7 @@ class Union_Type(Type):
     :type: list[Record_Type]
 
     """
+
     def __init__(self, location, types):
         assert isinstance(types, list)
         assert len(types) >= 1
@@ -2629,11 +2708,11 @@ class Union_Type(Type):
                 seen_in_type.add(comp.name)
                 if comp.name not in field_map:
                     field_map[comp.name] = {
-                        "component"       : comp,
-                        "n_typ"           : comp.n_typ,
-                        "count"           : 1,
-                        "total"           : len(self.types),
-                        "optional_in_any" : comp.optional,
+                        "component": comp,
+                        "n_typ": comp.n_typ,
+                        "count": 1,
+                        "total": len(self.types),
+                        "optional_in_any": comp.optional,
                     }
                 else:
                     info = field_map[comp.name]
@@ -2688,6 +2767,7 @@ class Builtin_Integer(Builtin_Numeric_Type):
     # lobster-trace: LRM.Builtin_Types
     # lobster-trace: LRM.Integer_Values
     """Builtin integer type."""
+
     def __init__(self):
         super().__init__("Integer")
 
@@ -2700,6 +2780,7 @@ class Builtin_Decimal(Builtin_Numeric_Type):
     # lobster-trace: LRM.Builtin_Types
     # lobster-trace: LRM.Decimal_Values
     """Builtin decimal type."""
+
     def __init__(self):
         super().__init__("Decimal")
 
@@ -2712,6 +2793,7 @@ class Builtin_Boolean(Builtin_Type):
     # lobster-trace: LRM.Builtin_Types
     # lobster-trace: LRM.Boolean_Values
     """Builtin boolean type."""
+
     def __init__(self):
         super().__init__("Boolean")
 
@@ -2724,27 +2806,29 @@ class Builtin_String(Builtin_Type):
     # lobster-trace: LRM.Builtin_Types
     # lobster-trace: LRM.String_Values
     """Builtin string type."""
+
     def __init__(self):
         super().__init__("String")
 
     def get_example_value(self):
         # lobster-exclude: utility method
-        return "\"potato\""
+        return '"potato"'
 
 
 class Builtin_Markup_String(Builtin_String):
     # lobster-trace: LRM.Builtin_Types
     # lobster-trace: LRM.Markup_String_Values
     """Builtin string type that allows checked references to TRLC
-       objects.
+    objects.
     """
+
     def __init__(self):
         super().__init__()
         self.name = "Markup_String"
 
     def get_example_value(self):
         # lobster-exclude: utility method
-        return "\"also see [[potato]]\""
+        return '"also see [[potato]]"'
 
 
 class Package(Entity):
@@ -2763,6 +2847,7 @@ class Package(Entity):
     :type: Symbol_Table
 
     """
+
     def __init__(self, name, location, builtin_stab, declared_late):
         # lobster-exclude: Constructor only declares variables
         super().__init__(name, location)
@@ -2779,8 +2864,7 @@ class Package(Entity):
         self.symbols.dump(indent + 1, omit_heading=True)
 
     def __repr__(self):
-        return "%s<%s>" % (self.__class__.__name__,
-                           self.name)
+        return "%s<%s>" % (self.__class__.__name__, self.name)
 
 
 class Composite_Type(Concrete_Type, metaclass=ABCMeta):
@@ -2798,21 +2882,16 @@ class Composite_Type(Concrete_Type, metaclass=ABCMeta):
     :type: list[Check]
 
     """
-    def __init__(self,
-                 name,
-                 description,
-                 location,
-                 package,
-                 inherited_symbols=None):
+
+    def __init__(self, name, description, location, package, inherited_symbols=None):
         # lobster-trace: LRM.Described_Name_Description
         super().__init__(name, location, package)
         assert isinstance(description, str) or description is None
-        assert isinstance(inherited_symbols, Symbol_Table) or \
-            inherited_symbols is None
+        assert isinstance(inherited_symbols, Symbol_Table) or inherited_symbols is None
 
-        self.components  = Symbol_Table(inherited_symbols)
+        self.components = Symbol_Table(inherited_symbols)
         self.description = description
-        self.checks      = []
+        self.checks = []
 
     def add_check(self, n_check):
         # lobster-trace: LRM.Check_Evaluation_Order
@@ -2854,21 +2933,15 @@ class Composite_Component(Typed_Entity):
 
     """
 
-    def __init__(self,
-                 name,
-                 description,
-                 location,
-                 member_of,
-                 n_typ,
-                 optional):
+    def __init__(self, name, description, location, member_of, n_typ, optional):
         # lobster-trace: LRM.Described_Name_Description
         super().__init__(name, location, n_typ)
         assert isinstance(description, str) or description is None
         assert isinstance(member_of, Composite_Type)
         assert isinstance(optional, bool)
         self.description = description
-        self.member_of   = member_of
-        self.optional    = optional
+        self.member_of = member_of
+        self.optional = optional
 
     def dump(self, indent=0):  # pragma: no cover
         # lobster-exclude: Debugging feature
@@ -2879,9 +2952,10 @@ class Composite_Component(Typed_Entity):
         self.write_indent(indent + 1, f"Type: {self.n_typ.name}")
 
     def __repr__(self):
-        return "%s<%s>" % (self.__class__.__name__,
-                           self.member_of.fully_qualified_name() + "." +
-                           self.name)
+        return "%s<%s>" % (
+            self.__class__.__name__,
+            self.member_of.fully_qualified_name() + "." + self.name,
+        )
 
 
 class Record_Type(Composite_Type):
@@ -2908,24 +2982,21 @@ class Record_Type(Composite_Type):
     :type: bool
 
     """
-    def __init__(self,
-                 name,
-                 description,
-                 location,
-                 package,
-                 n_parent,
-                 is_abstract):
+
+    def __init__(self, name, description, location, package, n_parent, is_abstract):
         # lobster-exclude: Constructor only declares variables
         assert isinstance(n_parent, Record_Type) or n_parent is None
         assert isinstance(is_abstract, bool)
-        super().__init__(name,
-                         description,
-                         location,
-                         package,
-                         n_parent.components if n_parent else None)
-        self.parent      = n_parent
-        self.frozen      = {}
-        self.is_final    = (n_parent.is_final if n_parent else False)
+        super().__init__(
+            name,
+            description,
+            location,
+            package,
+            n_parent.components if n_parent else None,
+        )
+        self.parent = n_parent
+        self.frozen = {}
+        self.is_final = n_parent.is_final if n_parent else False
         self.is_abstract = is_abstract
 
     def iter_checks(self):
@@ -2956,13 +3027,12 @@ class Record_Type(Composite_Type):
         :rtype: list[Composite_Component]
         """
         if self.parent:
-            return self.parent.all_components() + \
-                list(self.components.table.values())
+            return self.parent.all_components() + list(self.components.table.values())
         else:
             return list(self.components.table.values())
 
     def is_subclass_of(self, record_type):
-        """ Checks if this record type is or inherits from the given type
+        """Checks if this record type is or inherits from the given type
 
         :param record_type: check if are or extend this type
         :type record_type: Record_Type
@@ -3041,12 +3111,10 @@ class Tuple_Type(Composite_Type):
     precisely one less separator than components.
 
     """
+
     def __init__(self, name, description, location, package):
         # lobster-trace: LRM.Tuple_Declaration
-        super().__init__(name,
-                         description,
-                         location,
-                         package)
+        super().__init__(name, description, location, package)
         self.separators = []
 
     def add_separator(self, n_separator):
@@ -3132,20 +3200,21 @@ class Separator(Node):
     :attribute token: token used to separate fields of the tuple
     :type: Token
     """
+
     def __init__(self, token):
         super().__init__(token.location)
-        assert isinstance(token, Token) and token.kind in ("IDENTIFIER",
-                                                           "AT",
-                                                           "COLON",
-                                                           "SEMICOLON")
+        assert isinstance(token, Token) and token.kind in (
+            "IDENTIFIER",
+            "AT",
+            "COLON",
+            "SEMICOLON",
+        )
         self.token = token
 
     def to_string(self):
-        return {
-            "AT"        : "@",
-            "COLON"     : ":",
-            "SEMICOLON" : ";"
-        }.get(self.token.kind, self.token.value)
+        return {"AT": "@", "COLON": ":", "SEMICOLON": ";"}.get(
+            self.token.kind, self.token.value
+        )
 
     def dump(self, indent=0):  # pragma: no cover
         self.write_indent(indent, f"Separator {self.token.value}")
@@ -3166,11 +3235,12 @@ class Enumeration_Type(Concrete_Type):
     :type: Symbol_Table[Enumeration_Literal_Spec]
 
     """
+
     def __init__(self, name, description, location, package):
         # lobster-trace: LRM.Described_Name_Description
         super().__init__(name, location, package)
         assert isinstance(description, str) or description is None
-        self.literals    = Symbol_Table()
+        self.literals = Symbol_Table()
         self.description = description
 
     def dump(self, indent=0):  # pragma: no cover
@@ -3205,6 +3275,7 @@ class Enumeration_Literal_Spec(Typed_Entity):
     :type: str
 
     """
+
     def __init__(self, name, description, location, enum):
         # lobster-trace: LRM.Described_Name_Description
         super().__init__(name, location, enum)
@@ -3255,6 +3326,7 @@ class Record_Object(Typed_Entity):
     * :class:`Implicit_Null`
 
     """
+
     def __init__(self, name, location, n_typ, section, n_package):
         # lobster-trace: LRM.Section_Declaration
         # lobster-trace: LRM.Unspecified_Optional_Components
@@ -3264,11 +3336,10 @@ class Record_Object(Typed_Entity):
         assert isinstance(section, list) or section is None
         assert isinstance(n_package, Package)
         super().__init__(name, location, n_typ)
-        self.field     = {
-            comp.name: Implicit_Null(self, comp)
-            for comp in self.n_typ.all_components()
+        self.field = {
+            comp.name: Implicit_Null(self, comp) for comp in self.n_typ.all_components()
         }
-        self.section   = section
+        self.section = section
         self.n_package = n_package
 
     def fully_qualified_name(self):
@@ -3292,24 +3363,29 @@ class Record_Object(Typed_Entity):
         name of the object itself is not in this returned dictionary.
 
         """
-        return {name: value.to_python_object()
-                for name, value in self.field.items()}
+        return {name: value.to_python_object() for name, value in self.field.items()}
 
     def is_component_implicit_null(self, component) -> bool:
         return not isinstance(self.field[component.name], Implicit_Null)
 
     def assign(self, component, value):
         assert isinstance(component, Composite_Component)
-        assert isinstance(value, (Literal,
-                                  Array_Aggregate,
-                                  Tuple_Aggregate,
-                                  Record_Reference,
-                                  Implicit_Null,
-                                  Unary_Expression)), \
-                "value is %s" % value.__class__.__name__
+        assert isinstance(
+            value,
+            (
+                Literal,
+                Array_Aggregate,
+                Tuple_Aggregate,
+                Record_Reference,
+                Implicit_Null,
+                Unary_Expression,
+            ),
+        ), "value is %s" % value.__class__.__name__
         if self.is_component_implicit_null(component):
-            raise KeyError(f"Component {component.name} already \
-                           assigned to {self.n_typ.name} {self.name}!")
+            raise KeyError(
+                f"Component {component.name} already \
+                           assigned to {self.n_typ.name} {self.name}!"
+            )
         self.field[component.name] = value
 
     def dump(self, indent=0):  # pragma: no cover
@@ -3337,9 +3413,7 @@ class Record_Object(Typed_Entity):
 
         # First evaluate all tuple checks
         for n_comp in self.n_typ.all_components():
-            if not n_comp.n_typ.perform_type_checks(mh,
-                                                    self.field[n_comp.name],
-                                                    gstab):
+            if not n_comp.n_typ.perform_type_checks(mh, self.field[n_comp.name], gstab):
                 ok = False
 
         # TODO: Is there a bug here (a check relies on a tuple check)?
@@ -3354,10 +3428,10 @@ class Record_Object(Typed_Entity):
         return ok
 
     def __repr__(self):
-        return "%s<%s>" % (self.__class__.__name__,
-                           self.n_package.name + "." +
-                           self.n_typ.name + "." +
-                           self.name)
+        return "%s<%s>" % (
+            self.__class__.__name__,
+            self.n_package.name + "." + self.n_typ.name + "." + self.name,
+        )
 
 
 class Section(Entity):
@@ -3376,6 +3450,7 @@ class Section(Entity):
     :type: Section
 
     """
+
     def __init__(self, name, location, parent):
         super().__init__(name, location)
         assert isinstance(parent, Section) or parent is None
@@ -3393,15 +3468,16 @@ class Section(Entity):
 # Symbol Table & Scopes
 ##############################################################################
 
+
 class Symbol_Table:
-    """ Symbol table mapping names to entities
-    """
+    """Symbol table mapping names to entities"""
+
     def __init__(self, parent=None):
         # lobster-exclude: Constructor only declares variables
         assert isinstance(parent, Symbol_Table) or parent is None
-        self.parent   = parent
+        self.parent = parent
         self.imported = []
-        self.table    = OrderedDict()
+        self.table = OrderedDict()
         self.trlc_files = []
         self.section_names = []
 
@@ -3413,7 +3489,7 @@ class Symbol_Table:
 
     def all_names(self):
         # lobster-exclude: API for users
-        """ All names in the symbol table
+        """All names in the symbol table
 
         :rtype: set[str]
         """
@@ -3449,7 +3525,7 @@ class Symbol_Table:
 
     def iter_record_objects(self):
         # lobster-exclude: API for users
-        """ Iterate over all record objects
+        """Iterate over all record objects
 
         :rtype: iterable[Record_Object]
         """
@@ -3486,18 +3562,19 @@ class Symbol_Table:
         simple_name = self.simplified_name(entity.name)
 
         if self.contains_raw(simple_name):
-            pdef = self.lookup_direct(mh, entity.name, entity.location,
-                                      simplified=True)
+            pdef = self.lookup_direct(mh, entity.name, entity.location, simplified=True)
             if pdef.name == entity.name:
-                mh.error(entity.location,
-                         "duplicate definition, previous definition at %s" %
-                         mh.cross_file_reference(pdef.location))
+                mh.error(
+                    entity.location,
+                    "duplicate definition, previous definition at %s"
+                    % mh.cross_file_reference(pdef.location),
+                )
             else:
-                mh.error(entity.location,
-                         "%s is too similar to %s, declared at %s" %
-                         (entity.name,
-                          pdef.name,
-                          mh.cross_file_reference(pdef.location)))
+                mh.error(
+                    entity.location,
+                    "%s is too similar to %s, declared at %s"
+                    % (entity.name, pdef.name, mh.cross_file_reference(pdef.location)),
+                )
 
         else:
             self.table[simple_name] = entity
@@ -3518,8 +3595,7 @@ class Symbol_Table:
         if simple_name in self.table:
             # No need to continue searching since registering a
             # clashing name would have been stopped
-            return precise_name is None or \
-                self.table[simple_name].name == precise_name
+            return precise_name is None or self.table[simple_name].name == precise_name
 
         elif self.parent:
             return self.parent.contains_raw(simple_name, precise_name)
@@ -3532,7 +3608,7 @@ class Symbol_Table:
 
     def contains(self, name):
         # lobster-trace: LRM.Described_Name_Equality
-        """ Tests if the given name is in the table
+        """Tests if the given name is in the table
 
         :param name: the name to test
         :type name: str
@@ -3579,25 +3655,23 @@ class Symbol_Table:
                     if rv.name != name:
                         return None
 
-                    if required_subclass is not None and \
-                       not isinstance(rv, required_subclass):
-                        mh.error(rv.location,
-                                 "%s %s is not a %s" %
-                                 (rv.__class__.__name__,
-                                  name,
-                                  required_subclass.__name__))
+                    if required_subclass is not None and not isinstance(
+                        rv, required_subclass
+                    ):
+                        mh.error(
+                            rv.location,
+                            "%s %s is not a %s"
+                            % (rv.__class__.__name__, name, required_subclass.__name__),
+                        )
                     return rv
                 else:
                     ptr = ptr.parent
 
         return None
 
-    def lookup_direct(self,
-                      mh,
-                      name,
-                      error_location,
-                      required_subclass=None,
-                      simplified=False):
+    def lookup_direct(
+        self, mh, name, error_location, required_subclass=None, simplified=False
+    ):
         # lobster-trace: LRM.Described_Name_Equality
         # lobster-trace: LRM.Sufficiently_Distinct
         # lobster-trace: LRM.Valid_Base_Names
@@ -3653,45 +3727,41 @@ class Symbol_Table:
         assert isinstance(simplified, bool)
 
         simple_name = self.simplified_name(name)
-        ptr         = self
-        options     = []
+        ptr = self
+        options = []
 
         for ptr in [self] + self.imported:
             while ptr:
                 if simple_name in ptr.table:
                     rv = ptr.table[simple_name]
                     if not simplified and rv.name != name:
-                        mh.error(error_location,
-                                 "unknown symbol %s, did you mean %s?" %
-                                 (name,
-                                  rv.name))
+                        mh.error(
+                            error_location,
+                            "unknown symbol %s, did you mean %s?" % (name, rv.name),
+                        )
 
-                    if required_subclass is not None and \
-                       not isinstance(rv, required_subclass):
-                        mh.error(error_location,
-                                 "%s %s is not a %s" %
-                                 (rv.__class__.__name__,
-                                  name,
-                                  required_subclass.__name__))
+                    if required_subclass is not None and not isinstance(
+                        rv, required_subclass
+                    ):
+                        mh.error(
+                            error_location,
+                            "%s %s is not a %s"
+                            % (rv.__class__.__name__, name, required_subclass.__name__),
+                        )
                     return rv
                 else:
-                    options += list(item.name
-                                    for item in ptr.table.values())
-                    ptr      = ptr.parent
+                    options += list(item.name for item in ptr.table.values())
+                    ptr = ptr.parent
 
-        matches = get_close_matches(
-            word          = name,
-            possibilities = options,
-            n             = 1)
+        matches = get_close_matches(word=name, possibilities=options, n=1)
 
         if matches:
-            mh.error(error_location,
-                     "unknown symbol %s, did you mean %s?" %
-                     (name,
-                      matches[0]))
+            mh.error(
+                error_location,
+                "unknown symbol %s, did you mean %s?" % (name, matches[0]),
+            )
         else:
-            mh.error(error_location,
-                     "unknown symbol %s" % name)
+            mh.error(error_location, "unknown symbol %s" % name)
 
     def lookup(self, mh, referencing_token, required_subclass=None):
         # lobster-trace: LRM.Described_Name_Equality
@@ -3701,10 +3771,11 @@ class Symbol_Table:
         assert isinstance(required_subclass, type) or required_subclass is None
 
         return self.lookup_direct(
-            mh                = mh,
-            name              = referencing_token.value,
-            error_location    = referencing_token.location,
-            required_subclass = required_subclass)
+            mh=mh,
+            name=referencing_token.value,
+            error_location=referencing_token.location,
+            required_subclass=required_subclass,
+        )
 
     def write_indent(self, indent, message):  # pragma: no cover
         # lobster-exclude: Debugging feature
@@ -3741,16 +3812,11 @@ class Symbol_Table:
         stab.register(mh, Builtin_Boolean())
         stab.register(mh, Builtin_String())
         stab.register(mh, Builtin_Markup_String())
-        stab.register(mh,
-                      Builtin_Function("len", 1))
-        stab.register(mh,
-                      Builtin_Function("startswith", 2))
-        stab.register(mh,
-                      Builtin_Function("endswith", 2))
-        stab.register(mh,
-                      Builtin_Function("matches", 2))
-        stab.register(mh,
-                      Builtin_Function("oneof", 1, arity_at_least=True))
+        stab.register(mh, Builtin_Function("len", 1))
+        stab.register(mh, Builtin_Function("startswith", 2))
+        stab.register(mh, Builtin_Function("endswith", 2))
+        stab.register(mh, Builtin_Function("matches", 2))
+        stab.register(mh, Builtin_Function("oneof", 1, arity_at_least=True))
 
         return stab
 

--- a/trlc/errors.py
+++ b/trlc/errors.py
@@ -40,6 +40,7 @@ class Location:
     :attribute col_no: an optional column number, starting at 1
     :type: int:
     """
+
     def __init__(self, file_name, line_no=None, col_no=None):
         assert isinstance(file_name, str)
         if line_no is not None:
@@ -48,9 +49,9 @@ class Location:
         if col_no is not None:
             assert isinstance(col_no, int)
             assert col_no >= 1
-        self.file_name   = file_name
-        self.line_no     = line_no
-        self.col_no      = col_no
+        self.file_name = file_name
+        self.line_no = line_no
+        self.col_no = col_no
 
     def to_string(self, include_column=True):
         """Return a nice string representation
@@ -104,15 +105,17 @@ class Kind(enum.Enum):
     USER_WARNING = enum.auto()
 
     def __str__(self):
-        return {"SYS_ERROR"    : "error",
-                "SYS_CHECK"    : "issue",
-                "SYS_WARNING"  : "warning",
-                "USER_ERROR"   : "check error",
-                "USER_WARNING" : "check warning"}[self.name]
+        return {
+            "SYS_ERROR": "error",
+            "SYS_CHECK": "issue",
+            "SYS_WARNING": "warning",
+            "USER_ERROR": "check error",
+            "USER_WARNING": "check warning",
+        }[self.name]
 
 
 class TRLC_Error(Exception):
-    """ The universal exception that TRLC raises if something goes wrong
+    """The universal exception that TRLC raises if something goes wrong
 
     :attribute location: Where the issue originates from
     :type: Location
@@ -123,6 +126,7 @@ class TRLC_Error(Exception):
     :attribute message: Description of the problem
     :type: str
     """
+
     def __init__(self, location, kind, message):
         assert isinstance(location, Location)
         assert isinstance(kind, Kind)
@@ -130,8 +134,8 @@ class TRLC_Error(Exception):
 
         super().__init__()
         self.location = location
-        self.kind     = kind
-        self.message  = message
+        self.kind = kind
+        self.message = message
 
 
 class Message_Handler:
@@ -169,26 +173,34 @@ class Message_Handler:
     ``out_path``.
 
     """
-    def __init__(self, brief=False, detailed_info=True,
-                 out=None, strip_prefix=None, out_path=None):
+
+    def __init__(
+        self,
+        brief=False,
+        detailed_info=True,
+        out=None,
+        strip_prefix=None,
+        out_path=None,
+    ):
         assert isinstance(brief, bool)
         assert isinstance(strip_prefix, str) or strip_prefix is None
         assert isinstance(out_path, str) or out_path is None
-        self.brief         = brief
-        self.show_details  = detailed_info
-        self.warnings      = 0
-        self.errors        = 0
-        self.suppressed    = 0
-        self.sm            = None
+        self.brief = brief
+        self.show_details = detailed_info
+        self.warnings = 0
+        self.errors = 0
+        self.suppressed = 0
+        self.sm = None
         self.suppress_kind = set()
-        self.strip_prefix  = strip_prefix
+        self.strip_prefix = strip_prefix
         if out_path is not None:
             self._owned_file = open(  # pylint: disable=consider-using-with
-                out_path, "w", encoding="UTF-8")
-            self.out         = self._owned_file
+                out_path, "w", encoding="UTF-8"
+            )
+            self.out = self._owned_file
         else:
             self._owned_file = None
-            self.out         = out if out is not None else sys.stdout
+            self.out = out if out is not None else sys.stdout
 
     def close(self):
         if self._owned_file is not None:
@@ -215,13 +227,7 @@ class Message_Handler:
             return location.to_string(include_column=False)
         return self.sm.cross_file_reference(location)
 
-    def emit(self,
-             location,
-             kind,
-             message,
-             fatal=True,
-             extrainfo=None,
-             category=None):
+    def emit(self, location, kind, message, fatal=True, extrainfo=None, category=None):
         assert isinstance(location, Location)
         assert isinstance(kind, Kind)
         assert isinstance(message, str)
@@ -232,20 +238,16 @@ class Message_Handler:
         def _loc_str(include_column=True):
             loc = location.to_string(include_column)
             if self.strip_prefix and loc.startswith(self.strip_prefix):
-                loc = loc[len(self.strip_prefix):]
+                loc = loc[len(self.strip_prefix) :]
             return loc
 
         if self.brief:
             context = None
-            msg = "%s: trlc %s: %s" % (_loc_str(),
-                                       str(kind),
-                                       message)
+            msg = "%s: trlc %s: %s" % (_loc_str(), str(kind), message)
 
         else:
             context = location.context_lines()
-            msg = "%s: %s: %s" % (_loc_str(len(context) == 0),
-                                  str(kind),
-                                  message)
+            msg = "%s: %s: %s" % (_loc_str(len(context) == 0), str(kind), message)
 
         if category:
             msg += " [%s]" % category
@@ -261,16 +263,13 @@ class Message_Handler:
             else:
                 print(msg, file=self.out)
 
-            if not self.brief \
-               and self.show_details \
-               and extrainfo:
+            if not self.brief and self.show_details and extrainfo:
                 if context:
                     indent = len(context[1]) - 1
                 else:
                     indent = 0
                 for line in extrainfo.splitlines():
-                    print("%s| %s" % (" " * indent,
-                                      line.rstrip()), file=self.out)
+                    print("%s| %s" % (" " * indent, line.rstrip()), file=self.out)
 
         if fatal:
             raise TRLC_Error(location, kind, message)
@@ -280,16 +279,9 @@ class Message_Handler:
         assert isinstance(message, str)
 
         self.errors += 1
-        self.emit(location = location,
-                  kind     = Kind.SYS_ERROR,
-                  message  = message)
+        self.emit(location=location, kind=Kind.SYS_ERROR, message=message)
 
-    def error(self,
-              location,
-              message,
-              explanation=None,
-              fatal=True,
-              user=False):
+    def error(self, location, message, explanation=None, fatal=True, user=False):
         """ Create an error message
 
         For example::
@@ -328,14 +320,16 @@ class Message_Handler:
             kind = Kind.SYS_ERROR
 
         self.errors += 1
-        self.emit(location  = location,
-                  kind      = kind,
-                  message   = message,
-                  fatal     = fatal,
-                  extrainfo = explanation)
+        self.emit(
+            location=location,
+            kind=kind,
+            message=message,
+            fatal=fatal,
+            extrainfo=explanation,
+        )
 
     def warning(self, location, message, explanation=None, user=False):
-        """ Create a warning message
+        """Create a warning message
 
         :param location: where to attach the message
         :type location: Location
@@ -355,11 +349,13 @@ class Message_Handler:
             kind = Kind.SYS_WARNING
 
         self.warnings += 1
-        self.emit(location  = location,
-                  kind      = kind,
-                  message   = message,
-                  extrainfo = explanation,
-                  fatal     = False)
+        self.emit(
+            location=location,
+            kind=kind,
+            message=message,
+            extrainfo=explanation,
+            fatal=False,
+        )
 
     def check(self, location, message, check, explanation=None):
         assert isinstance(location, Location)
@@ -368,21 +364,25 @@ class Message_Handler:
         assert isinstance(explanation, str) or explanation is None
 
         self.warnings += 1
-        self.emit(location  = location,
-                  kind      = Kind.SYS_CHECK,
-                  message   = message,
-                  fatal     = False,
-                  extrainfo = explanation,
-                  category  = check)
+        self.emit(
+            location=location,
+            kind=Kind.SYS_CHECK,
+            message=message,
+            fatal=False,
+            extrainfo=explanation,
+            category=check,
+        )
 
     def ice_loc(self, location, message):  # pragma: no cover
         assert isinstance(location, Location)
         assert isinstance(message, str)
 
         self.errors += 1
-        self.emit(location  = location,
-                  kind      = Kind.SYS_ERROR,
-                  message   = message,
-                  extrainfo = "please report this to %s" % version.BUGS_URL,
-                  fatal     = False)
+        self.emit(
+            location=location,
+            kind=Kind.SYS_ERROR,
+            message=message,
+            extrainfo="please report this to %s" % version.BUGS_URL,
+            fatal=False,
+        )
         sys.exit(1)

--- a/trlc/lexer.py
+++ b/trlc/lexer.py
@@ -37,15 +37,15 @@ def triple_quoted_string_value(raw_value):
 
     non_empty_lines = [line for line in lines if line.strip()]
 
-    value      = lines[0]
-    common_ws  = ""
+    value = lines[0]
+    common_ws = ""
     common_len = 0
     if len(non_empty_lines) >= 2:
         # The loop below cannot complete by construction
         for c in non_empty_lines[1]:  # pragma: no cover
             if c not in (" \t"):
                 break
-            common_ws  += c
+            common_ws += c
             common_len += 1
     else:
         return value
@@ -74,15 +74,13 @@ class Source_Reference(Location):
         assert isinstance(start_pos, int)
         assert isinstance(end_pos, int)
         assert 0 <= start_pos <= end_pos < lexer.length
-        super().__init__(lexer.file_name,
-                         start_line,
-                         start_col)
-        self.lexer     = lexer
+        super().__init__(lexer.file_name, start_line, start_col)
+        self.lexer = lexer
         self.start_pos = start_pos
-        self.end_pos   = end_pos
+        self.end_pos = end_pos
 
     def text(self):
-        return self.lexer.content[self.start_pos:self.end_pos + 1]
+        return self.lexer.content[self.start_pos : self.end_pos + 1]
 
     def context_lines(self):
         line = ""
@@ -105,13 +103,12 @@ class Source_Reference(Location):
         stripped_line = line.lstrip()
         stripped_offset = offset - (len(line) - len(stripped_line))
 
-        return [stripped_line,
-                " " * stripped_offset + "^" * min(tlen, maxtrail)]
+        return [stripped_line, " " * stripped_offset + "^" * min(tlen, maxtrail)]
 
     def get_end_location(self):
-        lines_in_between = self.lexer.content[
-            self.start_pos : self.end_pos + 1
-        ].count("\n")
+        lines_in_between = self.lexer.content[self.start_pos : self.end_pos + 1].count(
+            "\n"
+        )
         end_line = self.line_no + lines_in_between
 
         end_col = self.end_pos + 1
@@ -128,39 +125,38 @@ class Token_Base:
         assert isinstance(location, Location)
         assert isinstance(kind, str)
         self.location = location
-        self.kind     = kind
-        self.value    = value
+        self.kind = kind
+        self.value = value
 
 
 class Token(Token_Base):
     KIND = {
-        "COMMENT"    : "comment",
-        "IDENTIFIER" : "identifier",
-        "KEYWORD"    : "keyword",
-        "BRA"        : "opening parenthesis '('",
-        "KET"        : "closing parenthesis ')'",
-        "S_BRA"      : "opening bracket '['",
-        "S_KET"      : "closing bracket ']'",
-        "C_BRA"      : "opening brace '{'",
-        "C_KET"      : "closing brace '}'",
-        "COMMA"      : "comma ','",
-        "AT"         : "separtor '@'",
-        "SEMICOLON"  : "separator ';'",
-        "COLON"      : "separator ':'",
-        "DOT"        : ".",
-        "RANGE"      : "..",
-        "ASSIGN"     : "=",
-        "OPERATOR"   : "operator",
-        "ARROW"      : "->",
-        "INTEGER"    : "integer literal",
-        "DECIMAL"    : "decimal literal",
-        "STRING"     : "string literal",
+        "COMMENT": "comment",
+        "IDENTIFIER": "identifier",
+        "KEYWORD": "keyword",
+        "BRA": "opening parenthesis '('",
+        "KET": "closing parenthesis ')'",
+        "S_BRA": "opening bracket '['",
+        "S_KET": "closing bracket ']'",
+        "C_BRA": "opening brace '{'",
+        "C_KET": "closing brace '}'",
+        "COMMA": "comma ','",
+        "AT": "separtor '@'",
+        "SEMICOLON": "separator ';'",
+        "COLON": "separator ':'",
+        "DOT": ".",
+        "RANGE": "..",
+        "ASSIGN": "=",
+        "OPERATOR": "operator",
+        "ARROW": "->",
+        "INTEGER": "integer literal",
+        "DECIMAL": "decimal literal",
+        "STRING": "string literal",
     }
 
     def __init__(self, location, kind, value=None, ast_link=None):
         assert kind in Token.KIND
-        if kind in ("COMMENT", "IDENTIFIER",
-                    "KEYWORD", "OPERATOR", "STRING"):
+        if kind in ("COMMENT", "IDENTIFIER", "KEYWORD", "OPERATOR", "STRING"):
             assert isinstance(value, str)
         elif kind == "INTEGER":
             assert isinstance(value, int)
@@ -182,16 +178,16 @@ class Lexer_Base(metaclass=ABCMeta):
     def __init__(self, mh, content):
         assert isinstance(mh, Message_Handler)
         assert isinstance(content, str)
-        self.mh        = mh
-        self.content   = content
-        self.length    = len(self.content)
-        self.tokens    = []
+        self.mh = mh
+        self.content = content
+        self.length = len(self.content)
+        self.tokens = []
 
-        self.lexpos  = -3
+        self.lexpos = -3
         self.line_no = 0
-        self.col_no  = 0
-        self.cc  = None
-        self.nc  = None
+        self.col_no = 0
+        self.cc = None
+        self.nc = None
         self.nnc = None
 
         self.advance()
@@ -236,62 +232,64 @@ class Lexer_Base(metaclass=ABCMeta):
             self.col_no += 1
         self.cc = self.nc
         self.nc = self.nnc
-        self.nnc = (self.content[self.lexpos + 2]
-                    if self.lexpos + 2 < self.length
-                    else None)
+        self.nnc = (
+            self.content[self.lexpos + 2] if self.lexpos + 2 < self.length else None
+        )
 
 
 class TRLC_Lexer(Lexer_Base):
-    KEYWORDS = frozenset([
-        "abs",
-        "abstract",
-        "and",
-        "checks",
-        "else",
-        "elsif",
-        "enum",
-        "error",
-        "exists",
-        "extends",
-        "false",
-        "fatal",
-        "final",
-        "forall",
-        "freeze",
-        "if",
-        "implies",
-        "import",
-        "in",
-        "not",
-        "null",
-        "optional",
-        "or",
-        "package",
-        "section",
-        "separator",
-        "then",
-        "true",
-        "tuple",
-        "type",
-        "warning",
-        "xor"
-    ])
+    KEYWORDS = frozenset(
+        [
+            "abs",
+            "abstract",
+            "and",
+            "checks",
+            "else",
+            "elsif",
+            "enum",
+            "error",
+            "exists",
+            "extends",
+            "false",
+            "fatal",
+            "final",
+            "forall",
+            "freeze",
+            "if",
+            "implies",
+            "import",
+            "in",
+            "not",
+            "null",
+            "optional",
+            "or",
+            "package",
+            "section",
+            "separator",
+            "then",
+            "true",
+            "tuple",
+            "type",
+            "warning",
+            "xor",
+        ]
+    )
 
     PUNCTUATION = {
-        "(" : "BRA",
-        ")" : "KET",
-        "{" : "C_BRA",
-        "}" : "C_KET",
-        "[" : "S_BRA",
-        "]" : "S_KET",
-        "," : "COMMA",
-        "@" : "AT",
-        ":" : "COLON",
-        ";" : "SEMICOLON",
-        "/" : "OPERATOR",
-        "%" : "OPERATOR",
-        "+" : "OPERATOR",
-        "-" : "OPERATOR",
+        "(": "BRA",
+        ")": "KET",
+        "{": "C_BRA",
+        "}": "C_KET",
+        "[": "S_BRA",
+        "]": "S_KET",
+        ",": "COMMA",
+        "@": "AT",
+        ":": "COLON",
+        ";": "SEMICOLON",
+        "/": "OPERATOR",
+        "%": "OPERATOR",
+        "+": "OPERATOR",
+        "-": "OPERATOR",
     }
 
     def __init__(self, mh, file_name, file_content=None):
@@ -311,11 +309,13 @@ class TRLC_Lexer(Lexer_Base):
 
     def current_location(self):
         # lobster-exclude: Utility function
-        return Source_Reference(lexer      = self,
-                                start_line = self.line_no,
-                                start_col  = self.col_no,
-                                start_pos  = self.lexpos,
-                                end_pos    = self.lexpos)
+        return Source_Reference(
+            lexer=self,
+            start_line=self.line_no,
+            start_col=self.col_no,
+            start_pos=self.lexpos,
+            end_pos=self.lexpos,
+        )
 
     def file_location(self):
         # lobster-exclude: Utility function
@@ -329,9 +329,9 @@ class TRLC_Lexer(Lexer_Base):
         if self.cc is None:
             return None
 
-        start_pos  = self.lexpos
+        start_pos = self.lexpos
         start_line = self.line_no
-        start_col  = self.col_no
+        start_col = self.col_no
 
         if self.cc == "/" and self.nc == "/":
             # lobster-trace: LRM.Comments
@@ -349,8 +349,7 @@ class TRLC_Lexer(Lexer_Base):
         elif self.is_alpha(self.cc):
             # lobster-trace: LRM.Identifier
             kind = "IDENTIFIER"
-            while self.nc and (self.is_alnum(self.nc) or
-                               self.nc == "_"):
+            while self.nc and (self.is_alnum(self.nc) or self.nc == "_"):
                 self.advance()
 
         elif self.cc in TRLC_Lexer.PUNCTUATION:
@@ -395,8 +394,7 @@ class TRLC_Lexer(Lexer_Base):
             if self.nc == "=":
                 self.advance()
             else:
-                self.mh.lex_error(self.current_location(),
-                                  "malformed != operator")
+                self.mh.lex_error(self.current_location(), "malformed != operator")
 
         elif self.cc == "*":
             # lobster-trace: LRM.Single_Delimiters
@@ -421,30 +419,39 @@ class TRLC_Lexer(Lexer_Base):
                         quotes_seen = 0
                     if self.nc is None:
                         self.mh.lex_error(
-                            Source_Reference(lexer      = self,
-                                             start_line = start_line,
-                                             start_col  = start_col,
-                                             start_pos  = start_pos,
-                                             end_pos    = self.lexpos),
-                            "unterminated triple-quoted string")
+                            Source_Reference(
+                                lexer=self,
+                                start_line=start_line,
+                                start_col=start_col,
+                                start_pos=start_pos,
+                                end_pos=self.lexpos,
+                            ),
+                            "unterminated triple-quoted string",
+                        )
             else:
                 while self.nc != '"':
                     if self.nc is None:
                         self.mh.lex_error(
-                            Source_Reference(lexer      = self,
-                                             start_line = start_line,
-                                             start_col  = start_col,
-                                             start_pos  = start_pos,
-                                             end_pos    = self.lexpos),
-                            "unterminated string")
+                            Source_Reference(
+                                lexer=self,
+                                start_line=start_line,
+                                start_col=start_col,
+                                start_pos=start_pos,
+                                end_pos=self.lexpos,
+                            ),
+                            "unterminated string",
+                        )
                     elif self.nc == "\n":
                         self.mh.lex_error(
-                            Source_Reference(lexer      = self,
-                                             start_line = start_line,
-                                             start_col  = start_col,
-                                             start_pos  = start_pos,
-                                             end_pos    = self.lexpos),
-                            "double quoted strings cannot include newlines")
+                            Source_Reference(
+                                lexer=self,
+                                start_line=start_line,
+                                start_col=start_col,
+                                start_pos=start_pos,
+                                end_pos=self.lexpos,
+                            ),
+                            "double quoted strings cannot include newlines",
+                        )
 
                     self.advance()
                     if self.cc == "\\" and self.nc == '"':
@@ -458,12 +465,15 @@ class TRLC_Lexer(Lexer_Base):
                 self.advance()
                 if self.cc != "'":
                     self.mh.lex_error(
-                        Source_Reference(lexer      = self,
-                                         start_line = start_line,
-                                         start_col  = start_col,
-                                         start_pos  = start_pos,
-                                         end_pos    = self.lexpos),
-                        "malformed triple-quoted string")
+                        Source_Reference(
+                            lexer=self,
+                            start_line=start_line,
+                            start_col=start_col,
+                            start_pos=start_pos,
+                            end_pos=self.lexpos,
+                        ),
+                        "malformed triple-quoted string",
+                    )
             quotes_seen = 0
             while quotes_seen < 3:
                 self.advance()
@@ -473,12 +483,15 @@ class TRLC_Lexer(Lexer_Base):
                     quotes_seen = 0
                 if self.nc is None:
                     self.mh.lex_error(
-                        Source_Reference(lexer      = self,
-                                         start_line = start_line,
-                                         start_col  = start_col,
-                                         start_pos  = start_pos,
-                                         end_pos    = self.lexpos),
-                        "unterminated triple-quoted string")
+                        Source_Reference(
+                            lexer=self,
+                            start_line=start_line,
+                            start_col=start_col,
+                            start_pos=start_pos,
+                            end_pos=self.lexpos,
+                        ),
+                        "unterminated triple-quoted string",
+                    )
 
         elif self.is_numeric(self.cc):
             # lobster-trace: LRM.Integers
@@ -486,25 +499,25 @@ class TRLC_Lexer(Lexer_Base):
             kind = "INTEGER"
 
             if self.cc == "0" and self.nc == "b":
-                digits_allowed   = "01"
+                digits_allowed = "01"
                 digits_forbidden = "23456789abcdefABCDEF"
-                int_base         = 2
-                require_digit    = True
-                decimal_allowed  = False
+                int_base = 2
+                require_digit = True
+                decimal_allowed = False
                 self.advance()
             elif self.cc == "0" and self.nc == "x":
-                digits_allowed   = "0123456789abcdefABCDEF"
+                digits_allowed = "0123456789abcdefABCDEF"
                 digits_forbidden = ""
-                int_base         = 16
-                require_digit    = True
-                decimal_allowed  = False
+                int_base = 16
+                require_digit = True
+                decimal_allowed = False
                 self.advance()
             else:
-                digits_allowed   = "0123456789"
+                digits_allowed = "0123456789"
                 digits_forbidden = "abcdefABCDEF"
-                int_base         = 10
-                require_digit    = False
-                decimal_allowed  = True
+                int_base = 10
+                require_digit = False
+                decimal_allowed = True
 
             while self.nc:
                 if self.nc in digits_allowed:
@@ -513,22 +526,27 @@ class TRLC_Lexer(Lexer_Base):
 
                 elif self.nc in digits_forbidden:
                     self.mh.lex_error(
-                        Source_Reference(lexer      = self,
-                                         start_line = start_line,
-                                         start_col  = start_col,
-                                         start_pos  = self.lexpos + 1,
-                                         end_pos    = self.lexpos + 1),
-                        "%s is not a valid base %u digit" % (self.nc,
-                                                             int_base))
+                        Source_Reference(
+                            lexer=self,
+                            start_line=start_line,
+                            start_col=start_col,
+                            start_pos=self.lexpos + 1,
+                            end_pos=self.lexpos + 1,
+                        ),
+                        "%s is not a valid base %u digit" % (self.nc, int_base),
+                    )
 
                 elif require_digit:
                     self.mh.lex_error(
-                        Source_Reference(lexer      = self,
-                                         start_line = start_line,
-                                         start_col  = start_col,
-                                         start_pos  = self.lexpos + 1,
-                                         end_pos    = self.lexpos + 1),
-                        "base %u digit is required here" % int_base)
+                        Source_Reference(
+                            lexer=self,
+                            start_line=start_line,
+                            start_col=start_col,
+                            start_pos=self.lexpos + 1,
+                            end_pos=self.lexpos + 1,
+                        ),
+                        "base %u digit is required here" % int_base,
+                    )
 
                 elif self.nc == "_":
                     self.advance()
@@ -545,18 +563,23 @@ class TRLC_Lexer(Lexer_Base):
                         if int_base == 10:
                             msg = "decimal point is not allowed here"
                         else:
-                            msg = ("base %u integer may not contain a"
-                                   " decimal point" % int_base)
+                            msg = (
+                                "base %u integer may not contain a"
+                                " decimal point" % int_base
+                            )
                         self.mh.lex_error(
-                            Source_Reference(lexer      = self,
-                                             start_line = start_line,
-                                             start_col  = start_col,
-                                             start_pos  = self.lexpos,
-                                             end_pos    = self.lexpos),
-                            msg)
-                    decimal_allowed   = False
-                    require_digit     = True
-                    kind              = "DECIMAL"
+                            Source_Reference(
+                                lexer=self,
+                                start_line=start_line,
+                                start_col=start_col,
+                                start_pos=self.lexpos,
+                                end_pos=self.lexpos,
+                            ),
+                            msg,
+                        )
+                    decimal_allowed = False
+                    require_digit = True
+                    kind = "DECIMAL"
 
                 else:  # pragma: no cover
                     # This is actually a false
@@ -566,22 +589,28 @@ class TRLC_Lexer(Lexer_Base):
 
             if require_digit:
                 self.mh.lex_error(
-                    Source_Reference(lexer      = self,
-                                     start_line = start_line,
-                                     start_col  = start_col,
-                                     start_pos  = start_pos,
-                                     end_pos    = self.lexpos),
-                    "unfinished base %u integer" % int_base)
+                    Source_Reference(
+                        lexer=self,
+                        start_line=start_line,
+                        start_col=start_col,
+                        start_pos=start_pos,
+                        end_pos=self.lexpos,
+                    ),
+                    "unfinished base %u integer" % int_base,
+                )
 
         else:
-            self.mh.lex_error(self.current_location(),
-                              "unexpected character '%s'" % self.cc)
+            self.mh.lex_error(
+                self.current_location(), "unexpected character '%s'" % self.cc
+            )
 
-        sref = Source_Reference(lexer      = self,
-                                start_line = start_line,
-                                start_col  = start_col,
-                                start_pos  = start_pos,
-                                end_pos    = min(self.lexpos, self.length - 1))
+        sref = Source_Reference(
+            lexer=self,
+            start_line=start_line,
+            start_col=start_col,
+            start_pos=start_pos,
+            end_pos=min(self.lexpos, self.length - 1),
+        )
 
         if kind == "IDENTIFIER":
             value = sref.text()
@@ -634,7 +663,6 @@ class TRLC_Lexer(Lexer_Base):
 
 
 class Token_Stream(TRLC_Lexer):
-
     def token(self):
         tok = super().token()
         if tok is not None:

--- a/trlc/lexer_md.py
+++ b/trlc/lexer_md.py
@@ -280,7 +280,7 @@ class MD_Lexer(TRLC_Lexer):
         self._raw_content = content  # kept for Phase 2 reprocessing
         self._stab = None  # set by prepare_phase2() after RSL
         self._md_tokens = []
-        self._tok_index   = 0
+        self._tok_index = 0
 
         # Phase 1: emit only preamble tokens (# PackageName, import lines).
         # Phase 2 is triggered by Source_Manager after parse_rsl_files().
@@ -322,7 +322,7 @@ class MD_Lexer(TRLC_Lexer):
             if stripped.startswith("import "):
                 preamble.append(line)
                 continue
-            break   # first non-preamble line stops Phase 1
+            break  # first non-preamble line stops Phase 1
         self._process("\n".join(preamble))
 
     def prepare_phase2(self, stab):
@@ -372,8 +372,9 @@ class MD_Lexer(TRLC_Lexer):
     def _is_tuple_array_field(record_type_ast, field_name):
         """Return True when *field_name* is declared as an array of tuples."""
         typ = MD_Lexer._get_field_type(record_type_ast, field_name)
-        return (isinstance(typ, trlc_ast.Array_Type) and
-                isinstance(typ.element_type, trlc_ast.Tuple_Type))
+        return isinstance(typ, trlc_ast.Array_Type) and isinstance(
+            typ.element_type, trlc_ast.Tuple_Type
+        )
 
     @staticmethod
     def _is_string_field(record_type_ast, field_name):
@@ -381,8 +382,9 @@ class MD_Lexer(TRLC_Lexer):
         typ = MD_Lexer._get_field_type(record_type_ast, field_name)
         return typ is not None and isinstance(typ, trlc_ast.Builtin_String)
 
-    def _emit_field_value(self, raw_value, location,
-                          record_type_ast=None, field_name=None):
+    def _emit_field_value(
+        self, raw_value, location, record_type_ast=None, field_name=None
+    ):
         """Type-aware field value emission (used in Phase 2).
 
         Dispatch rules when RSL type info is available:
@@ -517,7 +519,7 @@ class MD_Lexer(TRLC_Lexer):
                 self._emit(location, "DOT")
 
     # Separator symbol token kinds (mirrors TRLC_Lexer.PUNCTUATION).
-    _SEPARATOR_PUNCTUATION = {'@': 'AT', ':': 'COLON', ';': 'SEMICOLON'}
+    _SEPARATOR_PUNCTUATION = {"@": "AT", ":": "COLON", ";": "SEMICOLON"}
 
     @staticmethod
     def _normalize_array_value(raw_value):
@@ -533,12 +535,12 @@ class MD_Lexer(TRLC_Lexer):
         ``"identifier <sep> integer, ..."``.
         """
         # Replace <br> and <BR> tags with newlines for uniform processing
-        normalized = re.sub(r'<[Bb][Rr]\s*/?>', '\n', raw_value)
+        normalized = re.sub(r"<[Bb][Rr]\s*/?>", "\n", raw_value)
 
         # Split on newlines and commas, trim each part
         parts = []
-        for line in normalized.split('\n'):
-            for item in line.split(','):
+        for line in normalized.split("\n"):
+            for item in line.split(","):
                 trimmed = item.strip()
                 if trimmed:
                     parts.append(trimmed)
@@ -548,48 +550,48 @@ class MD_Lexer(TRLC_Lexer):
         # - identifier separators: collapse multiple spaces to one
         normalized_parts = []
         for part in parts:
-            part = re.sub(r'\s*([@:;])\s*', r' \1 ', part)
-            part = re.sub(r' +', ' ', part.strip())
+            part = re.sub(r"\s*([@:;])\s*", r" \1 ", part)
+            part = re.sub(r" +", " ", part.strip())
             normalized_parts.append(part)
 
-        return ', '.join(normalized_parts)
+        return ", ".join(normalized_parts)
 
     # Tuple-reference pattern: package-qualified identifier, separator, integer.
     # The reference MUST contain at least one dot (Package.name) so that plain
     # free-text values are never falsely matched.
     # Separator is @, :, ; or a plain identifier.
     _TUPLE_REF_RE = re.compile(
-        r'^'
-        r'(?P<ref>[a-zA-Z_]\w*\.[a-zA-Z_]\w*(?:\.[a-zA-Z_]\w*)*)'
-        r' '
-        r'(?P<sep>[@:;]|[a-zA-Z_]\w*)'
-        r' '
-        r'(?P<ver>\d+)'
-        r'$'
+        r"^"
+        r"(?P<ref>[a-zA-Z_]\w*\.[a-zA-Z_]\w*(?:\.[a-zA-Z_]\w*)*)"
+        r" "
+        r"(?P<sep>[@:;]|[a-zA-Z_]\w*)"
+        r" "
+        r"(?P<ver>\d+)"
+        r"$"
     )
 
     # Like _TUPLE_REF_RE but the dot is optional, so unqualified same-package
     # references (e.g. ``item @ 1``) are also accepted.  Only safe in the
     # Phase 2 type-aware path where the field type is already known.
     _TUPLE_REF_FLEXIBLE_RE = re.compile(
-        r'^'
-        r'(?P<ref>[a-zA-Z_]\w*(?:\.[a-zA-Z_]\w*)*)'
-        r' '
-        r'(?P<sep>[@:;]|[a-zA-Z_]\w*)'
-        r' '
-        r'(?P<ver>\d+)'
-        r'$'
+        r"^"
+        r"(?P<ref>[a-zA-Z_]\w*(?:\.[a-zA-Z_]\w*)*)"
+        r" "
+        r"(?P<sep>[@:;]|[a-zA-Z_]\w*)"
+        r" "
+        r"(?P<ver>\d+)"
+        r"$"
     )
 
     # Chunk patterns for the multi-separator tuple scanner.
     # A numeric chunk: hex, binary, or decimal (integer or float).
     _TUPLE_NUM_RE = re.compile(
-        r'0[xX][0-9a-fA-F][0-9a-fA-F_]*'
-        r'|0[bB][01][01_]*'
-        r'|\d+(?:\.\d+)?'
+        r"0[xX][0-9a-fA-F][0-9a-fA-F_]*"
+        r"|0[bB][01][01_]*"
+        r"|\d+(?:\.\d+)?"
     )
     # A separator chunk: @, :, ; or a word identifier.
-    _TUPLE_SEP_RE = re.compile(r'[@:;]|[a-zA-Z_]\w*')
+    _TUPLE_SEP_RE = re.compile(r"[@:;]|[a-zA-Z_]\w*")
 
     @staticmethod
     def _looks_like_array(raw_value, allow_unqualified=False):
@@ -605,13 +607,13 @@ class MD_Lexer(TRLC_Lexer):
         type is confirmed as a tuple-reference array.
         """
         normalized = MD_Lexer._normalize_array_value(raw_value)
-        parts = [p.strip() for p in normalized.split(',') if p.strip()]
-        pattern = (MD_Lexer._TUPLE_REF_FLEXIBLE_RE if allow_unqualified
-                   else MD_Lexer._TUPLE_REF_RE)
-        return bool(parts) and all(
-            pattern.match(part)
-            for part in parts
+        parts = [p.strip() for p in normalized.split(",") if p.strip()]
+        pattern = (
+            MD_Lexer._TUPLE_REF_FLEXIBLE_RE
+            if allow_unqualified
+            else MD_Lexer._TUPLE_REF_RE
         )
+        return bool(parts) and all(pattern.match(part) for part in parts)
 
     @staticmethod
     def _looks_like_simple_tuple(raw_value):
@@ -627,7 +629,7 @@ class MD_Lexer(TRLC_Lexer):
 
         def skip_ws():
             nonlocal pos
-            while pos < n and value[pos] in (' ', '\t'):
+            while pos < n and value[pos] in (" ", "\t"):
                 pos += 1
 
         skip_ws()
@@ -671,14 +673,14 @@ class MD_Lexer(TRLC_Lexer):
 
         def skip_ws():
             nonlocal pos
-            while pos < n and value[pos] in (' ', '\t'):
+            while pos < n and value[pos] in (" ", "\t"):
                 pos += 1
 
         skip_ws()
         m = MD_Lexer._TUPLE_NUM_RE.match(value, pos)
         if not m:
             return False
-        chunks.append(('num', m.group()))
+        chunks.append(("num", m.group()))
         pos = m.end()
 
         while pos < n:
@@ -688,13 +690,13 @@ class MD_Lexer(TRLC_Lexer):
             m = MD_Lexer._TUPLE_SEP_RE.match(value, pos)
             if not m:
                 return False
-            chunks.append(('sep', m.group()))
+            chunks.append(("sep", m.group()))
             pos = m.end()
             skip_ws()
             m = MD_Lexer._TUPLE_NUM_RE.match(value, pos)
             if not m:
                 return False
-            chunks.append(('num', m.group()))
+            chunks.append(("num", m.group()))
             pos = m.end()
 
         if pos != n:
@@ -702,13 +704,13 @@ class MD_Lexer(TRLC_Lexer):
 
         # Must have at least one separator so bare numbers fall through to
         # the integer/decimal scalar checks in _emit_value.
-        has_sep = any(kind == 'sep' for kind, _ in chunks)
+        has_sep = any(kind == "sep" for kind, _ in chunks)
         if not has_sep:
             return False
 
         for kind, text in chunks:
-            if kind == 'num':
-                if '.' in text:
+            if kind == "num":
+                if "." in text:
                     self._emit(location, "DECIMAL", Fraction(text.replace("_", "")))
                 else:
                     self._emit(location, "INTEGER", self._parse_number(text))
@@ -774,7 +776,7 @@ class MD_Lexer(TRLC_Lexer):
         so the caller can skip further processing of this value.
         """
         value = raw_value.strip()
-        if not (value.startswith('[') and value.endswith(']')):
+        if not (value.startswith("[") and value.endswith("]")):
             return False
         inner = value[1:-1].strip()
         # Only reject if the content inside the brackets actually looks like
@@ -814,10 +816,13 @@ class MD_Lexer(TRLC_Lexer):
             return False
 
         normalized = self._normalize_array_value(raw_value)
-        parts = [p.strip() for p in normalized.split(',')]
+        parts = [p.strip() for p in normalized.split(",")]
         self._emit(location, "S_BRA")
-        pattern = (MD_Lexer._TUPLE_REF_FLEXIBLE_RE if allow_unqualified
-                   else MD_Lexer._TUPLE_REF_RE)
+        pattern = (
+            MD_Lexer._TUPLE_REF_FLEXIBLE_RE
+            if allow_unqualified
+            else MD_Lexer._TUPLE_REF_RE
+        )
 
         for idx, part in enumerate(parts):
             if idx > 0:
@@ -830,7 +835,7 @@ class MD_Lexer(TRLC_Lexer):
                 integer = int(match.group("ver"))
 
                 # Emit qualified identifier (Pkg.item → IDENTIFIER DOT IDENTIFIER)
-                ident_parts = qual_ident.split('.')
+                ident_parts = qual_ident.split(".")
                 for i, ident_part in enumerate(ident_parts):
                     self._emit(location, "IDENTIFIER", ident_part)
                     if i < len(ident_parts) - 1:
@@ -1003,8 +1008,8 @@ class MD_Lexer(TRLC_Lexer):
         imported_packages = []
 
         # ── Type tracking for Phase 2 ─────────────────────────────────── #
-        current_package_name    = None   # from # PackageName heading
-        current_record_type_ast = None   # resolved after type row found
+        current_package_name = None  # from # PackageName heading
+        current_record_type_ast = None  # resolved after type row found
 
         # ── Record tracking ───────────────────────────────────────────── #
         # When a ### heading is seen we buffer the name and then wait for
@@ -1042,8 +1047,9 @@ class MD_Lexer(TRLC_Lexer):
                 str_field_lines.pop()
             text = "\n".join(str_field_lines)
 
-            emit_as_scalar = ("\n" not in text and
-                              MD_Lexer._looks_like_scalar_value(text))
+            emit_as_scalar = "\n" not in text and MD_Lexer._looks_like_scalar_value(
+                text
+            )
 
             value_loc = str_field_loc
             if str_field_first_content_line is not None:
@@ -1057,25 +1063,32 @@ class MD_Lexer(TRLC_Lexer):
                 self._emit(str_field_loc, "IDENTIFIER", str_field_name)
                 self._emit(str_field_loc, "ASSIGN")
                 self._emit_field_value(
-                    text, value_loc,
-                    current_record_type_ast, str_field_name)
+                    text, value_loc, current_record_type_ast, str_field_name
+                )
             else:
                 # "type" row not yet seen – buffer until the record opens.
                 # Check if it looks like an array (but don't emit yet)
                 is_bracket = (
-                    not emit_as_scalar and
-                    text.strip().startswith('[') and
-                    text.strip().endswith(']') and
-                    '@' in text
+                    not emit_as_scalar
+                    and text.strip().startswith("[")
+                    and text.strip().endswith("]")
+                    and "@" in text
                 )
                 is_array = (
-                    not emit_as_scalar and
-                    not is_bracket and
-                    MD_Lexer._looks_like_array(text)
+                    not emit_as_scalar
+                    and not is_bracket
+                    and MD_Lexer._looks_like_array(text)
                 )
                 pending_string_fields.append(
-                    (str_field_name, value_loc, text,
-                     emit_as_scalar, is_array, is_bracket))
+                    (
+                        str_field_name,
+                        value_loc,
+                        text,
+                        emit_as_scalar,
+                        is_array,
+                        is_bracket,
+                    )
+                )
             in_string_field = False
             str_field_name = None
             str_field_lines = []
@@ -1147,9 +1160,7 @@ class MD_Lexer(TRLC_Lexer):
                     if str_field_first_content_line is None and stripped:
                         line_stripped = line.lstrip()
                         str_field_first_content_line = line_no
-                        str_field_first_content_col = (
-                            len(line) - len(line_stripped) + 1
-                        )
+                        str_field_first_content_col = len(line) - len(line_stripped) + 1
                     str_field_lines.append(line)
                     continue
 
@@ -1165,10 +1176,12 @@ class MD_Lexer(TRLC_Lexer):
                     self.mh.lex_error(loc, "package heading must be '# <PackageName>'")
                 package_name = parts[0]
                 if (
-                    not package_name or
-                    not MD_Lexer._is_alpha(package_name[0]) or
-                    any(not (MD_Lexer._is_alnum(ch) or ch == "_")
-                        for ch in package_name[1:])
+                    not package_name
+                    or not MD_Lexer._is_alpha(package_name[0])
+                    or any(
+                        not (MD_Lexer._is_alnum(ch) or ch == "_")
+                        for ch in package_name[1:]
+                    )
                 ):
                     self.mh.lex_error(loc, "invalid package name in markdown heading")
                 self._emit(loc, "KEYWORD", "#")
@@ -1249,7 +1262,8 @@ class MD_Lexer(TRLC_Lexer):
                     in_record = True
                     record_type_found = True
                     current_record_type_ast = self._resolve_record_type(
-                        type_name, package_name=current_package_name)
+                        type_name, package_name=current_package_name
+                    )
 
                     # Flush any properties that arrived before "type"
                     for bkey, bval, bline in pending_props:
@@ -1257,27 +1271,31 @@ class MD_Lexer(TRLC_Lexer):
                         self._emit(bloc, "IDENTIFIER", bkey)
                         self._emit(bloc, "ASSIGN")
                         self._emit_field_value(
-                            bval, bloc,
-                            current_record_type_ast, bkey)
+                            bval, bloc, current_record_type_ast, bkey
+                        )
                     pending_props = []
 
                     # Flush any #### string fields that arrived
                     # before "type"
-                    for (fname, floc, ftext, _fis_scalar,
-                         _fis_array, _fis_bracket) in pending_string_fields:
+                    for (
+                        fname,
+                        floc,
+                        ftext,
+                        _fis_scalar,
+                        _fis_array,
+                        _fis_bracket,
+                    ) in pending_string_fields:
                         self._emit(floc, "IDENTIFIER", fname)
                         self._emit(floc, "ASSIGN")
                         self._emit_field_value(
-                            ftext, floc,
-                            current_record_type_ast, fname)
+                            ftext, floc, current_record_type_ast, fname
+                        )
                     pending_string_fields.clear()
 
                 elif record_type_found:
                     self._emit(loc, "IDENTIFIER", key)
                     self._emit(loc, "ASSIGN")
-                    self._emit_field_value(
-                        value, loc,
-                        current_record_type_ast, key)
+                    self._emit_field_value(value, loc, current_record_type_ast, key)
 
                 else:
                     # Buffer: "type" has not appeared yet

--- a/trlc/lint.py
+++ b/trlc/lint.py
@@ -31,13 +31,13 @@ class Linter:
         assert isinstance(verify_checks, bool)
         assert isinstance(debug_vcg, bool)
 
-        self.mh            = mh
-        self.stab          = stab
+        self.mh = mh
+        self.stab = stab
         self.verify_checks = verify_checks
-        self.debug_vcg     = debug_vcg
+        self.debug_vcg = debug_vcg
 
         self.abstract_extensions = {}
-        self.checked_types       = set()
+        self.checked_types = set()
 
     def perform_sanity_checks(self):
         # lobster-exclude: Not safety relevant
@@ -57,7 +57,8 @@ class Linter:
                     self.mh.check(
                         n_typ.location,
                         f"abstract type {n_typ.name} does not have any extensions",
-                        "abstract_leaf_types")
+                        "abstract_leaf_types",
+                    )
 
         return ok
 
@@ -86,17 +87,18 @@ class Linter:
                     n_typ.location,
                     "union type with a single member is equivalent to a"
                     " plain record reference",
-                    "union_single_type")
+                    "union_single_type",
+                )
             # lobster-trace: LRM.Union_Type_No_Subtype_Relations
             for i, t_i in enumerate(n_typ.types):
                 for j, t_j in enumerate(n_typ.types):
-                    if i != j and t_i is not t_j and \
-                            t_i.is_subclass_of(t_j):
+                    if i != j and t_i is not t_j and t_i.is_subclass_of(t_j):
                         self.mh.check(
                             n_typ.location,
                             "%s is a subtype of %s which is already"
                             " in this union" % (t_i.name, t_j.name),
-                            "union_redundant_subtype")
+                            "union_redundant_subtype",
+                        )
             for member_type in n_typ.types:
                 self.verify_type(member_type)
 
@@ -105,29 +107,25 @@ class Linter:
 
         # Detect confusing separators
         # lobster-trace: LRM.Tuple_Based_Literal_Ambiguity
-        previous_was_int     = False
+        previous_was_int = False
         previous_was_bad_sep = False
-        bad_separator        = None
-        location             = None
+        bad_separator = None
+        location = None
         for n_item in n_tuple_type.iter_sequence():
             if previous_was_bad_sep:
                 assert isinstance(n_item, ast.Composite_Component)
                 if isinstance(n_item.n_typ, ast.Builtin_Integer):
                     explanation = [
-                        "For example 0%s100 would be a base %u literal" %
-                        (bad_separator,
-                         {"b" : 2, "x" : 16}[bad_separator]),
-                        "instead of the tuple segment 0 %s 100." %
-                        bad_separator
+                        "For example 0%s100 would be a base %u literal"
+                        % (bad_separator, {"b": 2, "x": 16}[bad_separator]),
+                        "instead of the tuple segment 0 %s 100." % bad_separator,
                     ]
                 else:
                     explanation = [
-                        "For example 0%s%s would be a lexer error" %
-                        (bad_separator,
-                         n_item.n_typ.get_example_value()),
-                        "instead of the tuple segment 0 %s %s." %
-                        (bad_separator,
-                         n_item.n_typ.get_example_value())
+                        "For example 0%s%s would be a lexer error"
+                        % (bad_separator, n_item.n_typ.get_example_value()),
+                        "instead of the tuple segment 0 %s %s."
+                        % (bad_separator, n_item.n_typ.get_example_value()),
                     ]
 
                 self.mh.check(
@@ -135,21 +133,25 @@ class Linter:
                     "%s separator after integer component"
                     " creates ambiguities" % bad_separator,
                     "separator_based_literal_ambiguity",
-                    "\n".join(explanation))
+                    "\n".join(explanation),
+                )
 
-            elif isinstance(n_item, ast.Composite_Component) and \
-               isinstance(n_item.n_typ, ast.Builtin_Integer):
+            elif isinstance(n_item, ast.Composite_Component) and isinstance(
+                n_item.n_typ, ast.Builtin_Integer
+            ):
                 previous_was_int = True
 
-            elif isinstance(n_item, ast.Separator) and \
-                 previous_was_int and \
-                 n_item.to_string() in ("x", "b"):
+            elif (
+                isinstance(n_item, ast.Separator)
+                and previous_was_int
+                and n_item.to_string() in ("x", "b")
+            ):
                 previous_was_bad_sep = True
-                bad_separator        = n_item.to_string()
-                location             = n_item.location
+                bad_separator = n_item.to_string()
+                location = n_item.location
 
             else:
-                previous_was_int     = False
+                previous_was_int = False
                 previous_was_bad_sep = False
 
         # Walk over components
@@ -158,9 +160,7 @@ class Linter:
 
         # Verify checks
         if self.verify_checks:
-            vcg = VCG(mh          = self.mh,
-                      n_ctyp      = n_tuple_type,
-                      debug       = self.debug_vcg)
+            vcg = VCG(mh=self.mh, n_ctyp=n_tuple_type, debug=self.debug_vcg)
             vcg.analyze()
 
     def verify_record_type(self, n_record_type):
@@ -185,9 +185,7 @@ class Linter:
 
         # Verify checks
         if self.verify_checks:
-            vcg = VCG(mh          = self.mh,
-                      n_ctyp      = n_record_type,
-                      debug       = self.debug_vcg)
+            vcg = VCG(mh=self.mh, n_ctyp=n_record_type, debug=self.debug_vcg)
             vcg.analyze()
 
     def verify_array_type(self, n_typ):
@@ -197,29 +195,30 @@ class Linter:
         if n_typ.upper_bound is None:
             pass
         elif n_typ.lower_bound > n_typ.upper_bound:
-            self.mh.check(n_typ.loc_upper,
-                          "upper bound must be at least %u" %
-                          n_typ.lower_bound,
-                          "impossible_array_types")
+            self.mh.check(
+                n_typ.loc_upper,
+                "upper bound must be at least %u" % n_typ.lower_bound,
+                "impossible_array_types",
+            )
         elif n_typ.upper_bound == 0:
-            self.mh.check(n_typ.loc_upper,
-                          "this array makes no sense",
-                          "impossible_array_types")
+            self.mh.check(
+                n_typ.loc_upper, "this array makes no sense", "impossible_array_types"
+            )
         elif n_typ.upper_bound == 1 and n_typ.lower_bound == 1:
-            self.mh.check(n_typ.loc_upper,
-                          "array of fixed size 1 "
-                          "should not be an array",
-                          "weird_array_types",
-                          "An array with a fixed size of 1 should not\n"
-                          "be an array at all.")
+            self.mh.check(
+                n_typ.loc_upper,
+                "array of fixed size 1 should not be an array",
+                "weird_array_types",
+                "An array with a fixed size of 1 should not\nbe an array at all.",
+            )
         elif n_typ.upper_bound == 1 and n_typ.lower_bound == 0:
-            self.mh.check(n_typ.loc_upper,
-                          "consider making this array an"
-                          " optional %s" % n_typ.element_type.name,
-                          "weird_array_types",
-                          "An array with 0 to 1 components should just\n"
-                          "be an optional %s instead." %
-                          n_typ.element_type.name)
+            self.mh.check(
+                n_typ.loc_upper,
+                "consider making this array an optional %s" % n_typ.element_type.name,
+                "weird_array_types",
+                "An array with 0 to 1 components should just\n"
+                "be an optional %s instead." % n_typ.element_type.name,
+            )
 
     def markup_ref(self, item, string_literals):
         for string_literal in string_literals:
@@ -235,20 +234,23 @@ class Linter:
             if not file.cu.imports:
                 continue
             for item in file.cu.imports:
-                import_tokens = [t for t in file.lexer.tokens
-                                 if t.value == item.name]
-                markup = self.markup_ref(item,
-                                         (m.ast_link for m in
-                                          file.lexer.tokens if
-                                          isinstance(m.ast_link,
-                                                     ast.String_Literal) and
-                                          m.ast_link.has_references))
+                import_tokens = [t for t in file.lexer.tokens if t.value == item.name]
+                markup = self.markup_ref(
+                    item,
+                    (
+                        m.ast_link
+                        for m in file.lexer.tokens
+                        if isinstance(m.ast_link, ast.String_Literal)
+                        and m.ast_link.has_references
+                    ),
+                )
                 if markup is not None:
                     import_tokens.append(markup)
                 if len(import_tokens) == 1:
                     import_tk = import_tokens[0]
-                    self.mh.check(import_tk.location,
-                                    "unused import %s" % import_tk.value,
-                                    "unused_imports",
-                                    "Consider deleting this import"
-                                    " statement if not needed.")
+                    self.mh.check(
+                        import_tk.location,
+                        "unused import %s" % import_tk.value,
+                        "unused_imports",
+                        "Consider deleting this import statement if not needed.",
+                    )

--- a/trlc/nested.py
+++ b/trlc/nested.py
@@ -48,35 +48,43 @@ class Nested_Lexer(Lexer_Base):
 
         if self.origin_multi_string:
             loc = Source_Reference(
-                lexer      = self.origin_location.lexer,
-                start_line = self.origin_location.line_no + (start_line - 1),
-                start_col  = (self.origin_location.col_no + self.base_offset
-                              if start_line == 1
-                              else start_col),
-                start_pos  = (self.origin_location.start_pos +
-                              self.base_offset +
-                              begin),
-                end_pos    = (self.origin_location.start_pos +
-                              self.base_offset +
-                              end))
+                lexer=self.origin_location.lexer,
+                start_line=self.origin_location.line_no + (start_line - 1),
+                start_col=(
+                    self.origin_location.col_no + self.base_offset
+                    if start_line == 1
+                    else start_col
+                ),
+                start_pos=(self.origin_location.start_pos + self.base_offset + begin),
+                end_pos=(self.origin_location.start_pos + self.base_offset + end),
+            )
 
         else:
             escapes_to_start = self.content[0:begin].count('"')
-            escapes_to_end = escapes_to_start + \
-                self.content[begin:end + 1].count('"')
+            escapes_to_end = escapes_to_start + self.content[begin : end + 1].count('"')
             assert start_line == 1
             loc = Source_Reference(
-                lexer      = self.origin_location.lexer,
-                start_line = self.origin_location.line_no,
-                start_col  = (self.origin_location.col_no +
-                              self.base_offset +
-                              begin + escapes_to_start),
-                start_pos  = (self.origin_location.start_pos +
-                              self.base_offset +
-                              begin + escapes_to_start),
-                end_pos    = (self.origin_location.start_pos +
-                              self.base_offset +
-                              end + escapes_to_end))
+                lexer=self.origin_location.lexer,
+                start_line=self.origin_location.line_no,
+                start_col=(
+                    self.origin_location.col_no
+                    + self.base_offset
+                    + begin
+                    + escapes_to_start
+                ),
+                start_pos=(
+                    self.origin_location.start_pos
+                    + self.base_offset
+                    + begin
+                    + escapes_to_start
+                ),
+                end_pos=(
+                    self.origin_location.start_pos
+                    + self.base_offset
+                    + end
+                    + escapes_to_end
+                ),
+            )
 
         return loc
 

--- a/trlc/parser.py
+++ b/trlc/parser.py
@@ -31,12 +31,12 @@ class Markup_Token(Token_Base):
     # lobster-trace: LRM.Markup_String_Format
 
     KIND = {
-        "CHARACTER"          : "character",
-        "REFLIST_BEGIN"      : "[[",
-        "REFLIST_END"        : "]]",
-        "REFLIST_COMMA"      : ",",
-        "REFLIST_DOT"        : ".",
-        "REFLIST_IDENTIFIER" : "identifier",
+        "CHARACTER": "character",
+        "REFLIST_BEGIN": "[[",
+        "REFLIST_END": "]]",
+        "REFLIST_COMMA": ",",
+        "REFLIST_DOT": ".",
+        "REFLIST_IDENTIFIER": "identifier",
     }
 
     def __init__(self, location, kind, value):
@@ -63,19 +63,20 @@ class Markup_Lexer(Nested_Lexer):
         if self.cc is None:
             return None
 
-        start_pos  = self.lexpos
+        start_pos = self.lexpos
         start_line = self.line_no
-        start_col  = self.col_no
+        start_col = self.col_no
 
         if self.cc == "[" and self.nc == "[":
             kind = "REFLIST_BEGIN"
             self.advance()
             if self.in_reflist:
-                self.mh.lex_error(self.source_location(start_line,
-                                                       start_col,
-                                                       start_pos,
-                                                       start_pos + 1),
-                                  "cannot nest reference lists")
+                self.mh.lex_error(
+                    self.source_location(
+                        start_line, start_col, start_pos, start_pos + 1
+                    ),
+                    "cannot nest reference lists",
+                )
             else:
                 self.in_reflist = True
 
@@ -85,11 +86,12 @@ class Markup_Lexer(Nested_Lexer):
             if self.in_reflist:
                 self.in_reflist = False
             else:
-                self.mh.lex_error(self.source_location(start_line,
-                                                       start_col,
-                                                       start_pos,
-                                                       start_pos + 1),
-                                  "opening [[ for this ]] found")
+                self.mh.lex_error(
+                    self.source_location(
+                        start_line, start_col, start_pos, start_pos + 1
+                    ),
+                    "opening [[ for this ]] found",
+                )
 
         elif not self.in_reflist:
             kind = "CHARACTER"
@@ -102,26 +104,19 @@ class Markup_Lexer(Nested_Lexer):
 
         elif self.is_alpha(self.cc):
             kind = "REFLIST_IDENTIFIER"
-            while self.nc and (self.is_alnum(self.nc) or
-                               self.nc == "_"):
+            while self.nc and (self.is_alnum(self.nc) or self.nc == "_"):
                 self.advance()
 
         else:
-            self.mh.lex_error(self.source_location(start_line,
-                                                   start_col,
-                                                   start_pos,
-                                                   start_pos),
-                              "unexpected character '%s'" % self.cc)
+            self.mh.lex_error(
+                self.source_location(start_line, start_col, start_pos, start_pos),
+                "unexpected character '%s'" % self.cc,
+            )
 
-        loc = self.source_location(start_line,
-                                   start_col,
-                                   start_pos,
-                                   self.lexpos)
+        loc = self.source_location(start_line, start_col, start_pos, self.lexpos)
 
         # pylint: disable=possibly-used-before-assignment
-        return Markup_Token(loc,
-                            kind,
-                            self.content[start_pos:self.lexpos + 1])
+        return Markup_Token(loc, kind, self.content[start_pos : self.lexpos + 1])
 
 
 class Parser_Base:
@@ -131,11 +126,11 @@ class Parser_Base:
         assert isinstance(eoc_name, str)
         assert isinstance(token_map, dict)
         assert isinstance(keywords, frozenset)
-        self.mh    = mh
+        self.mh = mh
         self.lexer = lexer
 
-        self.eoc_name          = eoc_name
-        self.language_tokens   = token_map
+        self.eoc_name = eoc_name
+        self.language_tokens = token_map
         self.language_keywords = keywords
 
         self.ct = None
@@ -158,79 +153,90 @@ class Parser_Base:
             self.advance()
 
     def peek(self, kind):
-        assert kind in self.language_tokens, \
-            "%s is not a valid token" % kind
+        assert kind in self.language_tokens, "%s is not a valid token" % kind
         return self.nt is not None and self.nt.kind == kind
 
     def peek_eof(self):
         return self.nt is None
 
     def peek_kw(self, value):
-        assert value in self.language_keywords, \
-            "%s is not a valid keyword" % value
+        assert value in self.language_keywords, "%s is not a valid keyword" % value
         return self.peek("KEYWORD") and self.nt.value == value
 
     def match(self, kind):
         # lobster-trace: LRM.Matching_Value_Types
 
-        assert kind in self.language_tokens, \
-            "%s is not a valid token" % kind
+        assert kind in self.language_tokens, "%s is not a valid token" % kind
         if self.nt is None:
             if self.ct is None:
-                self.mh.error(self.lexer.file_location(),
-                              "expected %s, encountered %s instead" %
-                              (self.language_tokens[kind], self.eoc_name))
+                self.mh.error(
+                    self.lexer.file_location(),
+                    "expected %s, encountered %s instead"
+                    % (self.language_tokens[kind], self.eoc_name),
+                )
             else:
-                self.mh.error(self.ct.location,
-                              "expected %s, encountered %s instead" %
-                              (self.language_tokens[kind], self.eoc_name))
+                self.mh.error(
+                    self.ct.location,
+                    "expected %s, encountered %s instead"
+                    % (self.language_tokens[kind], self.eoc_name),
+                )
         elif self.nt.kind != kind:
-            self.mh.error(self.nt.location,
-                          "expected %s, encountered %s instead" %
-                          (self.language_tokens[kind],
-                           self.language_tokens[self.nt.kind]))
+            self.mh.error(
+                self.nt.location,
+                "expected %s, encountered %s instead"
+                % (self.language_tokens[kind], self.language_tokens[self.nt.kind]),
+            )
         self.advance()
 
     def match_eof(self):
         if self.nt is not None:
-            self.mh.error(self.nt.location,
-                          "expected %s, encountered %s instead" %
-                          (self.eoc_name,
-                           self.language_tokens[self.nt.kind]))
+            self.mh.error(
+                self.nt.location,
+                "expected %s, encountered %s instead"
+                % (self.eoc_name, self.language_tokens[self.nt.kind]),
+            )
 
     def match_kw(self, value):
-        assert value in self.language_keywords, \
-            "%s is not a valid keyword" % value
+        assert value in self.language_keywords, "%s is not a valid keyword" % value
         if self.nt is None:
             if self.ct is None:
-                self.mh.error(self.lexer.file_location(),
-                              "expected keyword %s, encountered %s instead" %
-                              (value, self.eoc_name))
+                self.mh.error(
+                    self.lexer.file_location(),
+                    "expected keyword %s, encountered %s instead"
+                    % (value, self.eoc_name),
+                )
             else:
-                self.mh.error(self.ct.location,
-                              "expected keyword %s, encountered %s instead" %
-                              (value, self.eoc_name))
+                self.mh.error(
+                    self.ct.location,
+                    "expected keyword %s, encountered %s instead"
+                    % (value, self.eoc_name),
+                )
         elif self.nt.kind != "KEYWORD":
-            self.mh.error(self.nt.location,
-                          "expected keyword %s, encountered %s instead" %
-                          (value,
-                           self.language_tokens[self.nt.kind]))
+            self.mh.error(
+                self.nt.location,
+                "expected keyword %s, encountered %s instead"
+                % (value, self.language_tokens[self.nt.kind]),
+            )
         elif self.nt.value != value:
-            self.mh.error(self.nt.location,
-                          "expected keyword %s,"
-                          " encountered keyword %s instead" %
-                          (value, self.nt.value))
+            self.mh.error(
+                self.nt.location,
+                "expected keyword %s,"
+                " encountered keyword %s instead" % (value, self.nt.value),
+            )
         self.advance()
 
 
 class Markup_Parser(Parser_Base):
     def __init__(self, parent, literal):
         assert isinstance(parent, Parser)
-        super().__init__(parent.mh, Markup_Lexer(parent.mh, literal),
-                         eoc_name  = "end-of-string",
-                         token_map = Markup_Token.KIND,
-                         keywords  = frozenset())
-        self.parent     = parent
+        super().__init__(
+            parent.mh,
+            Markup_Lexer(parent.mh, literal),
+            eoc_name="end-of-string",
+            token_map=Markup_Token.KIND,
+            keywords=frozenset(),
+        )
+        self.parent = parent
         self.references = literal.references
 
     def parse_all_references(self):
@@ -260,23 +266,22 @@ class Markup_Parser(Parser_Base):
         self.match("REFLIST_IDENTIFIER")
         if self.peek("REFLIST_DOT"):
             package = self.parent.stab.lookup_direct(
-                mh                = self.mh,
-                name              = self.ct.value,
-                error_location    = self.ct.location,
-                required_subclass = ast.Package)
+                mh=self.mh,
+                name=self.ct.value,
+                error_location=self.ct.location,
+                required_subclass=ast.Package,
+            )
             if not self.parent.cu.is_visible(package):
-                self.mh.error(self.ct.location,
-                              "package must be imported before use")
+                self.mh.error(self.ct.location, "package must be imported before use")
 
             self.match("REFLIST_DOT")
             self.match("REFLIST_IDENTIFIER")
         else:
             package = self.parent.cu.package
 
-        ref = ast.Record_Reference(location = self.ct.location,
-                                   name     = self.ct.value,
-                                   typ      = None,
-                                   package  = package)
+        ref = ast.Record_Reference(
+            location=self.ct.location, name=self.ct.value, typ=None, package=package
+        )
         self.references.append(ref)
 
 
@@ -285,14 +290,16 @@ class Parser(Parser_Base):
     ADDING_OPERATOR = ("+", "-")
     MULTIPLYING_OPERATOR = ("*", "/", "%")
 
-    def __init__(self,
-                 mh,
-                 stab,
-                 file_name,
-                 lint_mode,
-                 error_recovery,
-                 primary_file=True,
-                 lexer=None):
+    def __init__(
+        self,
+        mh,
+        stab,
+        file_name,
+        lint_mode,
+        error_recovery,
+        primary_file=True,
+        lexer=None,
+    ):
         assert isinstance(mh, Message_Handler)
         assert isinstance(stab, ast.Symbol_Table)
         assert isinstance(file_name, str)
@@ -301,33 +308,39 @@ class Parser(Parser_Base):
         assert isinstance(primary_file, bool)
         assert isinstance(lexer, TRLC_Lexer) or lexer is None
         if lexer:
-            super().__init__(mh, lexer,
-                             eoc_name  = "end-of-file",
-                             token_map = Token.KIND,
-                             keywords  = TRLC_Lexer.KEYWORDS)
+            super().__init__(
+                mh,
+                lexer,
+                eoc_name="end-of-file",
+                token_map=Token.KIND,
+                keywords=TRLC_Lexer.KEYWORDS,
+            )
         else:
-            super().__init__(mh, TRLC_Lexer(mh, file_name),
-                             eoc_name  = "end-of-file",
-                             token_map = Token.KIND,
-                             keywords  = TRLC_Lexer.KEYWORDS)
+            super().__init__(
+                mh,
+                TRLC_Lexer(mh, file_name),
+                eoc_name="end-of-file",
+                token_map=Token.KIND,
+                keywords=TRLC_Lexer.KEYWORDS,
+            )
 
-        self.lint_mode      = lint_mode
+        self.lint_mode = lint_mode
         self.error_recovery = error_recovery
 
         self.stab = stab
-        self.cu   = ast.Compilation_Unit(file_name)
+        self.cu = ast.Compilation_Unit(file_name)
 
-        self.primary   = primary_file
+        self.primary = primary_file
         self.secondary = False
         # Controls if the file is actually fully parsed: primary means
         # it was selected on the command-line and secondary means it
         # was selected by dependency analysis.
 
-        self.builtin_bool    = stab.lookup_assuming(self.mh, "Boolean")
-        self.builtin_int     = stab.lookup_assuming(self.mh, "Integer")
+        self.builtin_bool = stab.lookup_assuming(self.mh, "Boolean")
+        self.builtin_int = stab.lookup_assuming(self.mh, "Integer")
         self.builtin_decimal = stab.lookup_assuming(self.mh, "Decimal")
-        self.builtin_str     = stab.lookup_assuming(self.mh, "String")
-        self.builtin_mstr    = stab.lookup_assuming(self.mh, "Markup_String")
+        self.builtin_str = stab.lookup_assuming(self.mh, "String")
+        self.builtin_mstr = stab.lookup_assuming(self.mh, "Markup_String")
 
         self.section = []
         self.default_scope = ast.Scope()
@@ -346,10 +359,7 @@ class Parser(Parser_Base):
         else:
             return name, None, None
 
-    def parse_qualified_name(self,
-                             scope,
-                             required_subclass=None,
-                             match_ident=True):
+    def parse_qualified_name(self, scope, required_subclass=None, match_ident=True):
         # lobster-trace: LRM.Qualified_Name
         # lobster-trace: LRM.Valid_Qualifier
         # lobster-trace: LRM.Valid_Name
@@ -364,8 +374,7 @@ class Parser(Parser_Base):
 
         if isinstance(sym, ast.Package):
             if not self.cu.is_visible(sym):
-                self.mh.error(self.ct.location,
-                              "package must be imported before use")
+                self.mh.error(self.ct.location, "package must be imported before use")
             self.match("DOT")
             sym.set_ast_link(self.ct)
             self.match("IDENTIFIER")
@@ -391,10 +400,12 @@ class Parser(Parser_Base):
         t_enum = self.ct
         name, description, t_description = self.parse_described_name()
 
-        enum = ast.Enumeration_Type(name        = name.value,
-                                    description = description,
-                                    location    = name.location,
-                                    package     = self.cu.package)
+        enum = ast.Enumeration_Type(
+            name=name.value,
+            description=description,
+            location=name.location,
+            package=self.cu.package,
+        )
         self.cu.package.symbols.register(self.mh, enum)
         enum.set_ast_link(t_enum)
         enum.set_ast_link(name)
@@ -406,10 +417,12 @@ class Parser(Parser_Base):
         empty = True
         while not self.peek("C_KET"):
             name, description, t_description = self.parse_described_name()
-            lit = ast.Enumeration_Literal_Spec(name        = name.value,
-                                               description = description,
-                                               location    = name.location,
-                                               enum        = enum)
+            lit = ast.Enumeration_Literal_Spec(
+                name=name.value,
+                description=description,
+                location=name.location,
+                enum=enum,
+            )
             lit.set_ast_link(name)
             if t_description:
                 lit.set_ast_link(self.ct)
@@ -420,16 +433,13 @@ class Parser(Parser_Base):
 
         if empty:
             # lobster-trace: LRM.No_Empty_Enumerations
-            self.mh.error(enum.location,
-                          "empty enumerations are not permitted")
+            self.mh.error(enum.location, "empty enumerations are not permitted")
 
         return enum
 
-    def parse_tuple_field(self,
-                          n_tuple,
-                          optional_allowed,
-                          optional_reason,
-                          optional_required):
+    def parse_tuple_field(
+        self, n_tuple, optional_allowed, optional_reason, optional_required
+    ):
         assert isinstance(n_tuple, ast.Tuple_Type)
         assert isinstance(optional_allowed, bool)
         assert isinstance(optional_reason, str)
@@ -440,13 +450,13 @@ class Parser(Parser_Base):
 
         if optional_required or self.peek_kw("optional"):
             self.match_kw("optional")
-            t_optional        = self.ct
+            t_optional = self.ct
             field_is_optional = True
             if not optional_allowed:
                 self.mh.error(self.ct.location, optional_reason)
         else:
             field_is_optional = False
-            t_optional        = None
+            t_optional = None
 
         # lobster-trace: LRM.Tuple_Field_Types
         # S_BRA here means a union type '[T1, T2, ...]', not array bounds.
@@ -454,14 +464,15 @@ class Parser(Parser_Base):
             # lobster-trace: LRM.union_type
             field_type = self.parse_union_type()
         else:
-            field_type = self.parse_qualified_name(self.default_scope,
-                                                   ast.Type)
-        comp = ast.Composite_Component(name        = field_name.value,
-                                       description = field_description,
-                                       location    = field_name.location,
-                                       member_of   = n_tuple,
-                                       n_typ       = field_type,
-                                       optional    = field_is_optional)
+            field_type = self.parse_qualified_name(self.default_scope, ast.Type)
+        comp = ast.Composite_Component(
+            name=field_name.value,
+            description=field_description,
+            location=field_name.location,
+            member_of=n_tuple,
+            n_typ=field_type,
+            optional=field_is_optional,
+        )
         comp.set_ast_link(field_name)
         if t_descr:
             comp.set_ast_link(t_descr)
@@ -476,10 +487,12 @@ class Parser(Parser_Base):
         t_tuple = self.ct
         name, description, t_descr = self.parse_described_name()
 
-        n_tuple = ast.Tuple_Type(name        = name.value,
-                                 description = description,
-                                 location    = name.location,
-                                 package     = self.cu.package)
+        n_tuple = ast.Tuple_Type(
+            name=name.value,
+            description=description,
+            location=name.location,
+            package=self.cu.package,
+        )
 
         n_tuple.set_ast_link(t_tuple)
         n_tuple.set_ast_link(name)
@@ -490,12 +503,13 @@ class Parser(Parser_Base):
 
         n_field = self.parse_tuple_field(
             n_tuple,
-            optional_allowed  = False,
-            optional_reason   = "first field may not be optional",
-            optional_required = False)
+            optional_allowed=False,
+            optional_reason="first field may not be optional",
+            optional_required=False,
+        )
         n_tuple.components.register(self.mh, n_field)
 
-        has_separators    = False
+        has_separators = False
         optional_required = False
         separator_allowed = True
 
@@ -506,13 +520,15 @@ class Parser(Parser_Base):
                 t_sep = self.ct
                 if not separator_allowed:
                     # lobster-trace: LRM.Tuple_Separators_All_Or_None
-                    self.mh.error(self.ct.location,
-                                  "either all fields must be separated,"
-                                  " or none")
-                if self.peek("IDENTIFIER") or \
-                   self.peek("AT") or \
-                   self.peek("COLON") or \
-                   self.peek("SEMICOLON"):
+                    self.mh.error(
+                        self.ct.location, "either all fields must be separated, or none"
+                    )
+                if (
+                    self.peek("IDENTIFIER")
+                    or self.peek("AT")
+                    or self.peek("COLON")
+                    or self.peek("SEMICOLON")
+                ):
                     self.advance()
                     sep = ast.Separator(self.ct)
                     sep.set_ast_link(t_sep)
@@ -523,10 +539,10 @@ class Parser(Parser_Base):
             # lobster-trace: LRM.Tuple_Optional_Requires_Separators
             n_field = self.parse_tuple_field(
                 n_tuple,
-                optional_allowed  = has_separators,
-                optional_reason   = ("optional only permitted in tuples"
-                                     " with separators"),
-                optional_required = optional_required)
+                optional_allowed=has_separators,
+                optional_reason=("optional only permitted in tuples with separators"),
+                optional_required=optional_required,
+            )
             n_tuple.components.register(self.mh, n_field)
             # lobster-trace: LRM.Tuple_Optional_Fields
             optional_required |= n_field.optional
@@ -539,13 +555,15 @@ class Parser(Parser_Base):
         if has_separators:
             # lobster-trace: LRM.Restricted_Tuple_Nesting
             for n_field in n_tuple.components.values():
-                if isinstance(n_field.n_typ, ast.Tuple_Type) and \
-                   n_field.n_typ.has_separators():
+                if (
+                    isinstance(n_field.n_typ, ast.Tuple_Type)
+                    and n_field.n_typ.has_separators()
+                ):
                     self.mh.error(
                         n_field.location,
                         "tuple type %s, which contains separators,"
-                        " may not contain another tuple with separators"
-                        % n_tuple.name)
+                        " may not contain another tuple with separators" % n_tuple.name,
+                    )
 
         # Late registration to avoid recursion in tuples
         # lobster-trace: LRM.Tuple_Field_Types
@@ -566,16 +584,13 @@ class Parser(Parser_Base):
         t_s_bra = self.ct
 
         union_type_entries = []  # list of (Record_Type, Location)
-        first_type = self.parse_qualified_name(self.default_scope,
-                                               ast.Record_Type)
+        first_type = self.parse_qualified_name(self.default_scope, ast.Record_Type)
         first_type.set_ast_link(self.ct)
         union_type_entries.append((first_type, self.ct.location))
 
         while self.peek("COMMA"):
             self.match("COMMA")
-            next_type = self.parse_qualified_name(
-                self.default_scope,
-                ast.Record_Type)
+            next_type = self.parse_qualified_name(self.default_scope, ast.Record_Type)
             next_type.set_ast_link(self.ct)
             union_type_entries.append((next_type, self.ct.location))
 
@@ -586,16 +601,12 @@ class Parser(Parser_Base):
         for t, loc in union_type_entries:
             fqn = t.fully_qualified_name()
             if fqn in seen:
-                self.mh.error(loc,
-                              "duplicate type %s in union" % t.name,
-                              fatal=False)
+                self.mh.error(loc, "duplicate type %s in union" % t.name, fatal=False)
             else:
                 seen[fqn] = loc
 
         union_types = [t for t, _ in union_type_entries]
-        c_typ = ast.Union_Type(
-            location = t_s_bra.location,
-            types    = union_types)
+        c_typ = ast.Union_Type(location=t_s_bra.location, types=union_types)
         c_typ.set_ast_link(t_s_bra)
         c_typ.set_ast_link(t_s_ket)
         return c_typ
@@ -616,8 +627,7 @@ class Parser(Parser_Base):
         if self.peek("S_BRA"):
             c_typ = self.parse_union_type()
         else:
-            c_typ = self.parse_qualified_name(self.default_scope,
-                                              ast.Type)
+            c_typ = self.parse_qualified_name(self.default_scope, ast.Type)
             c_typ.set_ast_link(self.ct)
 
         if self.peek("S_BRA"):
@@ -630,37 +640,40 @@ class Parser(Parser_Base):
             self.match("RANGE")
             t_range = self.ct
             a_loc = self.ct.location
-            a_hi  = None
+            a_hi = None
             if self.peek("INTEGER"):
                 self.match("INTEGER")
                 a_hi = self.ct.value
             elif self.peek("OPERATOR") and self.nt.value == "*":
                 self.match("OPERATOR")
             else:
-                self.mh.error(self.nt.location,
-                              "expected INTEGER or * for upper bound")
+                self.mh.error(self.nt.location, "expected INTEGER or * for upper bound")
             t_hi = self.ct
             loc_hi = self.ct.location
             self.match("S_KET")
             t_s_ket = self.ct
-            c_typ = ast.Array_Type(location     = a_loc,
-                                   element_type = c_typ,
-                                   lower_bound  = a_lo,
-                                   upper_bound  = a_hi,
-                                   loc_lower    = loc_lo,
-                                   loc_upper    = loc_hi)
+            c_typ = ast.Array_Type(
+                location=a_loc,
+                element_type=c_typ,
+                lower_bound=a_lo,
+                upper_bound=a_hi,
+                loc_lower=loc_lo,
+                loc_upper=loc_hi,
+            )
             c_typ.set_ast_link(t_s_bra)
             c_typ.set_ast_link(t_lo)
             c_typ.set_ast_link(t_range)
             c_typ.set_ast_link(t_hi)
             c_typ.set_ast_link(t_s_ket)
 
-        c_comp = ast.Composite_Component(name        = c_name.value,
-                                         description = c_descr,
-                                         location    = c_name.location,
-                                         member_of   = n_record,
-                                         n_typ       = c_typ,
-                                         optional    = c_optional)
+        c_comp = ast.Composite_Component(
+            name=c_name.value,
+            description=c_descr,
+            location=c_name.location,
+            member_of=n_record,
+            n_typ=c_typ,
+            optional=c_optional,
+        )
         c_comp.set_ast_link(c_name)
         if t_descr:
             c_comp.set_ast_link(t_descr)
@@ -670,17 +683,17 @@ class Parser(Parser_Base):
         return c_comp
 
     def parse_record_declaration(self):
-        t_abstract  = None
-        t_final     = None
+        t_abstract = None
+        t_final = None
         is_abstract = False
-        is_final    = False
+        is_final = False
         if self.peek_kw("abstract"):
             self.match_kw("abstract")
-            t_abstract  = self.ct
+            t_abstract = self.ct
             is_abstract = True
         elif self.peek_kw("final"):
             self.match_kw("final")
-            t_final  = self.ct
+            t_final = self.ct
             is_final = True
 
         self.match_kw("type")
@@ -690,30 +703,33 @@ class Parser(Parser_Base):
         if self.peek_kw("extends"):
             self.match_kw("extends")
             t_extends = self.ct
-            root_record = self.parse_qualified_name(self.default_scope,
-                                                    ast.Record_Type)
+            root_record = self.parse_qualified_name(self.default_scope, ast.Record_Type)
             root_record.set_ast_link(t_extends)
             root_record.set_ast_link(self.ct)
         else:
             root_record = None
 
-        if self.lint_mode and \
-           root_record and root_record.is_final and \
-           not is_final:
-            self.mh.check(name.location,
-                          "consider clarifying that this record is final",
-                          "clarify_final",
-                          ("Parent record %s is final, making this record\n"
-                           "also final. Marking it explicitly as final\n"
-                           "clarifies this to casual readers." %
-                           root_record.fully_qualified_name()))
+        if self.lint_mode and root_record and root_record.is_final and not is_final:
+            self.mh.check(
+                name.location,
+                "consider clarifying that this record is final",
+                "clarify_final",
+                (
+                    "Parent record %s is final, making this record\n"
+                    "also final. Marking it explicitly as final\n"
+                    "clarifies this to casual readers."
+                    % root_record.fully_qualified_name()
+                ),
+            )
 
-        record = ast.Record_Type(name        = name.value,
-                                 description = description,
-                                 location    = name.location,
-                                 package     = self.cu.package,
-                                 n_parent    = root_record,
-                                 is_abstract = is_abstract)
+        record = ast.Record_Type(
+            name=name.value,
+            description=description,
+            location=name.location,
+            package=self.cu.package,
+            n_parent=root_record,
+            is_abstract=is_abstract,
+        )
         self.cu.package.symbols.register(self.mh, record)
         if is_abstract:
             record.set_ast_link(t_abstract)
@@ -731,16 +747,16 @@ class Parser(Parser_Base):
                 self.match_kw("freeze")
                 t_freeze = self.ct
                 self.match("IDENTIFIER")
-                n_comp = record.components.lookup(self.mh,
-                                                  self.ct,
-                                                  ast.Composite_Component)
+                n_comp = record.components.lookup(
+                    self.mh, self.ct, ast.Composite_Component
+                )
                 if record.is_frozen(n_comp):
                     n_value = record.get_freezing_expression(n_comp)
                     self.mh.error(
                         self.ct.location,
-                        "duplicate freezing of %s, previously frozen at %s" %
-                        (n_comp.name,
-                         self.mh.cross_file_reference(n_value.location)))
+                        "duplicate freezing of %s, previously frozen at %s"
+                        % (n_comp.name, self.mh.cross_file_reference(n_value.location)),
+                    )
                 n_comp.set_ast_link(t_freeze)
                 n_comp.set_ast_link(self.ct)
                 self.match("ASSIGN")
@@ -753,9 +769,10 @@ class Parser(Parser_Base):
             else:
                 n_comp = self.parse_record_component(record)
                 if record.is_final:
-                    self.mh.error(n_comp.location,
-                                  "cannot declare new components in"
-                                  " final record type")
+                    self.mh.error(
+                        n_comp.location,
+                        "cannot declare new components in final record type",
+                    )
                 else:
                     record.components.register(self.mh, n_comp)
 
@@ -777,60 +794,64 @@ class Parser(Parser_Base):
         if self.peek_kw("and"):
             while self.peek_kw("and"):
                 self.match_kw("and")
-                t_op  = self.ct
+                t_op = self.ct
                 a_op = ast.Binary_Operator.LOGICAL_AND
                 t_op.ast_link = a_op
                 n_rhs = self.parse_relation(scope)
                 n_lhs = ast.Binary_Expression(
-                    mh       = self.mh,
-                    location = t_op.location,
-                    typ      = self.builtin_bool,
-                    operator = a_op,
-                    n_lhs    = n_lhs,
-                    n_rhs    = n_rhs)
+                    mh=self.mh,
+                    location=t_op.location,
+                    typ=self.builtin_bool,
+                    operator=a_op,
+                    n_lhs=n_lhs,
+                    n_rhs=n_rhs,
+                )
 
         elif self.peek_kw("or"):
             while self.peek_kw("or"):
                 self.match_kw("or")
-                t_op  = self.ct
+                t_op = self.ct
                 a_op = ast.Binary_Operator.LOGICAL_OR
                 t_op.ast_link = a_op
                 n_rhs = self.parse_relation(scope)
                 n_lhs = ast.Binary_Expression(
-                    mh       = self.mh,
-                    location = t_op.location,
-                    typ      = self.builtin_bool,
-                    operator = a_op,
-                    n_lhs    = n_lhs,
-                    n_rhs    = n_rhs)
+                    mh=self.mh,
+                    location=t_op.location,
+                    typ=self.builtin_bool,
+                    operator=a_op,
+                    n_lhs=n_lhs,
+                    n_rhs=n_rhs,
+                )
 
         elif self.peek_kw("xor"):
             self.match_kw("xor")
-            t_op  = self.ct
+            t_op = self.ct
             a_op = ast.Binary_Operator.LOGICAL_XOR
             t_op.ast_link = a_op
             n_rhs = self.parse_relation(scope)
             n_lhs = ast.Binary_Expression(
-                mh       = self.mh,
-                location = t_op.location,
-                typ      = self.builtin_bool,
-                operator = a_op,
-                n_lhs    = n_lhs,
-                n_rhs    = n_rhs)
+                mh=self.mh,
+                location=t_op.location,
+                typ=self.builtin_bool,
+                operator=a_op,
+                n_lhs=n_lhs,
+                n_rhs=n_rhs,
+            )
 
         elif self.peek_kw("implies"):
             self.match_kw("implies")
-            t_op  = self.ct
+            t_op = self.ct
             a_op = ast.Binary_Operator.LOGICAL_IMPLIES
             t_op.ast_link = a_op
             n_rhs = self.parse_relation(scope)
             n_lhs = ast.Binary_Expression(
-                mh       = self.mh,
-                location = t_op.location,
-                typ      = self.builtin_bool,
-                operator = a_op,
-                n_lhs    = n_lhs,
-                n_rhs    = n_rhs)
+                mh=self.mh,
+                location=t_op.location,
+                typ=self.builtin_bool,
+                operator=a_op,
+                n_lhs=n_lhs,
+                n_rhs=n_rhs,
+            )
 
         return n_lhs
 
@@ -838,30 +859,32 @@ class Parser(Parser_Base):
         # lobster-trace: LRM.Relation
         # lobster-trace: LRM.Operators
         assert isinstance(scope, ast.Scope)
-        relop_mapping = {"==" : ast.Binary_Operator.COMP_EQ,
-                         "!=" : ast.Binary_Operator.COMP_NEQ,
-                         "<"  : ast.Binary_Operator.COMP_LT,
-                         "<=" : ast.Binary_Operator.COMP_LEQ,
-                         ">"  : ast.Binary_Operator.COMP_GT,
-                         ">=" : ast.Binary_Operator.COMP_GEQ}
+        relop_mapping = {
+            "==": ast.Binary_Operator.COMP_EQ,
+            "!=": ast.Binary_Operator.COMP_NEQ,
+            "<": ast.Binary_Operator.COMP_LT,
+            "<=": ast.Binary_Operator.COMP_LEQ,
+            ">": ast.Binary_Operator.COMP_GT,
+            ">=": ast.Binary_Operator.COMP_GEQ,
+        }
         assert set(relop_mapping) == set(Parser.COMPARISON_OPERATOR)
 
         n_lhs = self.parse_simple_expression(scope)
 
-        if self.peek("OPERATOR") and \
-           self.nt.value in Parser.COMPARISON_OPERATOR:
+        if self.peek("OPERATOR") and self.nt.value in Parser.COMPARISON_OPERATOR:
             self.match("OPERATOR")
-            t_op  = self.ct
+            t_op = self.ct
             a_op = relop_mapping[t_op.value]
             t_op.ast_link = a_op
             n_rhs = self.parse_simple_expression(scope)
             return ast.Binary_Expression(
-                mh       = self.mh,
-                location = t_op.location,
-                typ      = self.builtin_bool,
-                operator = a_op,
-                n_lhs    = n_lhs,
-                n_rhs    = n_rhs)
+                mh=self.mh,
+                location=t_op.location,
+                typ=self.builtin_bool,
+                operator=a_op,
+                n_lhs=n_lhs,
+                n_rhs=n_rhs,
+            )
 
         elif self.peek_kw("not") or self.peek_kw("in"):
             if self.peek_kw("not"):
@@ -881,52 +904,57 @@ class Parser(Parser_Base):
                 n_b = self.parse_simple_expression(scope)
                 n_b.set_ast_link(self.ct)
                 n_a.set_ast_link(t_n_a)
-                rv  = ast.Range_Test(
-                    mh       = self.mh,
-                    location = t_in.location,
-                    typ      = self.builtin_bool,
-                    n_lhs    = n_lhs,
-                    n_lower  = n_a,
-                    n_upper  = n_b)
+                rv = ast.Range_Test(
+                    mh=self.mh,
+                    location=t_in.location,
+                    typ=self.builtin_bool,
+                    n_lhs=n_lhs,
+                    n_lower=n_a,
+                    n_upper=n_b,
+                )
                 rv.set_ast_link(t_range)
                 rv.set_ast_link(t_in)
 
             elif isinstance(n_a.typ, ast.Builtin_String):
                 rv = ast.Binary_Expression(
-                    mh       = self.mh,
-                    location = t_in.location,
-                    typ      = self.builtin_bool,
-                    operator = ast.Binary_Operator.STRING_CONTAINS,
-                    n_lhs    = n_lhs,
-                    n_rhs    = n_a)
+                    mh=self.mh,
+                    location=t_in.location,
+                    typ=self.builtin_bool,
+                    operator=ast.Binary_Operator.STRING_CONTAINS,
+                    n_lhs=n_lhs,
+                    n_rhs=n_a,
+                )
                 rv.set_ast_link(t_in)
 
             elif isinstance(n_a.typ, ast.Array_Type):
                 a_op = ast.Binary_Operator.ARRAY_CONTAINS
                 t_in.ast_link = a_op
                 rv = ast.Binary_Expression(
-                    mh       = self.mh,
-                    location = t_in.location,
-                    typ      = self.builtin_bool,
-                    operator = a_op,
-                    n_lhs    = n_lhs,
-                    n_rhs    = n_a)
+                    mh=self.mh,
+                    location=t_in.location,
+                    typ=self.builtin_bool,
+                    operator=a_op,
+                    n_lhs=n_lhs,
+                    n_rhs=n_a,
+                )
 
             else:
                 self.mh.error(
                     n_a.location,
                     "membership test only defined for Strings and Arrays,"
-                    " not for %s" % n_a.typ.name)
+                    " not for %s" % n_a.typ.name,
+                )
 
             if t_not is not None:
                 a_unary_op = ast.Unary_Operator.LOGICAL_NOT
                 t_not.ast_link = a_unary_op
                 rv = ast.Unary_Expression(
-                    mh        = self.mh,
-                    location  = t_not.location,
-                    typ       = self.builtin_bool,
-                    operator  = a_unary_op,
-                    n_operand = rv)
+                    mh=self.mh,
+                    location=t_not.location,
+                    typ=self.builtin_bool,
+                    operator=a_unary_op,
+                    n_operand=rv,
+                )
 
             return rv
 
@@ -938,15 +966,12 @@ class Parser(Parser_Base):
         # lobster-trace: LRM.Operators
         # lobster-trace: LRM.Unary_Minus_Parsing
         assert isinstance(scope, ast.Scope)
-        un_add_map = {"+" : ast.Unary_Operator.PLUS,
-                      "-" : ast.Unary_Operator.MINUS}
-        bin_add_map = {"+" : ast.Binary_Operator.PLUS,
-                       "-" : ast.Binary_Operator.MINUS}
+        un_add_map = {"+": ast.Unary_Operator.PLUS, "-": ast.Unary_Operator.MINUS}
+        bin_add_map = {"+": ast.Binary_Operator.PLUS, "-": ast.Binary_Operator.MINUS}
         assert set(un_add_map) == set(Parser.ADDING_OPERATOR)
         assert set(bin_add_map) == set(Parser.ADDING_OPERATOR)
 
-        if self.peek("OPERATOR") and \
-           self.nt.value in Parser.ADDING_OPERATOR:
+        if self.peek("OPERATOR") and self.nt.value in Parser.ADDING_OPERATOR:
             self.match("OPERATOR")
             t_unary = self.ct
             a_unary = un_add_map[t_unary.value]
@@ -958,41 +983,45 @@ class Parser(Parser_Base):
         n_lhs = self.parse_term(scope)
         if t_unary:
             # pylint: disable=possibly-used-before-assignment
-            if self.lint_mode and \
-               isinstance(n_lhs, ast.Binary_Expression) and \
-               not has_explicit_brackets:
-                self.mh.check(t_unary.location,
-                              "expression means -(%s), place explicit "
-                              "brackets to clarify intent" %
-                              n_lhs.to_string(),
-                              "unary_minus_precedence")
+            if (
+                self.lint_mode
+                and isinstance(n_lhs, ast.Binary_Expression)
+                and not has_explicit_brackets
+            ):
+                self.mh.check(
+                    t_unary.location,
+                    "expression means -(%s), place explicit "
+                    "brackets to clarify intent" % n_lhs.to_string(),
+                    "unary_minus_precedence",
+                )
 
             n_lhs = ast.Unary_Expression(
-                mh        = self.mh,
-                location  = t_unary.location,
-                typ       = n_lhs.typ,
-                operator  = a_unary,
-                n_operand = n_lhs)
+                mh=self.mh,
+                location=t_unary.location,
+                typ=n_lhs.typ,
+                operator=a_unary,
+                n_operand=n_lhs,
+            )
 
         if isinstance(n_lhs.typ, ast.Builtin_String):
             rtyp = self.builtin_str
         else:
             rtyp = n_lhs.typ
 
-        while self.peek("OPERATOR") and \
-              self.nt.value in Parser.ADDING_OPERATOR:
+        while self.peek("OPERATOR") and self.nt.value in Parser.ADDING_OPERATOR:
             self.match("OPERATOR")
-            t_op  = self.ct
+            t_op = self.ct
             a_op = bin_add_map[t_op.value]
             t_op.ast_link = a_op
             n_rhs = self.parse_term(scope)
             n_lhs = ast.Binary_Expression(
-                mh       = self.mh,
-                location = t_op.location,
-                typ      = rtyp,
-                operator = a_op,
-                n_lhs    = n_lhs,
-                n_rhs    = n_rhs)
+                mh=self.mh,
+                location=t_op.location,
+                typ=rtyp,
+                operator=a_op,
+                n_lhs=n_lhs,
+                n_rhs=n_rhs,
+            )
 
         return n_lhs
 
@@ -1000,26 +1029,28 @@ class Parser(Parser_Base):
         # lobster-trace: LRM.Term
         # lobster-trace: LRM.Operators
         assert isinstance(scope, ast.Scope)
-        mul_map = {"*" : ast.Binary_Operator.TIMES,
-                   "/" : ast.Binary_Operator.DIVIDE,
-                   "%" : ast.Binary_Operator.REMAINDER}
+        mul_map = {
+            "*": ast.Binary_Operator.TIMES,
+            "/": ast.Binary_Operator.DIVIDE,
+            "%": ast.Binary_Operator.REMAINDER,
+        }
         assert set(mul_map) == set(Parser.MULTIPLYING_OPERATOR)
 
         n_lhs = self.parse_factor(scope)
-        while self.peek("OPERATOR") and \
-              self.nt.value in Parser.MULTIPLYING_OPERATOR:
+        while self.peek("OPERATOR") and self.nt.value in Parser.MULTIPLYING_OPERATOR:
             self.match("OPERATOR")
-            t_op  = self.ct
+            t_op = self.ct
             a_op = mul_map[t_op.value]
             t_op.ast_link = a_op
             n_rhs = self.parse_factor(scope)
             n_lhs = ast.Binary_Expression(
-                mh       = self.mh,
-                location = t_op.location,
-                typ      = n_lhs.typ,
-                operator = a_op,
-                n_lhs    = n_lhs,
-                n_rhs    = n_rhs)
+                mh=self.mh,
+                location=t_op.location,
+                typ=n_lhs.typ,
+                operator=a_op,
+                n_lhs=n_lhs,
+                n_rhs=n_rhs,
+            )
 
         return n_lhs
 
@@ -1029,49 +1060,51 @@ class Parser(Parser_Base):
 
         if self.peek_kw("not"):
             self.match_kw("not")
-            t_op      = self.ct
+            t_op = self.ct
             n_operand = self.parse_primary(scope)
             a_not = ast.Unary_Operator.LOGICAL_NOT
             t_op.ast_link = a_not
             return ast.Unary_Expression(
-                mh        = self.mh,
-                location  = t_op.location,
-                typ       = self.builtin_bool,
-                operator  = a_not,
-                n_operand = n_operand)
+                mh=self.mh,
+                location=t_op.location,
+                typ=self.builtin_bool,
+                operator=a_not,
+                n_operand=n_operand,
+            )
 
         elif self.peek_kw("abs"):
             self.match_kw("abs")
-            t_op      = self.ct
+            t_op = self.ct
             n_operand = self.parse_primary(scope)
             a_abs = ast.Unary_Operator.ABSOLUTE_VALUE
             t_op.ast_link = a_abs
             return ast.Unary_Expression(
-                mh        = self.mh,
-                location  = t_op.location,
-                typ       = n_operand.typ,
-                operator  = a_abs,
-                n_operand = n_operand)
+                mh=self.mh,
+                location=t_op.location,
+                typ=n_operand.typ,
+                operator=a_abs,
+                n_operand=n_operand,
+            )
 
         else:
             n_lhs = self.parse_primary(scope)
             if self.peek("OPERATOR") and self.nt.value == "**":
                 self.match("OPERATOR")
-                t_op  = self.ct
+                t_op = self.ct
                 n_rhs = self.parse_primary(scope)
                 rhs_value = n_rhs.evaluate(self.mh, None, None)
                 a_binary = ast.Binary_Operator.POWER
                 t_op.ast_link = a_binary
                 n_lhs = ast.Binary_Expression(
-                    mh       = self.mh,
-                    location = t_op.location,
-                    typ      = n_lhs.typ,
-                    operator = a_binary,
-                    n_lhs    = n_lhs,
-                    n_rhs    = n_rhs)
+                    mh=self.mh,
+                    location=t_op.location,
+                    typ=n_lhs.typ,
+                    operator=a_binary,
+                    n_lhs=n_lhs,
+                    n_rhs=n_rhs,
+                )
                 if rhs_value.value < 0:
-                    self.mh.error(n_rhs.location,
-                                  "exponent must not be negative")
+                    self.mh.error(n_rhs.location, "exponent must not be negative")
             return n_lhs
 
     def parse_primary(self, scope):
@@ -1147,25 +1180,27 @@ class Parser(Parser_Base):
         if scope.contains(t_qv.value):
             # lobster-trace: LRM.Quantification_Naming_Scope
             pdef = scope.lookup(self.mh, t_qv)
-            self.mh.error(t_qv.location,
-                          "shadows %s %s from %s" %
-                          (pdef.__class__.__name__,
-                           pdef.name,
-                           self.mh.cross_file_reference(pdef.location)))
+            self.mh.error(
+                t_qv.location,
+                "shadows %s %s from %s"
+                % (
+                    pdef.__class__.__name__,
+                    pdef.name,
+                    self.mh.cross_file_reference(pdef.location),
+                ),
+            )
         self.match_kw("in")
         t_in = self.ct
         self.match("IDENTIFIER")
         field = scope.lookup(self.mh, self.ct, ast.Composite_Component)
-        n_source = ast.Name_Reference(self.ct.location,
-                                      field)
+        n_source = ast.Name_Reference(self.ct.location, field)
         n_source.set_ast_link(self.ct)
         if not isinstance(field.n_typ, ast.Array_Type):
             # lobster-trace: LRM.Quantification_Object
-            self.mh.error(self.ct.location,
-                          "you can only quantify over arrays")
-        n_var = ast.Quantified_Variable(t_qv.value,
-                                        t_qv.location,
-                                        field.n_typ.element_type)
+            self.mh.error(self.ct.location, "you can only quantify over arrays")
+        n_var = ast.Quantified_Variable(
+            t_qv.value, t_qv.location, field.n_typ.element_type
+        )
         n_var.set_ast_link(t_qv)
         self.match("ARROW")
         t_arrow = self.ct
@@ -1177,13 +1212,14 @@ class Parser(Parser_Base):
         scope.pop()
 
         quantified_expression = ast.Quantified_Expression(
-            mh         = self.mh,
-            location   = loc,
-            typ        = self.builtin_bool,
-            universal  = universal,
-            n_variable = n_var,
-            n_source   = n_source,
-            n_expr     = n_expr)
+            mh=self.mh,
+            location=loc,
+            typ=self.builtin_bool,
+            universal=universal,
+            n_variable=n_var,
+            n_source=n_source,
+            n_expr=n_expr,
+        )
 
         quantified_expression.set_ast_link(t_quantified)
         quantified_expression.set_ast_link(t_in)
@@ -1203,12 +1239,10 @@ class Parser(Parser_Base):
         t_then = self.ct
         if_expr = self.parse_expression(scope)
         if if_expr.typ is None:
-            self.mh.error(if_expr.location,
-                          "null is not permitted here")
+            self.mh.error(if_expr.location, "null is not permitted here")
         if_action = ast.Action(self.mh, t_if, if_cond, if_expr)
 
-        rv = ast.Conditional_Expression(location  = t_if.location,
-                                        if_action = if_action)
+        rv = ast.Conditional_Expression(location=t_if.location, if_action=if_action)
         if_action.set_ast_link(t_if)
         if_action.set_ast_link(t_then)
 
@@ -1235,8 +1269,7 @@ class Parser(Parser_Base):
         # lobster-trace: LRM.Builtin_Functions
         # lobster-trace: LRM.Builtin_Type_Conversion_Functions
         assert isinstance(scope, ast.Scope)
-        assert isinstance(n_name, (ast.Builtin_Function,
-                                   ast.Builtin_Numeric_Type))
+        assert isinstance(n_name, (ast.Builtin_Function, ast.Builtin_Numeric_Type))
         assert isinstance(t_name, Token)
 
         # Parse the arguments.
@@ -1261,50 +1294,55 @@ class Parser(Parser_Base):
         # Enforce arity
         if isinstance(n_name, ast.Builtin_Function):
             required_arity = n_name.arity
-            precise        = not n_name.arity_at_least
+            precise = not n_name.arity_at_least
         else:
             required_arity = 1
-            precise        = True
+            precise = True
 
         if precise:
             if required_arity != len(parameters):
-                self.mh.error(t_name.location,
-                              "function requires %u parameters" %
-                              n_name.arity)
+                self.mh.error(
+                    t_name.location, "function requires %u parameters" % n_name.arity
+                )
         else:
             if required_arity > len(parameters):
-                self.mh.error(t_name.location,
-                              "function requires at least %u parameters" %
-                              n_name.arity)
+                self.mh.error(
+                    t_name.location,
+                    "function requires at least %u parameters" % n_name.arity,
+                )
 
         # Enforce types
         if n_name.name == "len":
             if isinstance(parameters[0].typ, ast.Builtin_String):
                 return ast.Unary_Expression(
-                    mh        = self.mh,
-                    location  = t_name.location,
-                    typ       = self.builtin_int,
-                    operator  = ast.Unary_Operator.STRING_LENGTH,
-                    n_operand = parameters[0])
+                    mh=self.mh,
+                    location=t_name.location,
+                    typ=self.builtin_int,
+                    operator=ast.Unary_Operator.STRING_LENGTH,
+                    n_operand=parameters[0],
+                )
             else:
                 return ast.Unary_Expression(
-                    mh        = self.mh,
-                    location  = t_name.location,
-                    typ       = self.builtin_int,
-                    operator  = ast.Unary_Operator.ARRAY_LENGTH,
-                    n_operand = parameters[0])
+                    mh=self.mh,
+                    location=t_name.location,
+                    typ=self.builtin_int,
+                    operator=ast.Unary_Operator.ARRAY_LENGTH,
+                    n_operand=parameters[0],
+                )
 
-        elif n_name.name in ("startswith",
-                             "endswith"):
+        elif n_name.name in ("startswith", "endswith"):
             return ast.Binary_Expression(
-                mh       = self.mh,
-                location = t_name.location,
-                typ      = self.builtin_bool,
-                operator = (ast.Binary_Operator.STRING_STARTSWITH
-                            if "startswith" in n_name.name
-                            else ast.Binary_Operator.STRING_ENDSWITH),
-                n_lhs    = parameters[0],
-                n_rhs    = parameters[1])
+                mh=self.mh,
+                location=t_name.location,
+                typ=self.builtin_bool,
+                operator=(
+                    ast.Binary_Operator.STRING_STARTSWITH
+                    if "startswith" in n_name.name
+                    else ast.Binary_Operator.STRING_ENDSWITH
+                ),
+                n_lhs=parameters[0],
+                n_rhs=parameters[1],
+            )
 
         elif n_name.name == "matches":
             parameters[1].ensure_type(self.mh, ast.Builtin_String)
@@ -1315,46 +1353,47 @@ class Parser(Parser_Base):
                 assert isinstance(value.typ, ast.Builtin_String)
                 re.compile(value.value)
             except re.error as err:
-                self.mh.error(value.location,
-                              str(err))
+                self.mh.error(value.location, str(err))
             return ast.Binary_Expression(
-                mh       = self.mh,
-                location = t_name.location,
-                typ      = self.builtin_bool,
-                operator = ast.Binary_Operator.STRING_REGEX,
-                n_lhs    = parameters[0],
-                n_rhs    = parameters[1])
+                mh=self.mh,
+                location=t_name.location,
+                typ=self.builtin_bool,
+                operator=ast.Binary_Operator.STRING_REGEX,
+                n_lhs=parameters[0],
+                n_rhs=parameters[1],
+            )
 
         elif n_name.name == "oneof":
             return ast.OneOf_Expression(
-                mh       = self.mh,
-                location = t_name.location,
-                typ      = self.builtin_bool,
-                choices  = parameters)
+                mh=self.mh,
+                location=t_name.location,
+                typ=self.builtin_bool,
+                choices=parameters,
+            )
 
         elif isinstance(n_name, ast.Builtin_Numeric_Type):
             parameters[0].ensure_type(self.mh, ast.Builtin_Numeric_Type)
             if isinstance(n_name, ast.Builtin_Integer):
                 return ast.Unary_Expression(
-                    mh        = self.mh,
-                    location  = t_name.location,
-                    typ       = self.builtin_int,
-                    operator  = ast.Unary_Operator.CONVERSION_TO_INT,
-                    n_operand = parameters[0])
+                    mh=self.mh,
+                    location=t_name.location,
+                    typ=self.builtin_int,
+                    operator=ast.Unary_Operator.CONVERSION_TO_INT,
+                    n_operand=parameters[0],
+                )
             elif isinstance(n_name, ast.Builtin_Decimal):
                 return ast.Unary_Expression(
-                    mh        = self.mh,
-                    location  = t_name.location,
-                    typ       = self.builtin_decimal,
-                    operator  = ast.Unary_Operator.CONVERSION_TO_DECIMAL,
-                    n_operand = parameters[0])
+                    mh=self.mh,
+                    location=t_name.location,
+                    typ=self.builtin_decimal,
+                    operator=ast.Unary_Operator.CONVERSION_TO_DECIMAL,
+                    n_operand=parameters[0],
+                )
             else:
-                self.mh.ice_loc(t_name.location,
-                                "unexpected type conversion")
+                self.mh.ice_loc(t_name.location, "unexpected type conversion")
 
         else:
-            self.mh.ice_loc(t_name.location,
-                            "unexpected builtin")
+            self.mh.ice_loc(t_name.location, "unexpected builtin")
 
     def parse_name(self, scope):
         # lobster-trace: LRM.Names
@@ -1385,13 +1424,11 @@ class Parser(Parser_Base):
         if self.peek("BRA"):
             # If we follow our name with brackets
             # immediately, we have a builtin function call.
-            n_name = self.stab.lookup(self.mh,
-                                        self.ct)
-            if not isinstance(n_name, (ast.Builtin_Function,
-                                        ast.Builtin_Numeric_Type)):
-                self.mh.error(self.ct.location,
-                                "not a valid builtin function "
-                                "or numeric type")
+            n_name = self.stab.lookup(self.mh, self.ct)
+            if not isinstance(n_name, (ast.Builtin_Function, ast.Builtin_Numeric_Type)):
+                self.mh.error(
+                    self.ct.location, "not a valid builtin function or numeric type"
+                )
         else:
             n_name = self.parse_qualified_name(scope, match_ident=False)
 
@@ -1402,62 +1439,60 @@ class Parser(Parser_Base):
             self.match("DOT")
             n_name.set_ast_link(self.ct)
             self.match("IDENTIFIER")
-            lit = n_name.literals.lookup(self.mh,
-                                         self.ct,
-                                         ast.Enumeration_Literal_Spec)
-            enum_lit = ast.Enumeration_Literal(location = self.ct.location,
-                                               literal  = lit)
+            lit = n_name.literals.lookup(self.mh, self.ct, ast.Enumeration_Literal_Spec)
+            enum_lit = ast.Enumeration_Literal(location=self.ct.location, literal=lit)
             enum_lit.set_ast_link(self.ct)
             return enum_lit
 
         # Anything that remains is either a function call or an actual
         # name. Let's just enforce this for sanity.
-        if not isinstance(n_name, (ast.Builtin_Function,
-                                   ast.Builtin_Numeric_Type,
-                                   ast.Composite_Component,
-                                   ast.Quantified_Variable,
-                                   )):
-            self.mh.error(self.ct.location,
-                          "%s %s is not a valid name" %
-                          (n_name.__class__.__name__,
-                           n_name.name))
+        if not isinstance(
+            n_name,
+            (
+                ast.Builtin_Function,
+                ast.Builtin_Numeric_Type,
+                ast.Composite_Component,
+                ast.Quantified_Variable,
+            ),
+        ):
+            self.mh.error(
+                self.ct.location,
+                "%s %s is not a valid name" % (n_name.__class__.__name__, n_name.name),
+            )
 
         # Right now function calls and type conversions must be
         # top-level, so let's get these out of the way as well.
-        if isinstance(n_name, (ast.Builtin_Function,
-                               ast.Builtin_Numeric_Type)):
+        if isinstance(n_name, (ast.Builtin_Function, ast.Builtin_Numeric_Type)):
             # lobster-trace: LRM.Builtin_Functions
             # lobster-trace: LRM.Builtin_Type_Conversion_Functions
             return self.parse_builtin(scope, n_name, self.ct)
 
-        assert isinstance(n_name, (ast.Composite_Component,
-                                   ast.Quantified_Variable))
+        assert isinstance(n_name, (ast.Composite_Component, ast.Quantified_Variable))
 
         # We now process the potentially recursive part:
         #        | name '.' IDENTIFIER
         #        | name '[' expression ']'
-        n_name = ast.Name_Reference(location = self.ct.location,
-                                    entity   = n_name)
+        n_name = ast.Name_Reference(location=self.ct.location, entity=n_name)
         n_name.set_ast_link(self.ct)
         while self.peek("DOT") or self.peek("S_BRA"):
             if self.peek("DOT"):
-                if not isinstance(n_name.typ, (ast.Tuple_Type,
-                                               ast.Record_Type,
-                                               ast.Union_Type)):
+                if not isinstance(
+                    n_name.typ, (ast.Tuple_Type, ast.Record_Type, ast.Union_Type)
+                ):
                     # lobster-trace: LRM.Valid_Index_Prefixes
-                    self.mh.error(n_name.location,
-                                  "expression '%s' has type %s, "
-                                  "which is not a tuple, record, or union" %
-                                  (n_name.to_string(),
-                                   n_name.typ.name))
+                    self.mh.error(
+                        n_name.location,
+                        "expression '%s' has type %s, "
+                        "which is not a tuple, record, or union"
+                        % (n_name.to_string(), n_name.typ.name),
+                    )
 
                 self.match("DOT")
                 t_dot = self.ct
                 self.match("IDENTIFIER")
                 t_field = self.ct
 
-                is_union_access = isinstance(n_name.typ,
-                                             ast.Union_Type)
+                is_union_access = isinstance(n_name.typ, ast.Union_Type)
                 is_universal = True
 
                 if is_union_access:
@@ -1470,15 +1505,15 @@ class Parser(Parser_Base):
                         self.mh.error(
                             t_field.location,
                             "field %s does not exist in any member"
-                            " of union type %s" %
-                            (field_name, n_name.typ.name))
+                            " of union type %s" % (field_name, n_name.typ.name),
+                        )
                     info = field_map[field_name]
                     if info["n_typ"] is None:
                         self.mh.error(
                             t_field.location,
                             "field %s has conflicting types in"
-                            " members of union type %s" %
-                            (field_name, n_name.typ.name))
+                            " members of union type %s" % (field_name, n_name.typ.name),
+                        )
                     is_universal = info["count"] == info["total"]
                     # lobster-trace: LRM.Union_Type_Partial_Field_Access
                     if self.lint_mode and not is_universal:
@@ -1487,36 +1522,39 @@ class Parser(Parser_Base):
                             "field %s exists only in %u of %u"
                             " members of union type %s;"
                             " accessing it on other members"
-                            " returns null" %
-                            (field_name,
-                             info["count"],
-                             info["total"],
-                             n_name.typ.name),
-                            "union_partial_field_access")
+                            " returns null"
+                            % (
+                                field_name,
+                                info["count"],
+                                info["total"],
+                                n_name.typ.name,
+                            ),
+                            "union_partial_field_access",
+                        )
                     n_field = info["component"]
                 else:
                     n_field = n_name.typ.components.lookup(
-                        self.mh,
-                        t_field,
-                        ast.Composite_Component)
+                        self.mh, t_field, ast.Composite_Component
+                    )
 
                 n_field.set_ast_link(t_field)
                 n_name = ast.Field_Access_Expression(
-                    mh              = self.mh,
-                    location        = t_field.location,
-                    n_prefix        = n_name,
-                    n_field         = n_field,
-                    is_union_access = is_union_access,
-                    is_universal    = is_universal)
+                    mh=self.mh,
+                    location=t_field.location,
+                    n_prefix=n_name,
+                    n_field=n_field,
+                    is_union_access=is_union_access,
+                    is_universal=is_universal,
+                )
                 n_name.set_ast_link(t_dot)
 
             elif self.peek("S_BRA"):
                 if not isinstance(n_name.typ, ast.Array_Type):
-                    self.mh.error(n_name.location,
-                                  "expression '%s' has type %s, "
-                                  "which is not an array" %
-                                  (n_name.to_string(),
-                                   n_name.typ.name))
+                    self.mh.error(
+                        n_name.location,
+                        "expression '%s' has type %s, "
+                        "which is not an array" % (n_name.to_string(), n_name.typ.name),
+                    )
 
                 self.match("S_BRA")
                 t_bracket = self.ct
@@ -1527,12 +1565,13 @@ class Parser(Parser_Base):
                 self.ct.ast_link = a_binary
 
                 n_name = ast.Binary_Expression(
-                    mh       = self.mh,
-                    location = t_bracket.location,
-                    typ      = n_name.typ.element_type,
-                    operator = a_binary,
-                    n_lhs    = n_name,
-                    n_rhs    = n_index)
+                    mh=self.mh,
+                    location=t_bracket.location,
+                    typ=n_name.typ.element_type,
+                    operator=a_binary,
+                    n_lhs=n_name,
+                    n_rhs=n_index,
+                )
 
         return n_name
 
@@ -1544,11 +1583,8 @@ class Parser(Parser_Base):
         self.match("IDENTIFIER")
         # lobster-trace: LRM.Applicable_Types
         # lobster-trace: LRM.Applicable_Components
-        n_ctype = self.cu.package.symbols.lookup(self.mh,
-                                                 self.ct,
-                                                 ast.Composite_Type)
-        n_check_block = ast.Check_Block(location = self.ct.location,
-                                        n_typ    = n_ctype)
+        n_ctype = self.cu.package.symbols.lookup(self.mh, self.ct, ast.Composite_Type)
+        n_check_block = ast.Check_Block(location=self.ct.location, n_typ=n_ctype)
         n_check_block.set_ast_link(t_checks)
         n_ctype.set_ast_link(self.ct)
         scope = ast.Scope()
@@ -1560,8 +1596,7 @@ class Parser(Parser_Base):
         while not self.peek("C_KET"):
             c_expr = self.parse_expression(scope)
             if not isinstance(c_expr.typ, ast.Builtin_Boolean):
-                self.mh.error(c_expr.location,
-                              "check expression must be Boolean")
+                self.mh.error(c_expr.location, "check expression must be Boolean")
 
             self.match("COMMA")
             t_first_comma = self.ct
@@ -1569,8 +1604,7 @@ class Parser(Parser_Base):
                 self.match("KEYWORD")
                 t_severity = self.ct
                 if self.ct.value not in ("warning", "error", "fatal"):
-                    self.mh.error(self.ct.location,
-                                  "expected warning|error|fatal")
+                    self.mh.error(self.ct.location, "expected warning|error|fatal")
                 c_sev = self.ct.value
             else:
                 c_sev = "error"
@@ -1578,13 +1612,15 @@ class Parser(Parser_Base):
             self.match("STRING")
             if "\n" in self.ct.value:
                 # lobster-trace: LRM.No_Newlines_In_Message
-                self.mh.error(self.ct.location,
-                              "error message must not contain a newline",
-                              fatal = False)
+                self.mh.error(
+                    self.ct.location,
+                    "error message must not contain a newline",
+                    fatal=False,
+                )
             t_msg = self.ct
 
             has_extrainfo = False
-            has_anchor    = False
+            has_anchor = False
             if self.peek("COMMA"):
                 self.match("COMMA")
                 t_second_comma = self.ct
@@ -1593,9 +1629,11 @@ class Parser(Parser_Base):
                 elif self.peek("STRING"):
                     has_extrainfo = True
                 else:
-                    self.mh.error(self.nt.location,
-                                  "expected either a details string or"
-                                  " identifier to anchor the check message")
+                    self.mh.error(
+                        self.nt.location,
+                        "expected either a details string or"
+                        " identifier to anchor the check message",
+                    )
 
             if has_extrainfo:
                 self.match("STRING")
@@ -1613,18 +1651,20 @@ class Parser(Parser_Base):
             if has_anchor:
                 self.match("IDENTIFIER")
                 t_anchor = self.ct
-                c_anchor = n_ctype.components.lookup(self.mh,
-                                                     self.ct,
-                                                     ast.Composite_Component)
+                c_anchor = n_ctype.components.lookup(
+                    self.mh, self.ct, ast.Composite_Component
+                )
             else:
                 c_anchor = None
 
-            n_check = ast.Check(n_type    = n_ctype,
-                                n_expr    = c_expr,
-                                n_anchor  = c_anchor,
-                                severity  = c_sev,
-                                t_message = t_msg,
-                                extrainfo = c_extrainfo)
+            n_check = ast.Check(
+                n_type=n_ctype,
+                n_expr=c_expr,
+                n_anchor=c_anchor,
+                severity=c_sev,
+                t_message=t_msg,
+                extrainfo=c_extrainfo,
+            )
 
             # pylint: disable=possibly-used-before-assignment
             # pylint: disable=used-before-assignment
@@ -1657,9 +1697,11 @@ class Parser(Parser_Base):
         self.match_kw("section")
         t_section = self.ct
         self.match("STRING")
-        sec = ast.Section(name     = self.ct.value,
-                          location = self.ct.location,
-                          parent = self.section[-1] if self.section else None)
+        sec = ast.Section(
+            name=self.ct.value,
+            location=self.ct.location,
+            parent=self.section[-1] if self.section else None,
+        )
         sec.set_ast_link(self.ct)
         sec.set_ast_link(t_section)
         self.section.append(sec)
@@ -1677,8 +1719,7 @@ class Parser(Parser_Base):
         if self.ct.value in ("true", "false"):
             return ast.Boolean_Literal(self.ct, self.builtin_bool)
         else:
-            self.mh.error(self.ct.location,
-                          "expected boolean literal (true or false)")
+            self.mh.error(self.ct.location, "expected boolean literal (true or false)")
 
     def parse_value(self, typ):
         # lobster-trace: LRM.Tuple_Syntax_Correct_Form
@@ -1687,13 +1728,14 @@ class Parser(Parser_Base):
         if isinstance(typ, ast.Builtin_Numeric_Type):
             # lobster-trace: LRM.Integer_Values
             # lobster-trace: LRM.Decimal_Values
-            if self.peek("OPERATOR") and \
-               self.nt.value in Parser.ADDING_OPERATOR:
+            if self.peek("OPERATOR") and self.nt.value in Parser.ADDING_OPERATOR:
                 self.match("OPERATOR")
                 t_op = self.ct
-                e_op = (ast.Unary_Operator.PLUS
-                        if t_op.value == "+"
-                        else ast.Unary_Operator.MINUS)
+                e_op = (
+                    ast.Unary_Operator.PLUS
+                    if t_op.value == "+"
+                    else ast.Unary_Operator.MINUS
+                )
                 t_op.ast_link = e_op
             else:
                 t_op = None
@@ -1710,11 +1752,13 @@ class Parser(Parser_Base):
                 assert False
 
             if t_op:
-                rv = ast.Unary_Expression(mh        = self.mh,
-                                          location  = t_op.location,
-                                          typ       = rv.typ,
-                                          operator  = e_op,
-                                          n_operand = rv)
+                rv = ast.Unary_Expression(
+                    mh=self.mh,
+                    location=t_op.location,
+                    typ=rv.typ,
+                    operator=e_op,
+                    n_operand=rv,
+                )
 
             return rv
 
@@ -1736,8 +1780,7 @@ class Parser(Parser_Base):
 
         elif isinstance(typ, ast.Array_Type):
             self.match("S_BRA")
-            rv = ast.Array_Aggregate(self.ct.location,
-                                     typ)
+            rv = ast.Array_Aggregate(self.ct.location, typ)
             rv.set_ast_link(self.ct)
             while not self.peek("S_KET"):
                 array_elem = self.parse_value(typ.element_type)
@@ -1748,46 +1791,42 @@ class Parser(Parser_Base):
                 elif self.peek("S_KET") or self.nt is None:
                     break
                 else:
-                    self.mh.error(self.ct.location,
-                                  "comma separating array elements is "
-                                  "missing",
-                                  fatal = False)
+                    self.mh.error(
+                        self.ct.location,
+                        "comma separating array elements is missing",
+                        fatal=False,
+                    )
 
             self.match("S_KET")
             rv.set_ast_link(self.ct)
 
             if len(rv.value) < typ.lower_bound:
-                self.mh.error(self.ct.location,
-                              "this array requires at least %u elements "
-                              "(only %u provided)" %
-                              (typ.lower_bound,
-                               len(rv.value)),
-                              fatal=False)
+                self.mh.error(
+                    self.ct.location,
+                    "this array requires at least %u elements "
+                    "(only %u provided)" % (typ.lower_bound, len(rv.value)),
+                    fatal=False,
+                )
             if typ.upper_bound and len(rv.value) > typ.upper_bound:
-                self.mh.error(rv.value[typ.upper_bound].location,
-                              "this array requires at most %u elements "
-                              "(%u provided)" %
-                              (typ.upper_bound,
-                               len(rv.value)),
-                              fatal=False)
+                self.mh.error(
+                    rv.value[typ.upper_bound].location,
+                    "this array requires at most %u elements "
+                    "(%u provided)" % (typ.upper_bound, len(rv.value)),
+                    fatal=False,
+                )
 
             return rv
 
         elif isinstance(typ, ast.Enumeration_Type):
-            enum = self.parse_qualified_name(self.default_scope,
-                                             ast.Enumeration_Type)
+            enum = self.parse_qualified_name(self.default_scope, ast.Enumeration_Type)
             enum.set_ast_link(self.ct)
             if enum != typ:
-                self.mh.error(self.ct.location,
-                              "expected %s" % typ.name)
+                self.mh.error(self.ct.location, "expected %s" % typ.name)
             self.match("DOT")
             enum.set_ast_link(self.ct)
             self.match("IDENTIFIER")
-            lit = enum.literals.lookup(self.mh,
-                                       self.ct,
-                                       ast.Enumeration_Literal_Spec)
-            return ast.Enumeration_Literal(self.ct.location,
-                                           lit)
+            lit = enum.literals.lookup(self.mh, self.ct, ast.Enumeration_Literal_Spec)
+            return ast.Enumeration_Literal(self.ct.location, lit)
 
         elif isinstance(typ, (ast.Record_Type, ast.Union_Type)):
             self.match("IDENTIFIER")
@@ -1800,16 +1839,16 @@ class Parser(Parser_Base):
                 the_pkg.set_ast_link(t_name)
                 the_pkg.set_ast_link(t_dot)
                 if not self.cu.is_visible(the_pkg):
-                    self.mh.error(self.ct.location,
-                                  "package must be imported before use")
+                    self.mh.error(
+                        self.ct.location, "package must be imported before use"
+                    )
                 t_name = self.ct
             else:
                 the_pkg = self.cu.package
 
-            rv = ast.Record_Reference(location = t_name.location,
-                                      name     = t_name.value,
-                                      typ      = typ,
-                                      package  = the_pkg)
+            rv = ast.Record_Reference(
+                location=t_name.location, name=t_name.value, typ=typ, package=the_pkg
+            )
             rv.set_ast_link(t_name)
 
             # We can do an early lookup if the target is known
@@ -1838,8 +1877,7 @@ class Parser(Parser_Base):
                         next_is_optional = True
 
                 elif n_item.token.kind == "IDENTIFIER":
-                    if self.peek("IDENTIFIER") and \
-                       self.nt.value == n_item.token.value:
+                    if self.peek("IDENTIFIER") and self.nt.value == n_item.token.value:
                         self.match("IDENTIFIER")
                         n_item.set_ast_link(self.ct)
                     else:
@@ -1863,17 +1901,17 @@ class Parser(Parser_Base):
                 else:
                     self.match("COMMA")
                     rv.set_ast_link(self.ct)
-                rv.assign(n_field.name,
-                          self.parse_value(n_field.n_typ))
+                rv.assign(n_field.name, self.parse_value(n_field.n_typ))
 
             self.match("KET")
             rv.set_ast_link(self.ct)
             return rv
 
         else:
-            self.mh.ice_loc(self.ct.location,
-                            "logic error: unexpected type %s" %
-                            typ.__class__.__name__)
+            self.mh.ice_loc(
+                self.ct.location,
+                "logic error: unexpected type %s" % typ.__class__.__name__,
+            )
 
     def parse_markup_string(self):
         # lobster-trace: LRM.Markup_String_Values
@@ -1893,22 +1931,23 @@ class Parser(Parser_Base):
         # lobster-trace: LRM.Evaluation_Of_Checks
         # lobster-trace: LRM.Single_Value_Assignment
 
-        r_typ = self.parse_qualified_name(self.default_scope,
-                                          ast.Record_Type)
+        r_typ = self.parse_qualified_name(self.default_scope, ast.Record_Type)
         r_typ.set_ast_link(self.ct)
         # lobster-trace: LRM.Abstract_Types
         if r_typ.is_abstract:
-            self.mh.error(self.ct.location,
-                          "cannot declare object of abstract record type %s" %
-                          r_typ.name)
+            self.mh.error(
+                self.ct.location,
+                "cannot declare object of abstract record type %s" % r_typ.name,
+            )
 
         self.match("IDENTIFIER")
         obj = ast.Record_Object(
-            name      = self.ct.value,
-            location  = self.ct.location,
-            n_typ     = r_typ,
-            section   = self.section.copy() if self.section else None,
-            n_package = self.cu.package)
+            name=self.ct.value,
+            location=self.ct.location,
+            n_typ=r_typ,
+            section=self.section.copy() if self.section else None,
+            n_package=self.cu.package,
+        )
         self.cu.package.symbols.register(self.mh, obj)
         obj.set_ast_link(self.ct)
 
@@ -1916,19 +1955,18 @@ class Parser(Parser_Base):
         obj.set_ast_link(self.ct)
         while not self.peek("C_KET"):
             self.match("IDENTIFIER")
-            comp = r_typ.components.lookup(self.mh,
-                                           self.ct,
-                                           ast.Composite_Component)
+            comp = r_typ.components.lookup(self.mh, self.ct, ast.Composite_Component)
             if obj.is_component_implicit_null(comp):
-                self.mh.error(self.ct.location,
-                              "component '%s' already assigned at line %i" %
-                              (comp.name,
-                               obj.field[comp.name].location.line_no))
+                self.mh.error(
+                    self.ct.location,
+                    "component '%s' already assigned at line %i"
+                    % (comp.name, obj.field[comp.name].location.line_no),
+                )
             comp.set_ast_link(self.ct)
             if r_typ.is_frozen(comp):
-                self.mh.error(self.ct.location,
-                              "cannot overwrite frozen component %s" %
-                              comp.name)
+                self.mh.error(
+                    self.ct.location, "cannot overwrite frozen component %s" % comp.name
+                )
             self.match("ASSIGN")
             comp.set_ast_link(self.ct)
             value = self.parse_value(comp.n_typ)
@@ -1944,9 +1982,9 @@ class Parser(Parser_Base):
                 elif not comp.optional:
                     self.mh.error(
                         obj.location,
-                        "required component %s (see %s) is not defined" %
-                        (comp.name,
-                         self.mh.cross_file_reference(comp.location)))
+                        "required component %s (see %s) is not defined"
+                        % (comp.name, self.mh.cross_file_reference(comp.location)),
+                    )
 
         self.match("C_KET")
         obj.set_ast_link(self.ct)
@@ -1979,10 +2017,12 @@ class Parser(Parser_Base):
 
         if declare_package:
             # lobster-trace: LRM.Package_Declaration
-            pkg = ast.Package(name          = self.ct.value,
-                              location      = self.ct.location,
-                              builtin_stab  = self.stab,
-                              declared_late = kind == "trlc")
+            pkg = ast.Package(
+                name=self.ct.value,
+                location=self.ct.location,
+                builtin_stab=self.stab,
+                declared_late=kind == "trlc",
+            )
             self.stab.register(self.mh, pkg)
         else:
             pkg = self.stab.lookup(self.mh, self.ct, ast.Package)
@@ -2025,12 +2065,14 @@ class Parser(Parser_Base):
                 # relevant keyword
                 self.skip_until_newline()
                 while not self.peek_eof():
-                    if self.peek_kw("checks") or \
-                       self.peek_kw("type") or \
-                       self.peek_kw("abstract") or \
-                       self.peek_kw("final") or \
-                       self.peek_kw("tuple") or \
-                       self.peek_kw("enum"):
+                    if (
+                        self.peek_kw("checks")
+                        or self.peek_kw("type")
+                        or self.peek_kw("abstract")
+                        or self.peek_kw("final")
+                        or self.peek_kw("tuple")
+                        or self.peek_kw("enum")
+                    ):
                         break
                     self.advance()
                     self.skip_until_newline()
@@ -2068,14 +2110,13 @@ class Parser(Parser_Base):
                     elif not self.peek("IDENTIFIER"):
                         pass
                     elif self.stab.contains(self.nt.value):
-                        n_sym = self.stab.lookup_assuming(self.mh,
-                                                          self.nt.value)
+                        n_sym = self.stab.lookup_assuming(self.mh, self.nt.value)
                         if isinstance(n_sym, ast.Package):
                             break
                     elif self.cu.package.symbols.contains(self.nt.value):
                         n_sym = self.cu.package.symbols.lookup_assuming(
-                            self.mh,
-                            self.nt.value)
+                            self.mh, self.nt.value
+                        )
                         if isinstance(n_sym, ast.Record_Type):
                             break
                     self.advance()

--- a/trlc/trlc.py
+++ b/trlc/trlc.py
@@ -36,6 +36,7 @@ from trlc.version import BUGS_URL, TRLC_VERSION
 # pylint: disable=unused-import
 try:
     import cvc5
+
     VCG_API_AVAILABLE = True
 except ImportError:  # pragma: no cover
     VCG_API_AVAILABLE = False
@@ -75,40 +76,44 @@ class Source_Manager:
     :type debug_vcg: bool
 
     """
-    def __init__(self, mh,
-                 lint_mode      = True,
-                 parse_trlc     = True,
-                 verify_mode    = False,
-                 debug_vcg      = False,
-                 error_recovery = True):
+
+    def __init__(
+        self,
+        mh,
+        lint_mode=True,
+        parse_trlc=True,
+        verify_mode=False,
+        debug_vcg=False,
+        error_recovery=True,
+    ):
         assert isinstance(mh, Message_Handler)
         assert isinstance(lint_mode, bool)
         assert isinstance(parse_trlc, bool)
         assert isinstance(verify_mode, bool)
         assert isinstance(debug_vcg, bool)
 
-        self.mh          = mh
-        self.mh.sm       = self
-        self.stab        = ast.Symbol_Table.create_global_table(mh)
-        self.includes    = {}
-        self.rsl_files   = {}
-        self.trlc_files  = {}
-        self.all_files   = {}
-        self.dep_graph   = {}
+        self.mh = mh
+        self.mh.sm = self
+        self.stab = ast.Symbol_Table.create_global_table(mh)
+        self.includes = {}
+        self.rsl_files = {}
+        self.trlc_files = {}
+        self.all_files = {}
+        self.dep_graph = {}
 
         self.files_with_preamble_errors = set()
 
-        self.lint_mode      = lint_mode
-        self.parse_trlc     = parse_trlc
-        self.verify_mode    = verify_mode
-        self.debug_vcg      = debug_vcg
+        self.lint_mode = lint_mode
+        self.parse_trlc = parse_trlc
+        self.verify_mode = verify_mode
+        self.debug_vcg = debug_vcg
         self.error_recovery = error_recovery
 
         self.exclude_patterns = []
-        self.common_root      = None
+        self.common_root = None
 
         self.progress_current = 0
-        self.progress_final   = 0
+        self.progress_final = 0
 
     def callback_parse_begin(self):
         pass
@@ -133,12 +138,12 @@ class Source_Manager:
         if self.common_root is None:
             return location.to_string(False)
         elif location.line_no is None:
-            return os.path.relpath(location.file_name,
-                                   self.common_root)
+            return os.path.relpath(location.file_name, self.common_root)
         else:
-            return "%s:%u" % (os.path.relpath(location.file_name,
-                                              self.common_root),
-                              location.line_no)
+            return "%s:%u" % (
+                os.path.relpath(location.file_name, self.common_root),
+                location.line_no,
+            )
 
     def update_common_root(self, file_name):
         assert isinstance(file_name, str)
@@ -147,8 +152,7 @@ class Source_Manager:
             self.common_root = os.path.dirname(os.path.abspath(file_name))
         else:
             new_root = os.path.dirname(os.path.abspath(file_name))
-            for n, (char_a, char_b) in enumerate(zip(self.common_root,
-                                                     new_root)):
+            for n, (char_a, char_b) in enumerate(zip(self.common_root, new_root)):
                 if char_a != char_b:
                     self.common_root = self.common_root[0:n]
                     break
@@ -161,23 +165,26 @@ class Source_Manager:
         if file_name.endswith(MARKDOWN_EXTENSION):
             lexer = MD_Lexer(self.mh, file_name, file_content)
             return TrlcMarkdownParser(
-                mh             = self.mh,
-                stab           = self.stab,
-                file_name      = file_name,
-                lint_mode      = self.lint_mode,
-                error_recovery = self.error_recovery,
-                primary_file   = primary_file,
-                lexer          = lexer)
+                mh=self.mh,
+                stab=self.stab,
+                file_name=file_name,
+                lint_mode=self.lint_mode,
+                error_recovery=self.error_recovery,
+                primary_file=primary_file,
+                lexer=lexer,
+            )
 
         lexer = Token_Stream(self.mh, file_name, file_content)
 
-        return Parser(mh             = self.mh,
-                      stab           = self.stab,
-                      file_name      = file_name,
-                      lint_mode      = self.lint_mode,
-                      error_recovery = self.error_recovery,
-                      primary_file   = primary_file,
-                      lexer          = lexer)
+        return Parser(
+            mh=self.mh,
+            stab=self.stab,
+            file_name=file_name,
+            lint_mode=self.lint_mode,
+            error_recovery=self.error_recovery,
+            primary_file=primary_file,
+            lexer=lexer,
+        )
 
     def register_include(self, dir_name):
         """Make contents of a directory available for automatic inclusion
@@ -199,12 +206,15 @@ class Source_Manager:
                     del dirs[n]
 
             self.includes.update(
-                {os.path.abspath(full_name): full_name
-                 for full_name in
-                   (os.path.join(path, file_name)
-                    for file_name in files
-                    if os.path.splitext(file_name)[1] in (".rsl",
-                                                          ".trlc"))})
+                {
+                    os.path.abspath(full_name): full_name
+                    for full_name in (
+                        os.path.join(path, file_name)
+                        for file_name in files
+                        if os.path.splitext(file_name)[1] in (".rsl", ".trlc")
+                    )
+                }
+            )
 
     def register_file(self, file_name, file_content=None, primary=True):
         """Schedule a file for parsing.
@@ -236,9 +246,11 @@ class Source_Manager:
             elif file_name.endswith(".trlc") or file_name.endswith(MARKDOWN_EXTENSION):
                 self.register_trlc_file(file_name, file_content, primary)
             else:  # pragma: no cover
-                self.mh.error(Location(os.path.basename(file_name)),
-                              "is not a rsl, trlc or trlc.md file",
-                              fatal = False)
+                self.mh.error(
+                    Location(os.path.basename(file_name)),
+                    "is not a rsl, trlc or trlc.md file",
+                    fatal=False,
+                )
                 return False
 
         except TRLC_Error:
@@ -276,9 +288,10 @@ class Source_Manager:
                     del dirs[n]
 
             for file_name in sorted(files):
-                if os.path.splitext(file_name)[1] in (".rsl",
-                                                      ".trlc") or \
-                        file_name.endswith(MARKDOWN_EXTENSION):
+                if os.path.splitext(file_name)[1] in (
+                    ".rsl",
+                    ".trlc",
+                ) or file_name.endswith(MARKDOWN_EXTENSION):
                     ok &= self.register_file(os.path.join(path, file_name))
         return ok
 
@@ -290,9 +303,7 @@ class Source_Manager:
         # lobster-trace: LRM.Preamble
 
         self.update_common_root(file_name)
-        parser = self.create_parser(file_name,
-                                    file_content,
-                                    primary)
+        parser = self.create_parser(file_name, file_content, primary)
         self.rsl_files[file_name] = parser
         self.all_files[file_name] = parser
         if os.path.abspath(file_name) in self.includes:
@@ -311,9 +322,7 @@ class Source_Manager:
             return
 
         self.update_common_root(file_name)
-        parser = self.create_parser(file_name,
-                                    file_content,
-                                    primary)
+        parser = self.create_parser(file_name, file_content, primary)
         self.trlc_files[file_name] = parser
         self.all_files[file_name] = parser
         if os.path.abspath(file_name) in self.includes:
@@ -330,20 +339,19 @@ class Source_Manager:
         ok = True
         graph = self.dep_graph
         files = {}
-        for container, kind in ((self.rsl_files, "rsl"),
-                                (self.trlc_files, "trlc")):
+        for container, kind in ((self.rsl_files, "rsl"), (self.trlc_files, "trlc")):
             # First parse preamble and register packages in graph
             for file_name in sorted(container):
                 try:
                     parser = container[file_name]
                     parser.parse_preamble(kind)
                     pkg_name = parser.cu.package.name
-                    if (pkg_name , "rsl") not in graph:
-                        graph[(pkg_name , "rsl")] = set()
-                        graph[(pkg_name , "trlc")] = set([(pkg_name , "rsl")])
-                        files[(pkg_name , "rsl")] = set()
-                        files[(pkg_name , "trlc")] = set()
-                    files[(pkg_name , kind)].add(file_name)
+                    if (pkg_name, "rsl") not in graph:
+                        graph[(pkg_name, "rsl")] = set()
+                        graph[(pkg_name, "trlc")] = set([(pkg_name, "rsl")])
+                        files[(pkg_name, "rsl")] = set()
+                        files[(pkg_name, "trlc")] = set()
+                    files[(pkg_name, kind)].add(file_name)
                 except TRLC_Error:
                     ok = False
                     self.files_with_preamble_errors.add(file_name)
@@ -359,17 +367,21 @@ class Source_Manager:
                 pkg_name = parser.cu.package.name
                 parser.cu.resolve_imports(self.mh, self.stab)
 
-                graph[(pkg_name , kind)] |= \
-                    {(imported_pkg.name , kind)
-                     for imported_pkg in parser.cu.imports}
+                graph[(pkg_name, kind)] |= {
+                    (imported_pkg.name, kind) for imported_pkg in parser.cu.imports
+                }
 
         # Build closure for our files
-        work_list = {(parser.cu.package.name , "rsl")
-                     for parser in self.rsl_files.values()
-                     if parser.cu.package and parser.primary}
-        work_list |= {(parser.cu.package.name , "trlc")
-                      for parser in self.trlc_files.values()
-                      if parser.cu.package and parser.primary}
+        work_list = {
+            (parser.cu.package.name, "rsl")
+            for parser in self.rsl_files.values()
+            if parser.cu.package and parser.primary
+        }
+        work_list |= {
+            (parser.cu.package.name, "trlc")
+            for parser in self.trlc_files.values()
+            if parser.cu.package and parser.primary
+        }
         work_list &= set(graph)
 
         required = set()
@@ -379,9 +391,7 @@ class Source_Manager:
             work_list |= (graph[node] - required) & set(graph)
 
         # Expand into actual file list and flag dependencies
-        file_list = {file_name
-                     for node in required
-                     for file_name in files[node]}
+        file_list = {file_name for node in required for file_name in files[node]}
         for file_name in file_list:
             if not self.all_files[file_name].primary:
                 self.all_files[file_name].secondary = True
@@ -398,10 +408,11 @@ class Source_Manager:
         ok = True
 
         # Select RSL files that we should parse
-        rsl_map = {(parser.cu.package.name , "rsl"): parser
-                   for parser in self.rsl_files.values()
-                   if parser.cu.package and (parser.primary or
-                                             parser.secondary)}
+        rsl_map = {
+            (parser.cu.package.name, "rsl"): parser
+            for parser in self.rsl_files.values()
+            if parser.cu.package and (parser.primary or parser.secondary)
+        }
 
         # Parse packages that have no unparsed dependencies. Keep
         # doing it until we parse everything or until we have reached
@@ -410,27 +421,33 @@ class Source_Manager:
         work_list = set(rsl_map)
         processed = set()
         while work_list:
-            candidates = {node
-                          for node in work_list
-                          if len(self.dep_graph.get(node, set()) -
-                                 processed) == 0}
+            candidates = {
+                node
+                for node in work_list
+                if len(self.dep_graph.get(node, set()) - processed) == 0
+            }
             if not candidates:
                 # lobster-trace: LRM.Circular_Dependencies
                 sorted_work_list = sorted(work_list)
                 offender = rsl_map[sorted_work_list[0]]
-                names = {rsl_map[node].cu.package.name:
-                         rsl_map[node].cu.location
-                         for node in sorted_work_list[1:]}
+                names = {
+                    rsl_map[node].cu.package.name: rsl_map[node].cu.location
+                    for node in sorted_work_list[1:]
+                }
                 self.mh.error(
-                    location    = offender.cu.location,
-                    message     = ("circular inheritence between %s" %
-                                   " | ".join(sorted(names))),
-                    explanation = "\n".join(
-                        sorted("%s is declared in %s" %
-                               (name,
-                                self.mh.cross_file_reference(loc))
-                               for name, loc in names.items())),
-                    fatal       = False)
+                    location=offender.cu.location,
+                    message=(
+                        "circular inheritence between %s" % " | ".join(sorted(names))
+                    ),
+                    explanation="\n".join(
+                        sorted(
+                            "%s is declared in %s"
+                            % (name, self.mh.cross_file_reference(loc))
+                            for name, loc in names.items()
+                        )
+                    ),
+                    fatal=False,
+                )
                 return False
 
             for node in sorted(candidates):
@@ -532,16 +549,18 @@ class Source_Manager:
             _md_lexer = getattr(_md_parser, "lexer", None)
             if isinstance(_md_lexer, MD_Lexer):
                 _md_lexer.prepare_phase2(self.stab)  # Rebuild tokens with types
-                _md_parser.ct = None                 # Reset parser cursor
-                _md_parser.advance()                 # Prime first body token
+                _md_parser.ct = None  # Reset parser cursor
+                _md_parser.advance()  # Prime first body token
 
         # Perform sanity checks (enabled by default). We only do this
         # if there were no errors so far.
         if self.lint_mode and ok:
-            linter = lint.Linter(mh            = self.mh,
-                                 stab          = self.stab,
-                                 verify_checks = self.verify_mode,
-                                 debug_vcg     = self.debug_vcg)
+            linter = lint.Linter(
+                mh=self.mh,
+                stab=self.stab,
+                verify_checks=self.verify_mode,
+                debug_vcg=self.debug_vcg,
+            )
             ok &= linter.perform_sanity_checks()
         # Stop here if we're not processing TRLC files.
         if not self.parse_trlc:  # pragma: no cover
@@ -585,112 +604,143 @@ def trlc():
     ap = argparse.ArgumentParser(
         prog="trlc",
         description="TRLC %s (Python reference implementation)" % TRLC_VERSION,
-        epilog=("TRLC is licensed under the GPLv3."
-                " Report bugs here: %s" % BUGS_URL),
+        epilog=("TRLC is licensed under the GPLv3. Report bugs here: %s" % BUGS_URL),
         allow_abbrev=False,
     )
     og_lint = ap.add_argument_group("analysis options")
-    og_lint.add_argument("--no-lint",
-                         default=False,
-                         action="store_true",
-                         help="Disable additional, optional warnings.")
-    og_lint.add_argument("--skip-trlc-files",
-                         default=False,
-                         action="store_true",
-                         help=("Only process rsl files,"
-                               " do not process any trlc files."))
-    og_lint.add_argument("--verify",
-                         default=False,
-                         action="store_true",
-                         help=("[EXPERIMENTAL] Attempt to statically"
-                               " verify absence of errors in user defined"
-                               " checks. Does not yet support all language"
-                               " constructs. Requires PyVCG to be "
-                               " installed."))
+    og_lint.add_argument(
+        "--no-lint",
+        default=False,
+        action="store_true",
+        help="Disable additional, optional warnings.",
+    )
+    og_lint.add_argument(
+        "--skip-trlc-files",
+        default=False,
+        action="store_true",
+        help=("Only process rsl files, do not process any trlc files."),
+    )
+    og_lint.add_argument(
+        "--verify",
+        default=False,
+        action="store_true",
+        help=(
+            "[EXPERIMENTAL] Attempt to statically"
+            " verify absence of errors in user defined"
+            " checks. Does not yet support all language"
+            " constructs. Requires PyVCG to be "
+            " installed."
+        ),
+    )
 
     og_input = ap.add_argument_group("input options")
-    og_input.add_argument("--include-bazel-dirs",
-                          action="store_true",
-                          help=("Enter bazel-* directories, which are"
-                                " excluded by default."))
-    og_input.add_argument("-I",
-                          action="append",
-                          dest="include_dirs",
-                          help=("Add include path. Files from these"
-                                " directories are parsed only when needed."
-                                " Can be specified more than once."),
-                          default=[])
+    og_input.add_argument(
+        "--include-bazel-dirs",
+        action="store_true",
+        help=("Enter bazel-* directories, which are excluded by default."),
+    )
+    og_input.add_argument(
+        "-I",
+        action="append",
+        dest="include_dirs",
+        help=(
+            "Add include path. Files from these"
+            " directories are parsed only when needed."
+            " Can be specified more than once."
+        ),
+        default=[],
+    )
 
     og_output = ap.add_argument_group("output options")
-    og_output.add_argument("--version",
-                           default=False,
-                           action="store_true",
-                           help="Print TRLC version and exit.")
-    og_output.add_argument("--brief",
-                           default=False,
-                           action="store_true",
-                           help=("Simpler output intended for CI. Does not"
-                                 " show context or additional information,"
-                                 " but prints the usual summary at the end."))
-    og_output.add_argument("--no-detailed-info",
-                           default=False,
-                           action="store_true",
-                           help=("Do not print counter-examples and other"
-                                 " supplemental information on failed"
-                                 " checks. The specific values of"
-                                 " counter-examples are unpredictable"
-                                 " from system to system, so if you need"
-                                 " perfectly reproducible output then use"
-                                 " this option."))
-    og_output.add_argument("--no-user-warnings",
-                           default=False,
-                           action="store_true",
-                           help=("Do not display any warnings from user"
-                                 " defined checks, only errors."))
-    og_output.add_argument("--no-error-recovery",
-                           default=False,
-                           action="store_true",
-                           help=("By default the tool attempts to recover"
-                                 " from parse errors to show more errors, but"
-                                 " this can occasionally generate weird"
-                                 " errors. You can use this option to stop"
-                                 " at the first real errors."))
-    og_output.add_argument("--show-file-list",
-                           action="store_true",
-                           help=("If there are no errors, produce a summary"
-                                 " naming every file processed."))
-    og_output.add_argument("--log",
-                           nargs    = '+',
-                           metavar  = ("FILE", "PREFIX"),
-                           default  = None,
-                           help     = ("Write all output to FILE, optionally"
-                                       " strip PREFIX from file paths in"
-                                       " messages. Intended for use as a"
-                                       " Bazel build action."))
-    og_output.add_argument("--error-on-warnings",
-                           action="store_true",
-                           help=("If there are warnings, return status code"
-                                 " 1 instead of 0."))
+    og_output.add_argument(
+        "--version",
+        default=False,
+        action="store_true",
+        help="Print TRLC version and exit.",
+    )
+    og_output.add_argument(
+        "--brief",
+        default=False,
+        action="store_true",
+        help=(
+            "Simpler output intended for CI. Does not"
+            " show context or additional information,"
+            " but prints the usual summary at the end."
+        ),
+    )
+    og_output.add_argument(
+        "--no-detailed-info",
+        default=False,
+        action="store_true",
+        help=(
+            "Do not print counter-examples and other"
+            " supplemental information on failed"
+            " checks. The specific values of"
+            " counter-examples are unpredictable"
+            " from system to system, so if you need"
+            " perfectly reproducible output then use"
+            " this option."
+        ),
+    )
+    og_output.add_argument(
+        "--no-user-warnings",
+        default=False,
+        action="store_true",
+        help=("Do not display any warnings from user defined checks, only errors."),
+    )
+    og_output.add_argument(
+        "--no-error-recovery",
+        default=False,
+        action="store_true",
+        help=(
+            "By default the tool attempts to recover"
+            " from parse errors to show more errors, but"
+            " this can occasionally generate weird"
+            " errors. You can use this option to stop"
+            " at the first real errors."
+        ),
+    )
+    og_output.add_argument(
+        "--show-file-list",
+        action="store_true",
+        help=("If there are no errors, produce a summary naming every file processed."),
+    )
+    og_output.add_argument(
+        "--log",
+        nargs="+",
+        metavar=("FILE", "PREFIX"),
+        default=None,
+        help=(
+            "Write all output to FILE, optionally"
+            " strip PREFIX from file paths in"
+            " messages. Intended for use as a"
+            " Bazel build action."
+        ),
+    )
+    og_output.add_argument(
+        "--error-on-warnings",
+        action="store_true",
+        help=("If there are warnings, return status code 1 instead of 0."),
+    )
 
     og_debug = ap.add_argument_group("debug options")
-    og_debug.add_argument("--debug-dump",
-                          default=False,
-                          action="store_true",
-                          help="Dump symbol table.")
-    og_debug.add_argument("--debug-api-dump",
-                          default=False,
-                          action="store_true",
-                          help=("Dump json of to_python_object() for all"
-                                " objects."))
-    og_debug.add_argument("--debug-vcg",
-                          default=False,
-                          action="store_true",
-                          help=("Emit graph and individual VCs. Requires"
-                                " graphviz to be installed."))
+    og_debug.add_argument(
+        "--debug-dump", default=False, action="store_true", help="Dump symbol table."
+    )
+    og_debug.add_argument(
+        "--debug-api-dump",
+        default=False,
+        action="store_true",
+        help=("Dump json of to_python_object() for all objects."),
+    )
+    og_debug.add_argument(
+        "--debug-vcg",
+        default=False,
+        action="store_true",
+        help=("Emit graph and individual VCs. Requires graphviz to be installed."),
+    )
 
-    ap.add_argument("items",
-                    nargs="*",
-                    metavar="DIR|FILE")
+    ap.add_argument("items", nargs="*", metavar="DIR|FILE")
     options = ap.parse_args()
 
     if options.log:
@@ -704,23 +754,26 @@ def trlc():
         sys.exit(0)
 
     if options.verify and not VCG_API_AVAILABLE:  # pragma: no cover
-        ap.error("The --verify option requires the optional dependency"
-                 " CVC5")
+        ap.error("The --verify option requires the optional dependency CVC5")
 
-    mh = Message_Handler(options.brief,
-                          not options.no_detailed_info,
-                          out_path     = options.log[0] if options.log else None,
-                          strip_prefix = options.log[1] if options.log else None)
+    mh = Message_Handler(
+        options.brief,
+        not options.no_detailed_info,
+        out_path=options.log[0] if options.log else None,
+        strip_prefix=options.log[1] if options.log else None,
+    )
 
     if options.no_user_warnings:  # pragma: no cover
         mh.suppress(Kind.USER_WARNING)
 
-    sm = Source_Manager(mh             = mh,
-                        lint_mode      = not options.no_lint,
-                        parse_trlc     = not options.skip_trlc_files,
-                        verify_mode    = options.verify,
-                        debug_vcg      = options.debug_vcg,
-                        error_recovery = not options.no_error_recovery)
+    sm = Source_Manager(
+        mh=mh,
+        lint_mode=not options.no_lint,
+        parse_trlc=not options.skip_trlc_files,
+        verify_mode=options.verify,
+        debug_vcg=options.debug_vcg,
+        error_recovery=not options.no_error_recovery,
+    )
 
     if not options.include_bazel_dirs:  # pragma: no cover
         sm.exclude_patterns.append(re.compile("^bazel-.*$"))
@@ -736,8 +789,9 @@ def trlc():
     # Process input files, defaulting to the current directory if none
     # given.
     for path_name in options.items:
-        if not (os.path.isdir(path_name) or
-                os.path.isfile(path_name)):  # pragma: no cover
+        if not (
+            os.path.isdir(path_name) or os.path.isfile(path_name)
+        ):  # pragma: no cover
             ap.error("%s is not a file or directory" % path_name)
     if options.items:
         for path_name in options.items:
@@ -772,13 +826,13 @@ def trlc():
             print(json.dumps(tmp, indent=2, sort_keys=True), file=mh.out)
 
     total_models = len(sm.rsl_files)
-    parsed_models = len([item
-                            for item in sm.rsl_files.values()
-                            if item.primary or item.secondary])
+    parsed_models = len(
+        [item for item in sm.rsl_files.values() if item.primary or item.secondary]
+    )
     total_trlc = len(sm.trlc_files)
-    parsed_trlc = len([item
-                        for item in sm.trlc_files.values()
-                        if item.primary or item.secondary])
+    parsed_trlc = len(
+        [item for item in sm.trlc_files.values() if item.primary or item.secondary]
+    )
 
     def count(parsed, total, what):
         rv = str(parsed)
@@ -789,14 +843,10 @@ def trlc():
             rv += "s"
         return rv
 
-    summary = "Processed %s" % count(parsed_models,
-                                        total_models,
-                                        "model")
+    summary = "Processed %s" % count(parsed_models, total_models, "model")
 
     if not options.skip_trlc_files:  # pragma: no cover
-        summary += " and %s" % count(parsed_trlc,
-                                        total_trlc,
-                                        "requirement file")
+        summary += " and %s" % count(parsed_trlc, total_trlc, "requirement file")
 
     summary += " and found"
 
@@ -816,6 +866,7 @@ def trlc():
     print(summary, file=mh.out)
 
     if options.show_file_list and ok:  # pragma: no cover
+
         def get_status(parser):
             if parser.primary:
                 return "[Primary] "
@@ -826,17 +877,19 @@ def trlc():
 
         for filename in sorted(sm.rsl_files):
             parser = sm.rsl_files[filename]
-            print("> %s Model %s (Package %s)" %
-                  (get_status(parser),
-                   filename,
-                   parser.cu.package.name), file=mh.out)
+            print(
+                "> %s Model %s (Package %s)"
+                % (get_status(parser), filename, parser.cu.package.name),
+                file=mh.out,
+            )
         if not options.skip_trlc_files:
             for filename in sorted(sm.trlc_files):
                 parser = sm.trlc_files[filename]
-                print("> %s Requirements %s (Package %s)" %
-                      (get_status(parser),
-                       filename,
-                       parser.cu.package.name), file=mh.out)
+                print(
+                    "> %s Requirements %s (Package %s)"
+                    % (get_status(parser), filename, parser.cu.package.name),
+                    file=mh.out,
+                )
 
     if ok:
         if (options.error_on_warnings and mh.warnings) or mh.errors:  # pragma: no cover

--- a/trlc/trlc_markdown_parser.py
+++ b/trlc/trlc_markdown_parser.py
@@ -150,7 +150,8 @@ class TrlcMarkdownParser(Parser):
                             break
                     elif self.cu.package.symbols.contains(self.nt.value):
                         n_sym = self.cu.package.symbols.lookup_assuming(
-                            self.mh, self.nt.value)
+                            self.mh, self.nt.value
+                        )
                         if isinstance(n_sym, ast.Record_Type):
                             break
                     self.advance()

--- a/trlc/vcg.py
+++ b/trlc/vcg.py
@@ -29,20 +29,22 @@ try:
     from pyvcg import graph
     from pyvcg import vcg
     from pyvcg.driver.file_smtlib import SMTLIB_Generator
+
     VCG_AVAILABLE = True
 except ImportError:  # pragma: no cover
     VCG_AVAILABLE = False
 
 try:
     from pyvcg.driver.cvc5_api import CVC5_Solver
+
     CVC5_API_AVAILABLE = True
 except ImportError:  # pragma: no cover
     CVC5_API_AVAILABLE = False
 
 CVC5_OPTIONS = {
-    "tlimit-per"      : 2500,
-    "seed"            : 42,
-    "sat-random-seed" : 42,
+    "tlimit-per": 2500,
+    "seed": 42,
+    "sat-random-seed": 42,
 }
 
 
@@ -52,8 +54,9 @@ class Unsupported(Exception):  # pragma: no cover
         assert isinstance(node, Node)
         assert isinstance(text, str) or text is None
         super().__init__()
-        self.message  = "%s not yet supported in VCG" % \
-            (text if text else node.__class__.__name__)
+        self.message = "%s not yet supported in VCG" % (
+            text if text else node.__class__.__name__
+        )
         self.location = node.location
 
 
@@ -64,9 +67,9 @@ class Feedback:
         assert isinstance(message, str)
         assert isinstance(kind, str)
         assert isinstance(expect_unsat, bool)
-        self.node         = node
-        self.message      = message
-        self.kind         = "vcg-" + kind
+        self.node = node
+        self.message = message
+        self.kind = "vcg-" + kind
         self.expect_unsat = expect_unsat
 
 
@@ -78,44 +81,43 @@ class VCG:
         assert isinstance(n_ctyp, Composite_Type)
         assert isinstance(debug, bool)
 
-        self.mh     = mh
+        self.mh = mh
         self.n_ctyp = n_ctyp
-        self.debug  = debug
+        self.debug = debug
 
-        self.vc_name = "trlc-%s-%s" % (n_ctyp.n_package.name,
-                                       n_ctyp.name)
+        self.vc_name = "trlc-%s-%s" % (n_ctyp.n_package.name, n_ctyp.name)
 
         self.tmp_id = 0
 
-        self.vcg      = vcg.VCG()
-        self.graph    = self.vcg.graph
-        self.start    = self.vcg.start
+        self.vcg = vcg.VCG()
+        self.graph = self.vcg.graph
+        self.start = self.vcg.start
         # Current start node, we will update this as we go along.
         self.preamble = None
         # We do remember the first node where we put all our
         # declarations, in case we need to add some more later.
 
-        self.constants    = {}
+        self.constants = {}
         self.enumerations = {}
-        self.tuples       = {}
-        self.records      = {}
-        self.arrays       = {}
-        self.bound_vars   = {}
-        self.qe_vars      = {}
-        self.tuple_base   = {}
-        self.uf_records   = {}
+        self.tuples = {}
+        self.records = {}
+        self.arrays = {}
+        self.bound_vars = {}
+        self.qe_vars = {}
+        self.tuple_base = {}
+        self.uf_records = {}
 
-        self.uf_matches   = None
+        self.uf_matches = None
         # Pointer to the UF we use for matches. We only generate it
         # when we must, as it may affect the logics selected due to
         # string theory being used.
 
-        self.functional   = False
+        self.functional = False
         # If set to true, then we ignore validity checks and do not
         # create intermediates. We just build the value and validity
         # expresions and return them.
 
-        self.emit_checks  = True
+        self.emit_checks = True
         # If set to false, we skip creating checks.
 
     @staticmethod
@@ -129,18 +131,16 @@ class VCG:
 
     def get_uf_matches(self):
         if self.uf_matches is None:
-            self.uf_matches = \
-                smt.Function("trlc.matches",
-                             smt.BUILTIN_BOOLEAN,
-                             smt.Bound_Variable(smt.BUILTIN_STRING,
-                                                "subject"),
-                             smt.Bound_Variable(smt.BUILTIN_STRING,
-                                                "regex"))
+            self.uf_matches = smt.Function(
+                "trlc.matches",
+                smt.BUILTIN_BOOLEAN,
+                smt.Bound_Variable(smt.BUILTIN_STRING, "subject"),
+                smt.Bound_Variable(smt.BUILTIN_STRING, "regex"),
+            )
 
             # Create UF for the matches function (for now, later we
             # will deal with regex properly).
-            self.preamble.add_statement(
-                smt.Function_Declaration(self.uf_matches))
+            self.preamble.add_statement(smt.Function_Declaration(self.uf_matches))
 
         return self.uf_matches
 
@@ -156,8 +156,7 @@ class VCG:
             return s_value, s_valid
 
         else:
-            sym_result = smt.Constant(s_value.sort,
-                                      self.new_temp_name())
+            sym_result = smt.Constant(s_value.sort, self.new_temp_name())
             self.attach_temp_declaration(node, sym_result, s_value)
 
             return sym_result, s_valid
@@ -174,11 +173,11 @@ class VCG:
         # Attach new graph node advance start
         if not bool_expr.is_static_true():
             gn_check = graph.Check(self.graph)
-            gn_check.add_goal(bool_expr,
-                              Feedback(origin,
-                                       "expression could be null",
-                                       "evaluation-of-null"),
-                              "validity check for %s" % origin.to_string())
+            gn_check.add_goal(
+                bool_expr,
+                Feedback(origin, "expression could be null", "evaluation-of-null"),
+                "validity check for %s" % origin.to_string(),
+            )
             self.start.add_edge_to(gn_check)
             self.start = gn_check
 
@@ -194,12 +193,10 @@ class VCG:
         # Attach new graph node advance start
         gn_check = graph.Check(self.graph)
         gn_check.add_goal(
-            smt.Boolean_Negation(
-                smt.Comparison("=", int_expr, smt.Integer_Literal(0))),
-            Feedback(origin,
-                     "divisor could be 0",
-                     "div-by-zero"),
-            "division by zero check for %s" % origin.to_string())
+            smt.Boolean_Negation(smt.Comparison("=", int_expr, smt.Integer_Literal(0))),
+            Feedback(origin, "divisor could be 0", "div-by-zero"),
+            "division by zero check for %s" % origin.to_string(),
+        )
         self.start.add_edge_to(gn_check)
         self.start = gn_check
 
@@ -215,12 +212,10 @@ class VCG:
         # Attach new graph node advance start
         gn_check = graph.Check(self.graph)
         gn_check.add_goal(
-            smt.Boolean_Negation(
-                smt.Comparison("=", real_expr, smt.Real_Literal(0))),
-            Feedback(origin,
-                     "divisor could be 0.0",
-                     "div-by-zero"),
-            "division by zero check for %s" % origin.to_string())
+            smt.Boolean_Negation(smt.Comparison("=", real_expr, smt.Real_Literal(0))),
+            Feedback(origin, "divisor could be 0.0", "div-by-zero"),
+            "division by zero check for %s" % origin.to_string(),
+        )
         self.start.add_edge_to(gn_check)
         self.start = gn_check
 
@@ -240,19 +235,18 @@ class VCG:
         gn_check = graph.Check(self.graph)
         gn_check.add_goal(
             smt.Comparison(">=", index_expr, smt.Integer_Literal(0)),
-            Feedback(origin,
-                     "array index could be less than 0",
-                     "array-index"),
-            "index lower bound check for %s" % origin.to_string())
+            Feedback(origin, "array index could be less than 0", "array-index"),
+            "index lower bound check for %s" % origin.to_string(),
+        )
         gn_check.add_goal(
-            smt.Comparison("<",
-                           index_expr,
-                           smt.Sequence_Length(seq_expr)),
-            Feedback(origin,
-                     "array index could be larger than len(%s)" %
-                     origin.n_lhs.to_string(),
-                     "array-index"),
-            "index lower bound check for %s" % origin.to_string())
+            smt.Comparison("<", index_expr, smt.Sequence_Length(seq_expr)),
+            Feedback(
+                origin,
+                "array index could be larger than len(%s)" % origin.n_lhs.to_string(),
+                "array-index",
+            ),
+            "index lower bound check for %s" % origin.to_string(),
+        )
 
         self.start.add_edge_to(gn_check)
         self.start = gn_check
@@ -268,12 +262,13 @@ class VCG:
 
         # Attach new graph node advance start
         gn_check = graph.Check(self.graph)
-        gn_check.add_goal(bool_expr,
-                          Feedback(origin,
-                                   "expression is always true",
-                                   "always-true",
-                                   expect_unsat = False),
-                          "feasability check for %s" % origin.to_string())
+        gn_check.add_goal(
+            bool_expr,
+            Feedback(
+                origin, "expression is always true", "always-true", expect_unsat=False
+            ),
+            "feasability check for %s" % origin.to_string(),
+        )
         self.start.add_edge_to(gn_check)
 
     def attach_assumption(self, bool_expr):
@@ -297,11 +292,13 @@ class VCG:
         gn_decl = graph.Assumption(self.graph)
         gn_decl.add_statement(
             smt.Constant_Declaration(
-                symbol   = sym,
-                value    = value,
-                comment  = "result of %s at %s" % (node.to_string(),
-                                                   node.location.to_string()),
-                relevant = False))
+                symbol=sym,
+                value=value,
+                comment="result of %s at %s"
+                % (node.to_string(), node.location.to_string()),
+                relevant=False,
+            )
+        )
         self.start.add_edge_to(gn_decl)
         self.start = gn_decl
 
@@ -317,8 +314,7 @@ class VCG:
         try:
             self.checks_on_composite_type(self.n_ctyp)
         except Unsupported as exc:  # pragma: no cover
-            self.mh.warning(exc.location,
-                            exc.message)
+            self.mh.warning(exc.location, exc.message)
 
     def checks_on_composite_type(self, n_ctyp):
         assert isinstance(n_ctyp, Composite_Type)
@@ -326,7 +322,7 @@ class VCG:
         # Create node for global declarations
         gn_locals = graph.Assumption(self.graph)
         self.start.add_edge_to(gn_locals)
-        self.start    = gn_locals
+        self.start = gn_locals
         self.preamble = gn_locals
 
         # Create local variables
@@ -354,29 +350,31 @@ class VCG:
 
         # Emit debug graph
         if self.debug:  # pragma: no cover
-            subprocess.run(["dot", "-Tpdf", "-o%s.pdf" % self.vc_name],
-                           input = self.graph.debug_render_dot(),
-                           check = True,
-                           encoding = "UTF-8")
+            subprocess.run(
+                ["dot", "-Tpdf", "-o%s.pdf" % self.vc_name],
+                input=self.graph.debug_render_dot(),
+                check=True,
+                encoding="UTF-8",
+            )
 
         # Generate VCs
         self.vcg.generate()
 
         # Solve VCs and provide feedback
         nok_feasibility_checks = []
-        ok_feasibility_checks  = set()
-        nok_validity_checks    = set()
+        ok_feasibility_checks = set()
+        nok_validity_checks = set()
 
         for vc_id, vc in enumerate(self.vcg.vcs):
             if self.debug:  # pramga: no cover
-                with open(self.vc_name + "_%04u.smt2" % vc_id, "w",
-                          encoding="UTF-8") as fd:
+                with open(
+                    self.vc_name + "_%04u.smt2" % vc_id, "w", encoding="UTF-8"
+                ) as fd:
                     fd.write(vc["script"].generate_vc(SMTLIB_Generator()))
 
             # Checks that have already failed don't need to be checked
             # again on a different path
-            if vc["feedback"].expect_unsat and \
-               vc["feedback"] in nok_validity_checks:
+            if vc["feedback"].expect_unsat and vc["feedback"] in nok_validity_checks:
                 continue
 
             solver = CVC5_Solver()
@@ -391,11 +389,12 @@ class VCG:
 
             if vc["feedback"].expect_unsat:
                 if status != "unsat":
-                    self.mh.check(vc["feedback"].node.location,
-                                  message,
-                                  vc["feedback"].kind,
-                                  self.create_counterexample(status,
-                                                             values))
+                    self.mh.check(
+                        vc["feedback"].node.location,
+                        message,
+                        vc["feedback"].kind,
+                        self.create_counterexample(status, values),
+                    )
                     nok_validity_checks.add(vc["feedback"])
             else:
                 if status == "unsat":
@@ -407,29 +406,30 @@ class VCG:
         # consistent
         for feedback in nok_feasibility_checks:
             if feedback not in ok_feasibility_checks:
-                self.mh.check(feedback.node.location,
-                              feedback.message,
-                              feedback.kind)
+                self.mh.check(feedback.node.location, feedback.message, feedback.kind)
                 ok_feasibility_checks.add(feedback)
 
     def create_counterexample(self, status, values):
         rv = [
-            "example %s triggering error:" %
-            self.n_ctyp.__class__.__name__.lower(),
-            "  %s bad_potato {" % self.n_ctyp.name
+            "example %s triggering error:" % self.n_ctyp.__class__.__name__.lower(),
+            "  %s bad_potato {" % self.n_ctyp.name,
         ]
 
         for n_component in self.n_ctyp.all_components():
             id_value = self.tr_component_value_name(n_component)
             id_valid = self.tr_component_valid_name(n_component)
-            if status == "unknown" and (id_value not in values or
-                                        id_valid not in values):
+            if status == "unknown" and (
+                id_value not in values or id_valid not in values
+            ):
                 rv.append("    %s = ???" % n_component.name)
             elif values.get(id_valid):
-                rv.append("    %s = %s" %
-                          (n_component.name,
-                           self.value_to_trlc(n_component.n_typ,
-                                              values[id_value])))
+                rv.append(
+                    "    %s = %s"
+                    % (
+                        n_component.name,
+                        self.value_to_trlc(n_component.n_typ, values[id_value]),
+                    )
+                )
             else:
                 rv.append("    /* %s is null */" % n_component.name)
 
@@ -509,9 +509,11 @@ class VCG:
                 if n_typ.n_package is self.n_ctyp.n_package:
                     return "%s_instance_%i" % (n_typ.name, instance_id)
                 else:
-                    return "%s.%s_instance_%i" % (n_typ.n_package.name,
-                                                  n_typ.name,
-                                                  instance_id)
+                    return "%s.%s_instance_%i" % (
+                        n_typ.n_package.name,
+                        n_typ.name,
+                        instance_id,
+                    )
             else:
                 return "instance_%i" % instance_id
 
@@ -523,16 +525,14 @@ class VCG:
                         parts.pop()
                         break
                     parts.append(
-                        self.value_to_trlc(n_item.n_typ,
-                                           value[n_item.name + ".value"]))
+                        self.value_to_trlc(n_item.n_typ, value[n_item.name + ".value"])
+                    )
 
                 else:
                     assert isinstance(n_item, Separator)
-                    sep_text = {
-                        "AT"        : "@",
-                        "COLON"     : ":",
-                        "SEMICOLON" : ";"
-                    }.get(n_item.token.kind, n_item.token.value)
+                    sep_text = {"AT": "@", "COLON": ":", "SEMICOLON": ";"}.get(
+                        n_item.token.kind, n_item.token.value
+                    )
                     parts.append(sep_text)
 
             if n_typ.has_separators():
@@ -541,21 +541,28 @@ class VCG:
                 return "(%s)" % ", ".join(parts)
 
         elif isinstance(n_typ, Array_Type):
-            return "[%s]" % ", ".join(self.value_to_trlc(n_typ.element_type,
-                                                         item)
-                                      for item in value)
+            return "[%s]" % ", ".join(
+                self.value_to_trlc(n_typ.element_type, item) for item in value
+            )
 
         else:  # pragma: no cover
-            self.flag_unsupported(n_typ,
-                                  "back-conversion from %s" % n_typ.name)
+            self.flag_unsupported(n_typ, "back-conversion from %s" % n_typ.name)
 
     def tr_component_value_name(self, n_component):
-        return n_component.member_of.fully_qualified_name() + \
-            "." + n_component.name + ".value"
+        return (
+            n_component.member_of.fully_qualified_name()
+            + "."
+            + n_component.name
+            + ".value"
+        )
 
     def tr_component_valid_name(self, n_component):
-        return n_component.member_of.fully_qualified_name() + \
-            "." + n_component.name + ".valid"
+        return (
+            n_component.member_of.fully_qualified_name()
+            + "."
+            + n_component.name
+            + ".valid"
+        )
 
     def emit_tuple_constraints(self, n_tuple, s_sym):
         assert isinstance(n_tuple, Tuple_Type)
@@ -586,13 +593,11 @@ class VCG:
         for i, component in enumerate(components):
             if component.optional:
                 condition = smt.Boolean_Negation(
-                    smt.Record_Access(s_sym,
-                                      component.name + ".valid"))
+                    smt.Record_Access(s_sym, component.name + ".valid")
+                )
                 consequences = [
-                    smt.Boolean_Negation(
-                        smt.Record_Access(s_sym,
-                                          c.name + ".valid"))
-                    for c in components[i + 1:]
+                    smt.Boolean_Negation(smt.Record_Access(s_sym, c.name + ".valid"))
+                    for c in components[i + 1 :]
                 ]
                 if len(consequences) == 0:
                     break
@@ -619,21 +624,22 @@ class VCG:
 
         id_value = self.tr_component_value_name(n_component)
         s_sort = self.tr_type(n_component.n_typ)
-        s_sym  = smt.Constant(s_sort, id_value)
+        s_sym = smt.Constant(s_sort, id_value)
         if frozen:
             old_functional, self.functional = self.functional, True
             s_val, _ = self.tr_expression(
-                self.n_ctyp.get_freezing_expression(n_component))
+                self.n_ctyp.get_freezing_expression(n_component)
+            )
             self.functional = old_functional
         else:
             s_val = None
         s_decl = smt.Constant_Declaration(
-            symbol   = s_sym,
-            value    = s_val,
-            comment  = "value for %s declared on %s" % (
-                n_component.name,
-                n_component.location.to_string()),
-            relevant = True)
+            symbol=s_sym,
+            value=s_val,
+            comment="value for %s declared on %s"
+            % (n_component.name, n_component.location.to_string()),
+            relevant=True,
+        )
         gn_locals.add_statement(s_decl)
         self.constants[id_value] = s_sym
 
@@ -647,27 +653,24 @@ class VCG:
                 s_lower = smt.Integer_Literal(n_component.n_typ.lower_bound)
                 gn_locals.add_statement(
                     smt.Assertion(
-                        smt.Comparison(">=",
-                                       smt.Sequence_Length(s_sym),
-                                       s_lower)))
+                        smt.Comparison(">=", smt.Sequence_Length(s_sym), s_lower)
+                    )
+                )
 
             if n_component.n_typ.upper_bound is not None:
                 s_upper = smt.Integer_Literal(n_component.n_typ.upper_bound)
                 gn_locals.add_statement(
                     smt.Assertion(
-                        smt.Comparison("<=",
-                                       smt.Sequence_Length(s_sym),
-                                       s_upper)))
+                        smt.Comparison("<=", smt.Sequence_Length(s_sym), s_upper)
+                    )
+                )
 
         id_valid = self.tr_component_valid_name(n_component)
-        s_sym  = smt.Constant(smt.BUILTIN_BOOLEAN, id_valid)
-        s_val  = (None
-                  if n_component.optional and not frozen
-                  else smt.Boolean_Literal(True))
-        s_decl = smt.Constant_Declaration(
-            symbol   = s_sym,
-            value    = s_val,
-            relevant = True)
+        s_sym = smt.Constant(smt.BUILTIN_BOOLEAN, id_valid)
+        s_val = (
+            None if n_component.optional and not frozen else smt.Boolean_Literal(True)
+        )
+        s_decl = smt.Constant_Declaration(symbol=s_sym, value=s_val, relevant=True)
         gn_locals.add_statement(s_decl)
         self.constants[id_valid] = s_sym
 
@@ -688,36 +691,37 @@ class VCG:
 
         elif isinstance(n_type, Enumeration_Type):
             if n_type not in self.enumerations:
-                s_sort = smt.Enumeration(n_type.n_package.name +
-                                         "." + n_type.name)
+                s_sort = smt.Enumeration(n_type.n_package.name + "." + n_type.name)
                 for n_lit in n_type.literals.values():
                     s_sort.add_literal(n_lit.name)
                 self.enumerations[n_type] = s_sort
                 self.start.add_statement(
                     smt.Enumeration_Declaration(
                         s_sort,
-                        "enumeration %s from %s" % (
-                            n_type.name,
-                            n_type.location.to_string())))
+                        "enumeration %s from %s"
+                        % (n_type.name, n_type.location.to_string()),
+                    )
+                )
             return self.enumerations[n_type]
 
         elif isinstance(n_type, Tuple_Type):
             if n_type not in self.tuples:
-                s_sort = smt.Record(n_type.n_package.name +
-                                    "." + n_type.name)
+                s_sort = smt.Record(n_type.n_package.name + "." + n_type.name)
                 for n_component in n_type.all_components():
-                    s_sort.add_component(n_component.name + ".value",
-                                         self.tr_type(n_component.n_typ))
+                    s_sort.add_component(
+                        n_component.name + ".value", self.tr_type(n_component.n_typ)
+                    )
                     if n_component.optional:
-                        s_sort.add_component(n_component.name + ".valid",
-                                             smt.BUILTIN_BOOLEAN)
+                        s_sort.add_component(
+                            n_component.name + ".valid", smt.BUILTIN_BOOLEAN
+                        )
                 self.tuples[n_type] = s_sort
                 self.start.add_statement(
                     smt.Record_Declaration(
                         s_sort,
-                        "tuple %s from %s" % (
-                            n_type.name,
-                            n_type.location.to_string())))
+                        "tuple %s from %s" % (n_type.name, n_type.location.to_string()),
+                    )
+                )
 
             return self.tuples[n_type]
 
@@ -798,8 +802,7 @@ class VCG:
             value = smt.Real_Literal(n_expr.value)
 
         elif isinstance(n_expr, Enumeration_Literal):
-            value = smt.Enumeration_Literal(self.tr_type(n_expr.typ),
-                                            n_expr.value.name)
+            value = smt.Enumeration_Literal(self.tr_type(n_expr.typ), n_expr.value.name)
 
         elif isinstance(n_expr, String_Literal):
             value = smt.String_Literal(n_expr.value)
@@ -822,12 +825,10 @@ class VCG:
             if n_ref.entity.member_of in self.tuple_base:
                 sym = self.tuple_base[n_ref.entity.member_of]
                 if n_ref.entity.optional:
-                    s_valid = smt.Record_Access(sym,
-                                                n_ref.entity.name + ".valid")
+                    s_valid = smt.Record_Access(sym, n_ref.entity.name + ".valid")
                 else:
                     s_valid = smt.Boolean_Literal(True)
-                s_value = smt.Record_Access(sym,
-                                            n_ref.entity.name + ".value")
+                s_value = smt.Record_Access(sym, n_ref.entity.name + ".value")
                 return s_value, s_valid
 
             else:
@@ -853,12 +854,10 @@ class VCG:
 
         if n_expr.operator == Unary_Operator.MINUS:
             if isinstance(n_expr.n_operand.typ, Builtin_Integer):
-                sym_value = smt.Unary_Int_Arithmetic_Op("-",
-                                                        operand_value)
+                sym_value = smt.Unary_Int_Arithmetic_Op("-", operand_value)
             else:
                 assert isinstance(n_expr.n_operand.typ, Builtin_Decimal)
-                sym_value = smt.Unary_Real_Arithmetic_Op("-",
-                                                         operand_value)
+                sym_value = smt.Unary_Real_Arithmetic_Op("-", operand_value)
 
         elif n_expr.operator == Unary_Operator.PLUS:
             sym_value = operand_value
@@ -868,13 +867,11 @@ class VCG:
 
         elif n_expr.operator == Unary_Operator.ABSOLUTE_VALUE:
             if isinstance(n_expr.n_operand.typ, Builtin_Integer):
-                sym_value = smt.Unary_Int_Arithmetic_Op("abs",
-                                                        operand_value)
+                sym_value = smt.Unary_Int_Arithmetic_Op("abs", operand_value)
 
             else:
                 assert isinstance(n_expr.n_operand.typ, Builtin_Decimal)
-                sym_value = smt.Unary_Real_Arithmetic_Op("abs",
-                                                         operand_value)
+                sym_value = smt.Unary_Real_Arithmetic_Op("abs", operand_value)
 
         elif n_expr.operator == Unary_Operator.STRING_LENGTH:
             sym_value = smt.String_Length(operand_value)
@@ -889,9 +886,9 @@ class VCG:
             sym_value = smt.Conversion_To_Integer("rna", operand_value)
 
         else:
-            self.mh.ice_loc(n_expr,
-                            "unexpected unary operator %s" %
-                            n_expr.operator.name)
+            self.mh.ice_loc(
+                n_expr, "unexpected unary operator %s" % n_expr.operator.name
+            )
 
         return self.create_return(n_expr, sym_value)
 
@@ -900,8 +897,7 @@ class VCG:
 
         # Some operators deal with validity in a different way. We
         # deal with them first and then exit.
-        if n_expr.operator in (Binary_Operator.COMP_EQ,
-                               Binary_Operator.COMP_NEQ):
+        if n_expr.operator in (Binary_Operator.COMP_EQ, Binary_Operator.COMP_NEQ):
             return self.tr_op_equality(n_expr)
 
         elif n_expr.operator == Binary_Operator.LOGICAL_IMPLIES:
@@ -926,32 +922,33 @@ class VCG:
         if n_expr.operator == Binary_Operator.LOGICAL_XOR:
             sym_value = smt.Exclusive_Disjunction(lhs_value, rhs_value)
 
-        elif n_expr.operator in (Binary_Operator.PLUS,
-                                 Binary_Operator.MINUS,
-                                 Binary_Operator.TIMES,
-                                 Binary_Operator.DIVIDE,
-                                 Binary_Operator.REMAINDER):
-
+        elif n_expr.operator in (
+            Binary_Operator.PLUS,
+            Binary_Operator.MINUS,
+            Binary_Operator.TIMES,
+            Binary_Operator.DIVIDE,
+            Binary_Operator.REMAINDER,
+        ):
             if isinstance(n_expr.n_lhs.typ, Builtin_String):
                 assert n_expr.operator == Binary_Operator.PLUS
                 sym_value = smt.String_Concatenation(lhs_value, rhs_value)
 
             elif isinstance(n_expr.n_lhs.typ, Builtin_Integer):
-                if n_expr.operator in (Binary_Operator.DIVIDE,
-                                       Binary_Operator.REMAINDER):
+                if n_expr.operator in (
+                    Binary_Operator.DIVIDE,
+                    Binary_Operator.REMAINDER,
+                ):
                     self.attach_int_division_check(rhs_value, n_expr)
 
                 smt_op = {
-                    Binary_Operator.PLUS      : "+",
-                    Binary_Operator.MINUS     : "-",
-                    Binary_Operator.TIMES     : "*",
-                    Binary_Operator.DIVIDE    : "floor_div",
-                    Binary_Operator.REMAINDER : "ada_remainder",
+                    Binary_Operator.PLUS: "+",
+                    Binary_Operator.MINUS: "-",
+                    Binary_Operator.TIMES: "*",
+                    Binary_Operator.DIVIDE: "floor_div",
+                    Binary_Operator.REMAINDER: "ada_remainder",
                 }[n_expr.operator]
 
-                sym_value = smt.Binary_Int_Arithmetic_Op(smt_op,
-                                                         lhs_value,
-                                                         rhs_value)
+                sym_value = smt.Binary_Int_Arithmetic_Op(smt_op, lhs_value, rhs_value)
 
             else:
                 assert isinstance(n_expr.n_lhs.typ, Builtin_Decimal)
@@ -959,53 +956,53 @@ class VCG:
                     self.attach_real_division_check(rhs_value, n_expr)
 
                 smt_op = {
-                    Binary_Operator.PLUS   : "+",
-                    Binary_Operator.MINUS  : "-",
-                    Binary_Operator.TIMES  : "*",
-                    Binary_Operator.DIVIDE : "/",
+                    Binary_Operator.PLUS: "+",
+                    Binary_Operator.MINUS: "-",
+                    Binary_Operator.TIMES: "*",
+                    Binary_Operator.DIVIDE: "/",
                 }[n_expr.operator]
 
-                sym_value = smt.Binary_Real_Arithmetic_Op(smt_op,
-                                                          lhs_value,
-                                                          rhs_value)
+                sym_value = smt.Binary_Real_Arithmetic_Op(smt_op, lhs_value, rhs_value)
 
-        elif n_expr.operator in (Binary_Operator.COMP_LT,
-                                 Binary_Operator.COMP_LEQ,
-                                 Binary_Operator.COMP_GT,
-                                 Binary_Operator.COMP_GEQ):
+        elif n_expr.operator in (
+            Binary_Operator.COMP_LT,
+            Binary_Operator.COMP_LEQ,
+            Binary_Operator.COMP_GT,
+            Binary_Operator.COMP_GEQ,
+        ):
             smt_op = {
-                Binary_Operator.COMP_LT  : "<",
-                Binary_Operator.COMP_LEQ : "<=",
-                Binary_Operator.COMP_GT  : ">",
-                Binary_Operator.COMP_GEQ : ">=",
+                Binary_Operator.COMP_LT: "<",
+                Binary_Operator.COMP_LEQ: "<=",
+                Binary_Operator.COMP_GT: ">",
+                Binary_Operator.COMP_GEQ: ">=",
             }[n_expr.operator]
 
             sym_value = smt.Comparison(smt_op, lhs_value, rhs_value)
 
-        elif n_expr.operator in (Binary_Operator.STRING_CONTAINS,
-                                 Binary_Operator.STRING_STARTSWITH,
-                                 Binary_Operator.STRING_ENDSWITH):
-
+        elif n_expr.operator in (
+            Binary_Operator.STRING_CONTAINS,
+            Binary_Operator.STRING_STARTSWITH,
+            Binary_Operator.STRING_ENDSWITH,
+        ):
             smt_op = {
-                Binary_Operator.STRING_CONTAINS   : "contains",
-                Binary_Operator.STRING_STARTSWITH : "prefixof",
-                Binary_Operator.STRING_ENDSWITH   : "suffixof"
+                Binary_Operator.STRING_CONTAINS: "contains",
+                Binary_Operator.STRING_STARTSWITH: "prefixof",
+                Binary_Operator.STRING_ENDSWITH: "suffixof",
             }
 
             # LHS / RHS ordering is not a mistake, in SMTLIB it's the
             # other way around than in TRLC.
-            sym_value = smt.String_Predicate(smt_op[n_expr.operator],
-                                             rhs_value,
-                                             lhs_value)
+            sym_value = smt.String_Predicate(
+                smt_op[n_expr.operator], rhs_value, lhs_value
+            )
 
         elif n_expr.operator == Binary_Operator.STRING_REGEX:
             rhs_evaluation = n_expr.n_rhs.evaluate(self.mh, None, None).value
             assert isinstance(rhs_evaluation, str)
 
             sym_value = smt.Function_Application(
-                self.get_uf_matches(),
-                lhs_value,
-                smt.String_Literal(rhs_evaluation))
+                self.get_uf_matches(), lhs_value, smt.String_Literal(rhs_evaluation)
+            )
 
         elif n_expr.operator == Binary_Operator.INDEX:
             self.attach_index_check(lhs_value, rhs_value, n_expr)
@@ -1031,14 +1028,14 @@ class VCG:
                 sym_value = lhs_value
                 for _ in range(1, static_value):
                     if isinstance(n_expr.n_lhs.typ, Builtin_Integer):
-                        sym_value = smt.Binary_Int_Arithmetic_Op("*",
-                                                                 sym_value,
-                                                                 lhs_value)
+                        sym_value = smt.Binary_Int_Arithmetic_Op(
+                            "*", sym_value, lhs_value
+                        )
                     else:
                         assert isinstance(n_expr.n_lhs.typ, Builtin_Decimal)
-                        sym_value = smt.Binary_Real_Arithmetic_Op("*",
-                                                                  sym_value,
-                                                                  lhs_value)
+                        sym_value = smt.Binary_Real_Arithmetic_Op(
+                            "*", sym_value, lhs_value
+                        )
 
         else:  # pragma: no cover
             self.flag_unsupported(n_expr, n_expr.operator.name)
@@ -1048,7 +1045,7 @@ class VCG:
     def tr_range_test(self, n_expr):
         assert isinstance(n_expr, Range_Test)
 
-        lhs_value, lhs_valid     = self.tr_expression(n_expr.n_lhs)
+        lhs_value, lhs_valid = self.tr_expression(n_expr.n_lhs)
         self.attach_validity_check(lhs_valid, n_expr.n_lhs)
         lower_value, lower_valid = self.tr_expression(n_expr.n_lower)
         self.attach_validity_check(lower_valid, n_expr.n_lower)
@@ -1057,7 +1054,8 @@ class VCG:
 
         sym_value = smt.Conjunction(
             smt.Comparison(">=", lhs_value, lower_value),
-            smt.Comparison("<=", lhs_value, upper_value))
+            smt.Comparison("<=", lhs_value, upper_value),
+        )
 
         return self.create_return(n_expr, sym_value)
 
@@ -1070,8 +1068,7 @@ class VCG:
             self.attach_validity_check(c_valid, n_choice)
             choices.append(c_value)
 
-        negated_choices = [smt.Boolean_Negation(c)
-                           for c in choices]
+        negated_choices = [smt.Boolean_Negation(c) for c in choices]
 
         # pylint: disable=consider-using-enumerate
 
@@ -1100,7 +1097,7 @@ class VCG:
         s_result, _ = self.tr_expression(n_expr.else_expr)
         for n_action in reversed(n_expr.actions):
             s_condition, _ = self.tr_expression(n_action.n_cond)
-            s_true, _      = self.tr_expression(n_action.n_expr)
+            s_true, _ = self.tr_expression(n_action.n_expr)
             s_result = smt.Conditional(s_condition, s_true, s_result)
 
         return self.create_return(n_expr, s_result)
@@ -1110,8 +1107,7 @@ class VCG:
         assert not self.functional
 
         gn_end = graph.Node(self.graph)
-        sym_result = smt.Constant(self.tr_type(n_expr.typ),
-                                  self.new_temp_name())
+        sym_result = smt.Constant(self.tr_type(n_expr.typ), self.new_temp_name())
 
         for n_action in n_expr.actions:
             test_value, test_valid = self.tr_expression(n_action.n_cond)
@@ -1122,9 +1118,7 @@ class VCG:
             self.attach_assumption(test_value)
             res_value, res_valid = self.tr_expression(n_action.n_expr)
             self.attach_validity_check(res_valid, n_action.n_expr)
-            self.attach_temp_declaration(n_action,
-                                         sym_result,
-                                         res_value)
+            self.attach_temp_declaration(n_action, sym_result, res_value)
             self.start.add_edge_to(gn_end)
 
             # Reset to test and proceed with the other actions
@@ -1134,9 +1128,7 @@ class VCG:
         # Finally execute the else part
         res_value, res_valid = self.tr_expression(n_expr.else_expr)
         self.attach_validity_check(res_valid, n_expr.else_expr)
-        self.attach_temp_declaration(n_expr,
-                                     sym_result,
-                                     res_value)
+        self.attach_temp_declaration(n_expr, sym_result, res_value)
         self.start.add_edge_to(gn_end)
 
         # And join
@@ -1150,8 +1142,7 @@ class VCG:
         if self.functional:
             lhs_value, _ = self.tr_expression(n_expr.n_lhs)
             rhs_value, _ = self.tr_expression(n_expr.n_rhs)
-            return self.create_return(n_expr,
-                                      smt.Implication(lhs_value, rhs_value))
+            return self.create_return(n_expr, smt.Implication(lhs_value, rhs_value))
 
         lhs_value, lhs_valid = self.tr_expression(n_expr.n_lhs)
         # Emit VC for validity
@@ -1159,16 +1150,13 @@ class VCG:
 
         # Split into two paths.
         current_start = self.start
-        sym_result = smt.Constant(smt.BUILTIN_BOOLEAN,
-                                  self.new_temp_name())
+        sym_result = smt.Constant(smt.BUILTIN_BOOLEAN, self.new_temp_name())
         gn_end = graph.Node(self.graph)
 
         ### 1: Implication is not valid
         self.start = current_start
         self.attach_assumption(smt.Boolean_Negation(lhs_value))
-        self.attach_temp_declaration(n_expr,
-                                     sym_result,
-                                     smt.Boolean_Literal(True))
+        self.attach_temp_declaration(n_expr, sym_result, smt.Boolean_Literal(True))
         self.start.add_edge_to(gn_end)
 
         ### 2: Implication is valid.
@@ -1176,9 +1164,7 @@ class VCG:
         self.attach_assumption(lhs_value)
         rhs_value, rhs_valid = self.tr_expression(n_expr.n_rhs)
         self.attach_validity_check(rhs_valid, n_expr.n_rhs)
-        self.attach_temp_declaration(n_expr,
-                                     sym_result,
-                                     rhs_value)
+        self.attach_temp_declaration(n_expr, sym_result, rhs_value)
         self.start.add_edge_to(gn_end)
 
         # Join paths
@@ -1193,8 +1179,7 @@ class VCG:
         if self.functional:
             lhs_value, _ = self.tr_expression(n_expr.n_lhs)
             rhs_value, _ = self.tr_expression(n_expr.n_rhs)
-            return self.create_return(n_expr,
-                                      smt.Conjunction(lhs_value, rhs_value))
+            return self.create_return(n_expr, smt.Conjunction(lhs_value, rhs_value))
 
         lhs_value, lhs_valid = self.tr_expression(n_expr.n_lhs)
         # Emit VC for validity
@@ -1202,16 +1187,13 @@ class VCG:
 
         # Split into two paths.
         current_start = self.start
-        sym_result = smt.Constant(smt.BUILTIN_BOOLEAN,
-                                  self.new_temp_name())
+        sym_result = smt.Constant(smt.BUILTIN_BOOLEAN, self.new_temp_name())
         gn_end = graph.Node(self.graph)
 
         ### 1: LHS is not true
         self.start = current_start
         self.attach_assumption(smt.Boolean_Negation(lhs_value))
-        self.attach_temp_declaration(n_expr,
-                                     sym_result,
-                                     smt.Boolean_Literal(False))
+        self.attach_temp_declaration(n_expr, sym_result, smt.Boolean_Literal(False))
         self.start.add_edge_to(gn_end)
 
         ### 2: LHS is true
@@ -1219,9 +1201,7 @@ class VCG:
         self.attach_assumption(lhs_value)
         rhs_value, rhs_valid = self.tr_expression(n_expr.n_rhs)
         self.attach_validity_check(rhs_valid, n_expr.n_rhs)
-        self.attach_temp_declaration(n_expr,
-                                     sym_result,
-                                     rhs_value)
+        self.attach_temp_declaration(n_expr, sym_result, rhs_value)
         self.start.add_edge_to(gn_end)
 
         # Join paths
@@ -1236,8 +1216,7 @@ class VCG:
         if self.functional:
             lhs_value, _ = self.tr_expression(n_expr.n_lhs)
             rhs_value, _ = self.tr_expression(n_expr.n_rhs)
-            return self.create_return(n_expr,
-                                      smt.Disjunction(lhs_value, rhs_value))
+            return self.create_return(n_expr, smt.Disjunction(lhs_value, rhs_value))
 
         lhs_value, lhs_valid = self.tr_expression(n_expr.n_lhs)
         # Emit VC for validity
@@ -1245,16 +1224,13 @@ class VCG:
 
         # Split into two paths.
         current_start = self.start
-        sym_result = smt.Constant(smt.BUILTIN_BOOLEAN,
-                                  self.new_temp_name())
+        sym_result = smt.Constant(smt.BUILTIN_BOOLEAN, self.new_temp_name())
         gn_end = graph.Node(self.graph)
 
         ### 1: LHS is true
         self.start = current_start
         self.attach_assumption(lhs_value)
-        self.attach_temp_declaration(n_expr,
-                                     sym_result,
-                                     smt.Boolean_Literal(True))
+        self.attach_temp_declaration(n_expr, sym_result, smt.Boolean_Literal(True))
         self.start.add_edge_to(gn_end)
 
         ### 2: LHS is not true
@@ -1262,9 +1238,7 @@ class VCG:
         self.attach_assumption(smt.Boolean_Negation(lhs_value))
         rhs_value, rhs_valid = self.tr_expression(n_expr.n_rhs)
         self.attach_validity_check(rhs_valid, n_expr.n_rhs)
-        self.attach_temp_declaration(n_expr,
-                                     sym_result,
-                                     rhs_value)
+        self.attach_temp_declaration(n_expr, sym_result, rhs_value)
         self.start.add_edge_to(gn_end)
 
         # Join paths
@@ -1277,25 +1251,20 @@ class VCG:
         assert isinstance(lhs, smt.Expression)
         assert isinstance(rhs, smt.Expression)
 
-        value_lhs = smt.Record_Access(lhs,
-                                      n_component.name + ".value")
-        value_rhs = smt.Record_Access(rhs,
-                                      n_component.name + ".value")
-        valid_equal = self.tr_core_equality(n_component.n_typ,
-                                            value_lhs,
-                                            value_rhs)
+        value_lhs = smt.Record_Access(lhs, n_component.name + ".value")
+        value_rhs = smt.Record_Access(rhs, n_component.name + ".value")
+        valid_equal = self.tr_core_equality(n_component.n_typ, value_lhs, value_rhs)
 
         if not n_component.optional:
             return valid_equal
 
-        valid_lhs = smt.Record_Access(lhs,
-                                      n_component.name + ".valid")
-        valid_rhs = smt.Record_Access(rhs,
-                                      n_component.name + ".valid")
+        valid_lhs = smt.Record_Access(lhs, n_component.name + ".valid")
+        valid_rhs = smt.Record_Access(rhs, n_component.name + ".valid")
 
         return smt.Conjunction(
             smt.Comparison("=", valid_lhs, valid_rhs),
-            smt.Implication(valid_lhs, valid_equal))
+            smt.Implication(valid_lhs, valid_equal),
+        )
 
     def tr_core_equality(self, n_typ, lhs, rhs):
         assert isinstance(n_typ, Type)
@@ -1306,9 +1275,8 @@ class VCG:
             parts = []
             for n_component in n_typ.all_components():
                 parts.append(
-                    self.tr_core_equality_tuple_component(n_component,
-                                                          lhs,
-                                                          rhs))
+                    self.tr_core_equality_tuple_component(n_component, lhs, rhs)
+                )
 
             if len(parts) == 0:
                 return smt.Boolean_Literal(True)
@@ -1325,8 +1293,7 @@ class VCG:
 
     def tr_op_equality(self, n_expr):
         assert isinstance(n_expr, Binary_Expression)
-        assert n_expr.operator in (Binary_Operator.COMP_EQ,
-                                   Binary_Operator.COMP_NEQ)
+        assert n_expr.operator in (Binary_Operator.COMP_EQ, Binary_Operator.COMP_NEQ)
 
         lhs_value, lhs_valid = self.tr_expression(n_expr.n_lhs)
         rhs_value, rhs_valid = self.tr_expression(n_expr.n_rhs)
@@ -1338,9 +1305,7 @@ class VCG:
 
         if lhs_valid.is_static_true() and rhs_valid.is_static_true():
             # Simplified form, this is just x == y
-            result = self.tr_core_equality(comp_typ,
-                                           lhs_value,
-                                           rhs_value)
+            result = self.tr_core_equality(comp_typ, lhs_value, rhs_value)
 
         elif lhs_valid.is_static_false() and rhs_valid.is_static_false():
             # This is null == null, so true
@@ -1358,10 +1323,10 @@ class VCG:
             # This is <expr> == <expr> without shortcuts
             result = smt.Conjunction(
                 smt.Comparison("=", lhs_valid, rhs_valid),
-                smt.Implication(lhs_valid,
-                                self.tr_core_equality(comp_typ,
-                                                      lhs_value,
-                                                      rhs_value)))
+                smt.Implication(
+                    lhs_valid, self.tr_core_equality(comp_typ, lhs_value, rhs_value)
+                ),
+            )
 
         if n_expr.operator == Binary_Operator.COMP_NEQ:
             result = smt.Boolean_Negation(result)
@@ -1373,8 +1338,7 @@ class VCG:
 
         # Nested quantifiers are not supported yet
         if self.functional:  # pragma: no cover
-            self.flag_unsupported(n_expr,
-                                  "functional evaluation of quantifier")
+            self.flag_unsupported(n_expr, "functional evaluation of quantifier")
 
         # TRLC quantifier
         #   (forall x in arr_name => body)
@@ -1394,8 +1358,7 @@ class VCG:
         # value of some sequence member.
 
         # Evaluate subject first and creat a null check
-        s_subject_value, s_subject_valid = \
-            self.tr_name_reference(n_expr.n_source)
+        s_subject_value, s_subject_valid = self.tr_name_reference(n_expr.n_source)
         self.attach_validity_check(s_subject_valid, n_expr.n_source)
 
         # Create validity checks for the body. We do this by creating
@@ -1406,32 +1369,37 @@ class VCG:
         self.attach_empty_assumption()
         src_typ = n_expr.n_source.typ
         assert isinstance(src_typ, Array_Type)
-        s_qe_index = smt.Constant(smt.BUILTIN_INTEGER,
-                                  self.new_temp_name())
+        s_qe_index = smt.Constant(smt.BUILTIN_INTEGER, self.new_temp_name())
         self.start.add_statement(
             smt.Constant_Declaration(
-                symbol   = s_qe_index,
-                comment  = ("quantifier elimination (index) for %s at %s" %
-                            (n_expr.to_string(),
-                             n_expr.location.to_string()))))
+                symbol=s_qe_index,
+                comment=(
+                    "quantifier elimination (index) for %s at %s"
+                    % (n_expr.to_string(), n_expr.location.to_string())
+                ),
+            )
+        )
         self.start.add_statement(
-            smt.Assertion(smt.Comparison(">=",
-                                         s_qe_index,
-                                         smt.Integer_Literal(0))))
+            smt.Assertion(smt.Comparison(">=", s_qe_index, smt.Integer_Literal(0)))
+        )
         self.start.add_statement(
             smt.Assertion(
-                smt.Comparison("<",
-                               s_qe_index,
-                               smt.Sequence_Length(s_subject_value))))
-        s_qe_sym = smt.Constant(self.tr_type(src_typ.element_type),
-                                self.new_temp_name())
+                smt.Comparison("<", s_qe_index, smt.Sequence_Length(s_subject_value))
+            )
+        )
+        s_qe_sym = smt.Constant(
+            self.tr_type(src_typ.element_type), self.new_temp_name()
+        )
         self.start.add_statement(
             smt.Constant_Declaration(
-                symbol   = s_qe_sym,
-                value    = smt.Sequence_Index(s_subject_value, s_qe_index),
-                comment  = ("quantifier elimination (symbol) for %s at %s" %
-                            (n_expr.to_string(),
-                             n_expr.location.to_string()))))
+                symbol=s_qe_sym,
+                value=smt.Sequence_Index(s_subject_value, s_qe_index),
+                comment=(
+                    "quantifier elimination (symbol) for %s at %s"
+                    % (n_expr.to_string(), n_expr.location.to_string())
+                ),
+            )
+        )
         self.qe_vars[n_expr.n_var] = s_qe_sym
 
         _, b_valid = self.tr_expression(n_expr.n_expr)
@@ -1444,8 +1412,7 @@ class VCG:
         # raise exception. Asserting the actual value of the
         # quantifier is more awkward.
 
-        s_q_idx = smt.Bound_Variable(smt.BUILTIN_INTEGER,
-                                     self.new_temp_name())
+        s_q_idx = smt.Bound_Variable(smt.BUILTIN_INTEGER, self.new_temp_name())
         s_q_sym = smt.Sequence_Index(s_subject_value, s_q_idx)
         self.bound_vars[n_expr.n_var] = s_q_sym
 
@@ -1454,27 +1421,21 @@ class VCG:
         self.functional = temp
 
         bounds_expr = smt.Conjunction(
-            smt.Comparison(">=",
-                           s_q_idx,
-                           smt.Integer_Literal(0)),
-            smt.Comparison("<",
-                           s_q_idx,
-                           smt.Sequence_Length(s_subject_value)))
+            smt.Comparison(">=", s_q_idx, smt.Integer_Literal(0)),
+            smt.Comparison("<", s_q_idx, smt.Sequence_Length(s_subject_value)),
+        )
         if n_expr.universal:
             value = smt.Quantifier(
-                "forall",
-                [s_q_idx],
-                smt.Implication(bounds_expr, b_value))
+                "forall", [s_q_idx], smt.Implication(bounds_expr, b_value)
+            )
         else:
             value = smt.Quantifier(
-                "exists",
-                [s_q_idx],
-                smt.Conjunction(bounds_expr, b_value))
+                "exists", [s_q_idx], smt.Conjunction(bounds_expr, b_value)
+            )
 
         return value, smt.Boolean_Literal(True)
 
-    def _ensure_record_deref(self, type_key, sort_name, uf_name,
-                             components):
+    def _ensure_record_deref(self, type_key, sort_name, uf_name, components):
         """Lazily create an SMT record sort and uninterpreted function
         for dereferencing integer-encoded references.
 
@@ -1491,19 +1452,14 @@ class VCG:
         for field_name, field_sort, needs_valid in components:
             record_sort.add_component(field_name + ".value", field_sort)
             if needs_valid:
-                record_sort.add_component(field_name + ".valid",
-                                          smt.BUILTIN_BOOLEAN)
+                record_sort.add_component(field_name + ".valid", smt.BUILTIN_BOOLEAN)
         self.records[type_key] = record_sort
-        self.preamble.add_statement(
-            smt.Record_Declaration(
-                record_sort,
-                sort_name))
+        self.preamble.add_statement(smt.Record_Declaration(record_sort, sort_name))
 
         to_record_uf = smt.Function(
-            uf_name, record_sort,
-            smt.Bound_Variable(smt.BUILTIN_INTEGER, "ref"))
-        self.preamble.add_statement(
-            smt.Function_Declaration(to_record_uf))
+            uf_name, record_sort, smt.Bound_Variable(smt.BUILTIN_INTEGER, "ref")
+        )
+        self.preamble.add_statement(smt.Function_Declaration(to_record_uf))
         self.uf_records[type_key] = to_record_uf
 
         return record_sort, to_record_uf
@@ -1517,11 +1473,13 @@ class VCG:
             self.attach_validity_check(prefix_valid, n_expr.n_prefix)
 
         if isinstance(prefix_typ, Tuple_Type):
-            field_value = smt.Record_Access(prefix_value,
-                                            n_expr.n_field.name + ".value")
+            field_value = smt.Record_Access(
+                prefix_value, n_expr.n_field.name + ".value"
+            )
             if n_expr.n_field.optional:
-                field_valid = smt.Record_Access(prefix_value,
-                                                n_expr.n_field.name + ".valid")
+                field_valid = smt.Record_Access(
+                    prefix_value, n_expr.n_field.name + ".valid"
+                )
             else:
                 field_valid = smt.Boolean_Literal(True)
 
@@ -1537,19 +1495,17 @@ class VCG:
                     (c.name, self.tr_type(c.n_typ), c.optional)
                     for c in prefix_typ.all_components()
                 ]
-                sort_name = "%s.%s" % (prefix_typ.n_package.name,
-                                       prefix_typ.name)
-                uf_name = "access.%s.%s" % (prefix_typ.n_package.name,
-                                            prefix_typ.name)
+                sort_name = "%s.%s" % (prefix_typ.n_package.name, prefix_typ.name)
+                uf_name = "access.%s.%s" % (prefix_typ.n_package.name, prefix_typ.name)
             else:
                 field_map = prefix_typ.get_field_map()
-                union_id = "_".join(t.fully_qualified_name()
-                                    for t in prefix_typ.types)
+                union_id = "_".join(t.fully_qualified_name() for t in prefix_typ.types)
                 components = [
-                    (name,
-                     self.tr_type(info["n_typ"]),
-                     info["count"] != info["total"] or
-                     info["optional_in_any"])
+                    (
+                        name,
+                        self.tr_type(info["n_typ"]),
+                        info["count"] != info["total"] or info["optional_in_any"],
+                    )
                     for name, info in field_map.items()
                     if info["n_typ"] is not None
                 ]
@@ -1557,31 +1513,31 @@ class VCG:
                 uf_name = "access.union." + union_id
 
             _, to_record_uf = self._ensure_record_deref(
-                sort_name, sort_name, uf_name, components)
-            dereference = smt.Function_Application(to_record_uf,
-                                                   prefix_value)
+                sort_name, sort_name, uf_name, components
+            )
+            dereference = smt.Function_Application(to_record_uf, prefix_value)
 
             # Perform the field access on the dereferenced record
-            field_value = smt.Record_Access(dereference,
-                                            n_expr.n_field.name + ".value")
+            field_value = smt.Record_Access(dereference, n_expr.n_field.name + ".value")
             if isinstance(prefix_typ, Union_Type):
                 info = prefix_typ.get_field_map()[n_expr.n_field.name]
-                has_valid = (info["count"] != info["total"] or
-                             info["optional_in_any"])
+                has_valid = info["count"] != info["total"] or info["optional_in_any"]
             else:
                 has_valid = n_expr.n_field.optional
 
             if has_valid:
                 field_valid = smt.Record_Access(
-                    dereference,
-                    n_expr.n_field.name + ".valid")
+                    dereference, n_expr.n_field.name + ".valid"
+                )
             else:
                 field_valid = smt.Boolean_Literal(True)
 
         else:
-            self.mh.ice_loc(n_expr.n_prefix.location,
-                            "unexpected type %s as prefix of field access" %
-                            n_expr.n_prefix.typ.__class__.__name__)
+            self.mh.ice_loc(
+                n_expr.n_prefix.location,
+                "unexpected type %s as prefix of field access"
+                % n_expr.n_prefix.typ.__class__.__name__,
+            )
 
         # pylint: disable=possibly-used-before-assignment
         return field_value, field_valid

--- a/trlc/version.py
+++ b/trlc/version.py
@@ -21,8 +21,9 @@
 VERSION_TUPLE = (3, 0, 1)
 VERSION_SUFFIX = ""
 
-TRLC_VERSION = ("%u.%u.%u" % VERSION_TUPLE) + \
-    ("-%s" % VERSION_SUFFIX if VERSION_SUFFIX else "")
+TRLC_VERSION = ("%u.%u.%u" % VERSION_TUPLE) + (
+    "-%s" % VERSION_SUFFIX if VERSION_SUFFIX else ""
+)
 
 FULL_NAME = "TRLC %s" % TRLC_VERSION
 

--- a/util/BUILD
+++ b/util/BUILD
@@ -1,0 +1,8 @@
+exports_files(
+    [
+        "lint_check.sh",
+        "pycodestyle_runner.py",
+    ],
+    visibility = ["//visibility:public"],
+)
+

--- a/util/BUILD
+++ b/util/BUILD
@@ -2,7 +2,7 @@ exports_files(
     [
         "lint_check.sh",
         "pycodestyle_runner.py",
+        "clean_coverage.sh",
     ],
     visibility = ["//visibility:public"],
 )
-

--- a/util/BUILD
+++ b/util/BUILD
@@ -1,0 +1,6 @@
+exports_files(
+    [
+        "clean_coverage.sh",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/util/bump_version_post_release.py
+++ b/util/bump_version_post_release.py
@@ -35,9 +35,7 @@ tmp = ""
 with open(VERSION_FILE, "r") as fd:
     for raw_line in fd:
         if raw_line.startswith("VERSION_TUPLE"):
-            raw_line = 'VERSION_TUPLE = (%u, %u, %u)\n' % (major,
-                                                           minor,
-                                                           release)
+            raw_line = "VERSION_TUPLE = (%u, %u, %u)\n" % (major, minor, release)
         elif raw_line.startswith("VERSION_SUFFIX"):
             raw_line = 'VERSION_SUFFIX = "dev"\n'
 

--- a/util/changelog.py
+++ b/util/changelog.py
@@ -22,7 +22,7 @@
 
 
 def current_section():
-    """ Get most recent (i.e. first) section of the changelog """
+    """Get most recent (i.e. first) section of the changelog"""
     tmp = ""
     relevant_log = ""
     mode = "searching for changelog"
@@ -47,7 +47,7 @@ def current_section():
 
 
 def set_current_title(new_title):
-    """ Update last CHANGELOG entry to the given title. """
+    """Update last CHANGELOG entry to the given title."""
     assert isinstance(new_title, str)
 
     tmp = ""
@@ -69,7 +69,7 @@ def set_current_title(new_title):
 
 
 def add_new_section(new_title):
-    """ Add new CHANGELOG entry with the given title. """
+    """Add new CHANGELOG entry with the given title."""
     assert isinstance(new_title, str)
 
     tmp = ""

--- a/util/clean_coverage.sh
+++ b/util/clean_coverage.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# For `bazel run`, this points at the checkout root.
+workspace_dir="${BUILD_WORKSPACE_DIRECTORY:-$PWD}"
+cd "$workspace_dir"
+
+rm -rf htmlcov
+find . -name '.coverage*' -type f -delete
+find . -name '*.pyc' -type f -delete
+
+echo "All .coverage, .coverage.* and *.pyc files deleted."

--- a/util/github_release.py
+++ b/util/github_release.py
@@ -46,16 +46,16 @@ def main():
 
     auth = requests.auth.HTTPBasicAuth(username, token)
 
-    api_endpoint = "https://api.github.com/repos/%s/%s/releases" % \
-        ("bmw-software-engineering", "trlc")
+    api_endpoint = "https://api.github.com/repos/%s/%s/releases" % (
+        "bmw-software-engineering",
+        "trlc",
+    )
 
     tag_name = "trlc-%s" % TRLC_VERSION
     rel_name = "Release %s" % TRLC_VERSION
     rel_body = "### %s\n\n%s" % (TRLC_VERSION, util.changelog.current_section())
 
-    data = {"tag_name" : tag_name,
-            "name"     : rel_name,
-            "body"     : rel_body}
+    data = {"tag_name": tag_name, "name": rel_name, "body": rel_body}
 
     r = requests.post(api_endpoint, auth=auth, data=json.dumps(data))
     print(r)

--- a/util/large-test-generator.py
+++ b/util/large-test-generator.py
@@ -5,13 +5,11 @@ import argparse
 import random
 from pprint import pprint
 
-STRING_CONTENT_SINGLE = "".join(chr(c)
-                                for c in range(0x200)
-                                if (chr(c).isprintable() and
-                                    chr(c) != "\n"))
-STRING_CONTENT_TRIPLE = "".join(chr(c)
-                                for c in range(0x200)
-                                if chr(c).isprintable())
+STRING_CONTENT_SINGLE = "".join(
+    chr(c) for c in range(0x200) if (chr(c).isprintable() and chr(c) != "\n")
+)
+STRING_CONTENT_TRIPLE = "".join(chr(c) for c in range(0x200) if chr(c).isprintable())
+
 
 def generate_string(options):
     if random.randint(0, 1):
@@ -25,8 +23,7 @@ def generate_string(options):
         escape = None
         banned = "'"
 
-    string = "".join(random.choice(content)
-                     for _ in range(random.randint(25, 200)))
+    string = "".join(random.choice(content) for _ in range(random.randint(25, 200)))
 
     if banned is not None:
         string = string.replace(banned, "")
@@ -39,7 +36,6 @@ def generate_string(options):
 
 def generate_tests(options):
     random.seed(42)
-
 
     packages = ["generic"]
     for i in range(options.packages - 1):
@@ -55,31 +51,35 @@ def generate_tests(options):
     tree = {pkg: set() for pkg in packages}
     for pkg_id, pkg in enumerate(packages[1:], 1):
         tree[pkg].add("generic")
-        tree[pkg] |= set(random.choices(
-            packages[1:pkg_id] + packages[pkg_id + 1:],
-            k = random.randint(0, options.max_imports_per_package)))
+        tree[pkg] |= set(
+            random.choices(
+                packages[1:pkg_id] + packages[pkg_id + 1 :],
+                k=random.randint(0, options.max_imports_per_package),
+            )
+        )
 
     # packages -> files -> items
     items = {}
-    pkg_items = {"generic" : []}
+    pkg_items = {"generic": []}
     for pkg_name in packages[1:]:
         items[pkg_name] = {}
         pkg_items[pkg_name] = []
         num_files = random.randint(1, options.max_files_per_package)
-        num_items = random.randint(options.max_items_per_package // 3,
-                                   options.max_items_per_package)
+        num_items = random.randint(
+            options.max_items_per_package // 3, options.max_items_per_package
+        )
         offset = 1
         for file_id in range(1, num_files + 1):
-            file_name = "%s_%u.trlc" % (pkg_name,
-                                        file_id)
+            file_name = "%s_%u.trlc" % (pkg_name, file_id)
             if file_id == num_files:
                 item_count = num_items
             else:
                 item_count = random.randint(0, num_items * 2 // 3)
                 num_items -= item_count
 
-            items[pkg_name][file_name] = ["Item_%u" % (offset + item_id)
-                                          for item_id in range(item_count)]
+            items[pkg_name][file_name] = [
+                "Item_%u" % (offset + item_id) for item_id in range(item_count)
+            ]
             pkg_items[pkg_name] += items[pkg_name][file_name]
             offset += item_count
 
@@ -99,39 +99,31 @@ def generate_tests(options):
                 for item_name in items[pkg_name][file_name]:
                     total_items += 1
                     links = random.choices(
-                        pkg_items[pkg_name] +
-                        ["%s.%s" % (p_name, i_name)
-                         for p_name in tree[pkg_name]
-                         for i_name in pkg_items[p_name]],
-                        k = random.randint(0, options.max_links_per_item))
+                        pkg_items[pkg_name]
+                        + [
+                            "%s.%s" % (p_name, i_name)
+                            for p_name in tree[pkg_name]
+                            for i_name in pkg_items[p_name]
+                        ],
+                        k=random.randint(0, options.max_links_per_item),
+                    )
                     fd.write("generic.Requirement %s {\n" % item_name)
                     fd.write("  description = %s\n" % generate_string(options))
                     if links:
                         fd.write("  links = [%s]\n" % ", ".join(links))
                     fd.write("}\n\n")
 
-    print("Wrote %u items over %u packages." % (total_items,
-                                                total_pkg))
+    print("Wrote %u items over %u packages." % (total_items, total_pkg))
+
 
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument("target",
-                    help="generate test in this directory")
-    ap.add_argument("--packages",
-                    type=int,
-                    default=100)
-    ap.add_argument("--max-files-per-package",
-                    type=int,
-                    default=10)
-    ap.add_argument("--max-items-per-package",
-                    type=int,
-                    default=1500)
-    ap.add_argument("--max-imports-per-package",
-                    type=int,
-                    default=2)
-    ap.add_argument("--max-links-per-item",
-                    type=int,
-                    default=5)
+    ap.add_argument("target", help="generate test in this directory")
+    ap.add_argument("--packages", type=int, default=100)
+    ap.add_argument("--max-files-per-package", type=int, default=10)
+    ap.add_argument("--max-items-per-package", type=int, default=1500)
+    ap.add_argument("--max-imports-per-package", type=int, default=2)
+    ap.add_argument("--max-links-per-item", type=int, default=5)
 
     options = ap.parse_args()
 

--- a/util/lint_check.sh
+++ b/util/lint_check.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Wrapper to run pylint on TRLC sources
+
+set -euo pipefail
+
+exec python3 -m pylint --rcfile=pylint3.cfg \
+    --reports=no \
+    trlc trlc*.py lobster-*.py

--- a/util/mk_ast_hierarchy.py
+++ b/util/mk_ast_hierarchy.py
@@ -11,22 +11,25 @@ import trlc.ast
 
 DOC_BASE = "https://bmw-software-engineering.github.io/trlc/manual/ast.html"
 
+
 def main():
     ap = argparse.ArgumentParser()
     options = ap.parse_args()
 
     module = trlc.ast
-    root   = module.Node
+    root = module.Node
 
     print('digraph "AST Hierarchy" {')
     print('rankdir="LR";')
     for name, c in inspect.getmembers(module, inspect.isclass):
         if not issubclass(c, root):
             continue
-        url = "%s#trlc.ast.%s" % (DOC_BASE,
-                                  name)
+        url = "%s#trlc.ast.%s" % (DOC_BASE, name)
         doc = c.__doc__.split("\n\n", 1)[0]
-        print('"%s" [href="%s", shape=none, fontcolor="#0969da", tooltip="%s"];' % (name, url, doc))
+        print(
+            '"%s" [href="%s", shape=none, fontcolor="#0969da", tooltip="%s"];'
+            % (name, url, doc)
+        )
         for b in c.__bases__:
             if issubclass(b, root):
                 print('"%s" -> "%s";' % (b.__name__, name))

--- a/util/mk_parser_hierarchy.py
+++ b/util/mk_parser_hierarchy.py
@@ -17,13 +17,13 @@ import trlc.errors
 
 DOC_BASE = "https://github.com/bmw-software-engineering/trlc/blob/main/trlc/"
 
+
 def is_ignored(cls):
     if cls is object:
         return True
-    elif issubclass(cls, (trlc.ast.Node,
-                          trlc.errors.Message_Handler,
-                          numbers.Rational,
-                          type)):
+    elif issubclass(
+        cls, (trlc.ast.Node, trlc.errors.Message_Handler, numbers.Rational, type)
+    ):
         return True
     else:
         return False
@@ -48,7 +48,10 @@ def main():
                 doc = ""
             else:
                 doc = c.__doc__.split("\n\n", 1)[0]
-            print('"%s" [href="%s", shape=none, fontcolor="#0969da", tooltip="%s"];' % (name, url, doc))
+            print(
+                '"%s" [href="%s", shape=none, fontcolor="#0969da", tooltip="%s"];'
+                % (name, url, doc)
+            )
             for b in c.__bases__:
                 if is_ignored(b):
                     continue

--- a/util/pycodestyle_runner.py
+++ b/util/pycodestyle_runner.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""Wrapper to run pycodestyle on TRLC sources."""
+
+import subprocess
+import sys
+
+DEFAULT_TARGETS = [
+    "trlc",
+    "trlc.py",
+    "trlc-lrm-generator.py",
+    "lobster-trlc-system-test.py",
+]
+
+
+targets = sys.argv[1:] or DEFAULT_TARGETS
+result = subprocess.run([sys.executable, "-m", "pycodestyle", *targets], cwd=".")
+sys.exit(result.returncode)

--- a/util/release.py
+++ b/util/release.py
@@ -41,6 +41,7 @@ with open(VERSION_FILE, "w") as fd:
     fd.write(tmp)
 
 from trlc.version import TRLC_VERSION
+
 print(TRLC_VERSION)
 
 # Update last CHANGELOG entry and documentation to use the new


### PR DESCRIPTION
**Migrate code quality checks from `make lint` to Bazel's native linting via `aspect_rules_lint`, and add a reusable coverage cleanup target.**

### Changes

**Bazel infrastructure**
- MODULE.bazel: add `rules_shell@0.6.1` for shell script execution.
- BUILD: add `sh_binary` for `//:clean-coverage`, add `py_sources`, and fix unit-test deps from `//trlc:trlc` to trlc.
- util/clean_coverage.sh: implement the cleanup script used by Bazel.
- util/BUILD: export the cleanup script as a Bazel label.
- .bazelrc: add `build:lint` config for the `pylint` and `ty` lint aspects.

**Type checking**
- pyproject.toml: Add `ty` rule suppressions (`unresolved-attribute`, `invalid-assignment`) to reduce false positives on unannotated AST types; add per-file `unresolved-import` override for lobster-trlc-system-test.py

**CI**
- ci.yml: Rename job "PyLint" → "Bazel Lint"; install Bazel via `bazel-contrib/setup-bazel@0.19.0` with caching; replace `make lint` with `bazel build --config=lint`; add separate format check step (`bazel run //:format.check`)

**Dependencies**
- requirements_dev.txt: Relax pylint constraint to `pylint>=3,<4.0`; update lock file

**Docs & cleanup**
- dev_setup.md: Replace `make lint` / `make clean-coverage` with Bazel equivalents
- Makefile: Annotate `clean-coverage` with Bazel equivalent comment
- [copilot-instructions.md]: Update format style rule to explicitly name Ruff (bazel run //:format.fix) and Buildifier as the enforcing tools

**Code formatting**

- Ruff formatting applied across all Python source files (no logic changes)
- Buildifier formatting applied across all BUILD files (no logic changes)