### PR TITLE
feature(markdown): support arrays in .trlc.md files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ generated in the following situations:
 
 * [TRLC_RST] Fix trlc_rst rendering plain-String description fields as broken field lists
 
+* [TRLC] Add support for tuple-reference arrays in `.trlc.md` files.
+  Supports comma, `<br>`, and newline separation, and all LRM separator
+  kinds (`@`, `:`, `;`, identifier). Bracket notation is not supported.
+
 ### 3.0.1
 
 * [TRLC] Add experimental feature to parse markdown files and interpret their content as trlc objects.

--- a/tests-system/markdown-array-bracket-error/items.trlc
+++ b/tests-system/markdown-array-bracket-error/items.trlc
@@ -1,0 +1,13 @@
+package MdArrayTest
+
+Item item_a {
+  description = "Item A"
+}
+
+Item item_b {
+  description = "Item B"
+}
+
+Item item_c {
+  description = "Item C"
+}

--- a/tests-system/markdown-array-bracket-error/model.rsl
+++ b/tests-system/markdown-array-bracket-error/model.rsl
@@ -1,0 +1,49 @@
+package MdArrayTest
+
+type Item {
+  description String
+}
+
+tuple ItemRefAt {
+  item      Item
+  separator @
+  version   Integer
+}
+
+tuple ItemRefColon {
+  item      Item
+  separator :
+  version   Integer
+}
+
+tuple ItemRefSemicolon {
+  item      Item
+  separator ;
+  version   Integer
+}
+
+tuple ItemRefWord {
+  item      Item
+  separator via
+  version   Integer
+}
+
+type RequirementAt {
+  description String
+  refs        ItemRefAt [1 .. *]
+}
+
+type RequirementColon {
+  description String
+  refs        ItemRefColon [1 .. *]
+}
+
+type RequirementSemicolon {
+  description String
+  refs        ItemRefSemicolon [1 .. *]
+}
+
+type RequirementWord {
+  description String
+  refs        ItemRefWord [1 .. *]
+}

--- a/tests-system/markdown-array-bracket-error/output
+++ b/tests-system/markdown-array-bracket-error/output
@@ -1,0 +1,10 @@
+markdown-array-bracket-error/req_field_ac_err.trlc.md:13:1: error: bracket notation for tuple-reference arrays is not supported
+| Use comma-separated or newline-separated tuple references without brackets instead, e.g. 'Pkg.item_a @ 1, Pkg.item_b @ 2'
+markdown-array-bracket-error/req_field_ac_err.trlc.md:25:1: error: bracket notation for tuple-reference arrays is not supported
+| Use comma-separated or newline-separated tuple references without brackets instead, e.g. 'Pkg.item_a @ 1, Pkg.item_b @ 2'
+markdown-array-bracket-error/req_table_a_err.trlc.md:11:1: error: bracket notation for tuple-reference arrays is not supported
+| Use comma-separated or newline-separated tuple references without brackets instead, e.g. 'Pkg.item_a @ 1, Pkg.item_b @ 2'
+markdown-array-bracket-error/req_field_ac_err.trlc.md:15:1: error: expected opening bracket '[', encountered closing brace '}' instead
+markdown-array-bracket-error/req_field_ac_err.trlc.md:27:1: error: expected opening bracket '[', encountered closing brace '}' instead
+markdown-array-bracket-error/req_table_a_err.trlc.md:13:1: error: expected opening bracket '[', encountered closing brace '}' instead
+Processed 1 model and 3 requirement files and found 6 errors

--- a/tests-system/markdown-array-bracket-error/output.brief
+++ b/tests-system/markdown-array-bracket-error/output.brief
@@ -1,0 +1,7 @@
+markdown-array-bracket-error/req_field_ac_err.trlc.md:13:1: trlc error: bracket notation for tuple-reference arrays is not supported
+markdown-array-bracket-error/req_field_ac_err.trlc.md:25:1: trlc error: bracket notation for tuple-reference arrays is not supported
+markdown-array-bracket-error/req_table_a_err.trlc.md:11:1: trlc error: bracket notation for tuple-reference arrays is not supported
+markdown-array-bracket-error/req_field_ac_err.trlc.md:15:1: trlc error: expected opening bracket '[', encountered closing brace '}' instead
+markdown-array-bracket-error/req_field_ac_err.trlc.md:27:1: trlc error: expected opening bracket '[', encountered closing brace '}' instead
+markdown-array-bracket-error/req_table_a_err.trlc.md:13:1: trlc error: expected opening bracket '[', encountered closing brace '}' instead
+Processed 1 model and 3 requirement files and found 6 errors

--- a/tests-system/markdown-array-bracket-error/output.json
+++ b/tests-system/markdown-array-bracket-error/output.json
@@ -1,0 +1,10 @@
+markdown-array-bracket-error/req_field_ac_err.trlc.md:13:1: error: bracket notation for tuple-reference arrays is not supported
+| Use comma-separated or newline-separated tuple references without brackets instead, e.g. 'Pkg.item_a @ 1, Pkg.item_b @ 2'
+markdown-array-bracket-error/req_field_ac_err.trlc.md:25:1: error: bracket notation for tuple-reference arrays is not supported
+| Use comma-separated or newline-separated tuple references without brackets instead, e.g. 'Pkg.item_a @ 1, Pkg.item_b @ 2'
+markdown-array-bracket-error/req_table_a_err.trlc.md:11:1: error: bracket notation for tuple-reference arrays is not supported
+| Use comma-separated or newline-separated tuple references without brackets instead, e.g. 'Pkg.item_a @ 1, Pkg.item_b @ 2'
+markdown-array-bracket-error/req_field_ac_err.trlc.md:15:1: error: expected opening bracket '[', encountered closing brace '}' instead
+markdown-array-bracket-error/req_field_ac_err.trlc.md:27:1: error: expected opening bracket '[', encountered closing brace '}' instead
+markdown-array-bracket-error/req_table_a_err.trlc.md:13:1: error: expected opening bracket '[', encountered closing brace '}' instead
+Processed 1 model and 3 requirement files and found 6 errors

--- a/tests-system/markdown-array-bracket-error/output.smtlib
+++ b/tests-system/markdown-array-bracket-error/output.smtlib
@@ -1,0 +1,10 @@
+markdown-array-bracket-error/req_field_ac_err.trlc.md:13:1: error: bracket notation for tuple-reference arrays is not supported
+| Use comma-separated or newline-separated tuple references without brackets instead, e.g. 'Pkg.item_a @ 1, Pkg.item_b @ 2'
+markdown-array-bracket-error/req_field_ac_err.trlc.md:25:1: error: bracket notation for tuple-reference arrays is not supported
+| Use comma-separated or newline-separated tuple references without brackets instead, e.g. 'Pkg.item_a @ 1, Pkg.item_b @ 2'
+markdown-array-bracket-error/req_table_a_err.trlc.md:11:1: error: bracket notation for tuple-reference arrays is not supported
+| Use comma-separated or newline-separated tuple references without brackets instead, e.g. 'Pkg.item_a @ 1, Pkg.item_b @ 2'
+markdown-array-bracket-error/req_field_ac_err.trlc.md:15:1: error: expected opening bracket '[', encountered closing brace '}' instead
+markdown-array-bracket-error/req_field_ac_err.trlc.md:27:1: error: expected opening bracket '[', encountered closing brace '}' instead
+markdown-array-bracket-error/req_table_a_err.trlc.md:13:1: error: expected opening bracket '[', encountered closing brace '}' instead
+Processed 1 model and 3 requirement files and found 6 errors

--- a/tests-system/markdown-array-bracket-error/req_field_ac_err.trlc.md
+++ b/tests-system/markdown-array-bracket-error/req_field_ac_err.trlc.md
@@ -1,0 +1,27 @@
+# MdArrayTest
+
+## Requirements
+
+### REQ_FIELD_A_BRACKET
+
+| identifier  | REQ_FIELD_A_BRACKET                           |
+|-------------|------------------------------------------------|
+| type        | RequirementSemicolon                           |
+| description | Field.A: single item with brackets using ; (should error) |
+
+#### refs
+[MdArrayTest.item_a ; 1]
+
+<hr>
+
+### REQ_FIELD_C_BRACKET
+
+| identifier  | REQ_FIELD_C_BRACKET                            |
+|-------------|------------------------------------------------|
+| type        | RequirementWord                                |
+| description | Field.C: multi-item with brackets using identifier separator (should error) |
+
+#### refs
+[MdArrayTest.item_a via 1, MdArrayTest.item_b via 2]
+
+<hr>

--- a/tests-system/markdown-array-bracket-error/req_table_a_err.trlc.md
+++ b/tests-system/markdown-array-bracket-error/req_table_a_err.trlc.md
@@ -1,0 +1,13 @@
+# MdArrayTest
+
+## Requirements
+
+### REQ_TABLE_A_BRACKET
+
+| identifier  | REQ_TABLE_A_BRACKET                             |
+|-------------|--------------------------------------------------|
+| type        | RequirementColon                                 |
+| description | Table.A: bracket in table cell using : (should error) |
+| refs        | [MdArrayTest.item_a : 1, MdArrayTest.item_b : 2] |
+
+<hr>

--- a/tests-system/markdown-array/items.trlc
+++ b/tests-system/markdown-array/items.trlc
@@ -1,0 +1,13 @@
+package MdArrayTest
+
+Item item_a {
+  description = "Item A"
+}
+
+Item item_b {
+  description = "Item B"
+}
+
+Item item_c {
+  description = "Item C"
+}

--- a/tests-system/markdown-array/model.rsl
+++ b/tests-system/markdown-array/model.rsl
@@ -1,0 +1,49 @@
+package MdArrayTest
+
+type Item {
+  description String
+}
+
+tuple ItemRefAt {
+  item      Item
+  separator @
+  version   Integer
+}
+
+tuple ItemRefColon {
+  item      Item
+  separator :
+  version   Integer
+}
+
+tuple ItemRefSemicolon {
+  item      Item
+  separator ;
+  version   Integer
+}
+
+tuple ItemRefWord {
+  item      Item
+  separator via
+  version   Integer
+}
+
+type RequirementAt {
+  description String
+  refs        ItemRefAt [1 .. *]
+}
+
+type RequirementColon {
+  description String
+  refs        ItemRefColon [1 .. *]
+}
+
+type RequirementSemicolon {
+  description String
+  refs        ItemRefSemicolon [1 .. *]
+}
+
+type RequirementWord {
+  description String
+  refs        ItemRefWord [1 .. *]
+}

--- a/tests-system/markdown-array/output
+++ b/tests-system/markdown-array/output
@@ -1,0 +1,1 @@
+Processed 1 model and 6 requirement files and found no issues

--- a/tests-system/markdown-array/output
+++ b/tests-system/markdown-array/output
@@ -1,1 +1,1 @@
-Processed 1 model and 6 requirement files and found no issues
+Processed 1 model and 7 requirement files and found no issues

--- a/tests-system/markdown-array/output.brief
+++ b/tests-system/markdown-array/output.brief
@@ -1,0 +1,1 @@
+Processed 1 model and 6 requirement files and found no issues

--- a/tests-system/markdown-array/output.brief
+++ b/tests-system/markdown-array/output.brief
@@ -1,1 +1,1 @@
-Processed 1 model and 6 requirement files and found no issues
+Processed 1 model and 7 requirement files and found no issues

--- a/tests-system/markdown-array/output.json
+++ b/tests-system/markdown-array/output.json
@@ -38,6 +38,28 @@
       }
     ]
   },
+  "REQ_MIXED": {
+    "description": "Mixed: unqualified and fully qualified in one array",
+    "refs": [
+      {
+        "item": "MdArrayTest.item_a",
+        "version": 1
+      },
+      {
+        "item": "MdArrayTest.item_b",
+        "version": 2
+      }
+    ]
+  },
+  "REQ_QUALIFIED_SAME_PKG": {
+    "description": "Qualified with own package name \u2014 also valid",
+    "refs": [
+      {
+        "item": "MdArrayTest.item_a",
+        "version": 1
+      }
+    ]
+  },
   "REQ_TABLE_B_COMMA": {
     "description": "Test comma-separated tuples in table using @",
     "refs": [
@@ -64,6 +86,28 @@
       }
     ]
   },
+  "REQ_UNQUAL_MULTI": {
+    "description": "Multiple unqualified references, comma-separated",
+    "refs": [
+      {
+        "item": "MdArrayTest.item_a",
+        "version": 1
+      },
+      {
+        "item": "MdArrayTest.item_b",
+        "version": 2
+      }
+    ]
+  },
+  "REQ_UNQUAL_SINGLE": {
+    "description": "Single unqualified reference (same package, no prefix)",
+    "refs": [
+      {
+        "item": "MdArrayTest.item_a",
+        "version": 1
+      }
+    ]
+  },
   "item_a": {
     "description": "Item A"
   },
@@ -74,4 +118,4 @@
     "description": "Item C"
   }
 }
-Processed 1 model and 6 requirement files and found no issues
+Processed 1 model and 7 requirement files and found no issues

--- a/tests-system/markdown-array/output.json
+++ b/tests-system/markdown-array/output.json
@@ -1,0 +1,77 @@
+{
+  "REQ_FIELD_B_SINGLE": {
+    "description": "Test single tuple in field using ;",
+    "refs": [
+      {
+        "item": "MdArrayTest.item_a",
+        "version": 1
+      }
+    ]
+  },
+  "REQ_FIELD_D_COMMA": {
+    "description": "Test comma-separated tuples in field using identifier separator",
+    "refs": [
+      {
+        "item": "MdArrayTest.item_a",
+        "version": 1
+      },
+      {
+        "item": "MdArrayTest.item_b",
+        "version": 2
+      }
+    ]
+  },
+  "REQ_FIELD_E_NEWLINE": {
+    "description": "Test newline-separated tuples with flexible whitespace using @",
+    "refs": [
+      {
+        "item": "MdArrayTest.item_a",
+        "version": 1
+      },
+      {
+        "item": "MdArrayTest.item_b",
+        "version": 2
+      },
+      {
+        "item": "MdArrayTest.item_c",
+        "version": 3
+      }
+    ]
+  },
+  "REQ_TABLE_B_COMMA": {
+    "description": "Test comma-separated tuples in table using @",
+    "refs": [
+      {
+        "item": "MdArrayTest.item_a",
+        "version": 1
+      },
+      {
+        "item": "MdArrayTest.item_b",
+        "version": 2
+      }
+    ]
+  },
+  "REQ_TABLE_C_BR": {
+    "description": "Test <br>-separated tuples in table using :",
+    "refs": [
+      {
+        "item": "MdArrayTest.item_a",
+        "version": 1
+      },
+      {
+        "item": "MdArrayTest.item_b",
+        "version": 2
+      }
+    ]
+  },
+  "item_a": {
+    "description": "Item A"
+  },
+  "item_b": {
+    "description": "Item B"
+  },
+  "item_c": {
+    "description": "Item C"
+  }
+}
+Processed 1 model and 6 requirement files and found no issues

--- a/tests-system/markdown-array/output.smtlib
+++ b/tests-system/markdown-array/output.smtlib
@@ -1,0 +1,1 @@
+Processed 1 model and 6 requirement files and found no issues

--- a/tests-system/markdown-array/output.smtlib
+++ b/tests-system/markdown-array/output.smtlib
@@ -1,1 +1,1 @@
-Processed 1 model and 6 requirement files and found no issues
+Processed 1 model and 7 requirement files and found no issues

--- a/tests-system/markdown-array/req_field_b.trlc.md
+++ b/tests-system/markdown-array/req_field_b.trlc.md
@@ -1,0 +1,14 @@
+# MdArrayTest
+
+## Requirements
+
+### REQ_FIELD_B_SINGLE
+
+| identifier | REQ_FIELD_B_SINGLE |
+|------------|-------------------|
+| type       | RequirementSemicolon |
+| description| Test single tuple in field using ; |
+
+#### refs
+MdArrayTest.item_a ; 1
+

--- a/tests-system/markdown-array/req_field_d.trlc.md
+++ b/tests-system/markdown-array/req_field_d.trlc.md
@@ -1,0 +1,14 @@
+# MdArrayTest
+
+## Requirements
+
+### REQ_FIELD_D_COMMA
+
+| identifier | REQ_FIELD_D_COMMA |
+|------------|-------------------|
+| type       | RequirementWord   |
+| description| Test comma-separated tuples in field using identifier separator |
+
+#### refs
+MdArrayTest.item_a via 1, MdArrayTest.item_b via 2
+

--- a/tests-system/markdown-array/req_field_e.trlc.md
+++ b/tests-system/markdown-array/req_field_e.trlc.md
@@ -1,0 +1,15 @@
+# MdArrayTest
+
+## Requirements
+
+### REQ_FIELD_E_NEWLINE
+
+| identifier | REQ_FIELD_E_NEWLINE |
+|------------|-------------------|
+| type       | RequirementAt     |
+| description| Test newline-separated tuples with flexible whitespace using @ |
+
+#### refs
+MdArrayTest.item_a @ 1
+MdArrayTest.item_b @ 2
+MdArrayTest.item_c              @              3

--- a/tests-system/markdown-array/req_table_b.trlc.md
+++ b/tests-system/markdown-array/req_table_b.trlc.md
@@ -1,0 +1,14 @@
+# MdArrayTest
+
+## Requirements
+
+### REQ_TABLE_B_COMMA
+
+| identifier | REQ_TABLE_B_COMMA         |
+|------------|---------------------------|
+| type       | RequirementAt             |
+| description| Test comma-separated tuples in table using @ |
+| refs       | MdArrayTest.item_a @ 1 , MdArrayTest.item_b @ 2 |
+
+<hr>
+

--- a/tests-system/markdown-array/req_table_c.trlc.md
+++ b/tests-system/markdown-array/req_table_c.trlc.md
@@ -1,0 +1,14 @@
+# MdArrayTest
+
+## Requirements
+
+### REQ_TABLE_C_BR
+
+| identifier | REQ_TABLE_C_BR            |
+|------------|---------------------------|
+| type       | RequirementColon          |
+| description| Test <br>-separated tuples in table using : |
+| refs       | MdArrayTest.item_a : 1 <br> MdArrayTest.item_b : 2 |
+
+<hr>
+

--- a/tests-system/markdown-array/req_unqualified.trlc.md
+++ b/tests-system/markdown-array/req_unqualified.trlc.md
@@ -1,0 +1,51 @@
+# MdArrayTest
+
+## Unqualified References
+
+### REQ_UNQUAL_SINGLE
+
+| identifier  | REQ_UNQUAL_SINGLE |
+|-------------|-------------------|
+| type        | RequirementAt |
+| description | Single unqualified reference (same package, no prefix) |
+
+#### refs
+item_a @ 1
+
+<hr>
+
+### REQ_UNQUAL_MULTI
+
+| identifier  | REQ_UNQUAL_MULTI |
+|-------------|-----------------|
+| type        | RequirementAt |
+| description | Multiple unqualified references, comma-separated |
+
+#### refs
+item_a @ 1, item_b @ 2
+
+<hr>
+
+### REQ_MIXED
+
+| identifier  | REQ_MIXED |
+|-------------|-----------|
+| type        | RequirementAt |
+| description | Mixed: unqualified and fully qualified in one array |
+
+#### refs
+item_a @ 1, MdArrayTest.item_b @ 2
+
+<hr>
+
+### REQ_QUALIFIED_SAME_PKG
+
+| identifier  | REQ_QUALIFIED_SAME_PKG |
+|-------------|------------------------|
+| type        | RequirementAt |
+| description | Qualified with own package name — also valid |
+
+#### refs
+MdArrayTest.item_a @ 1
+
+<hr>

--- a/tests-unit/test_lexer_md.py
+++ b/tests-unit/test_lexer_md.py
@@ -1,0 +1,287 @@
+import unittest
+from fractions import Fraction
+
+from trlc import ast as trlc_ast
+from trlc.errors import Location, Message_Handler, TRLC_Error, Kind
+from trlc.lexer_md import MD_Lexer
+
+
+class ListHandler(Message_Handler):
+    def __init__(self):
+        super().__init__()
+        self.messages = []
+
+    def emit(self, location, kind, message, fatal=True, extrainfo=None):
+        assert isinstance(location, Location)
+        assert isinstance(kind, Kind)
+        assert isinstance(message, str)
+        assert isinstance(fatal, bool)
+        assert isinstance(extrainfo, str) or extrainfo is None
+
+        self.messages.append((location, kind, message))
+
+        if fatal:
+            raise TRLC_Error(location, kind, message)
+
+    def pop_message(self):
+        assert self.messages
+        message, self.messages = self.messages[0], self.messages[1:]
+        return message
+
+
+def token_pairs(lexer):
+    pairs = []
+    while True:
+        token = lexer.token()
+        if token is None:
+            break
+        pairs.append((token.kind, token.value))
+    return pairs
+
+
+def make_record_type(record_name="ReqType"):
+    builtin_stab = trlc_ast.Symbol_Table()
+    package = trlc_ast.Package("DemoPkg", Location("test"), builtin_stab, False)
+    record_type = trlc_ast.Record_Type(
+        record_name,
+        None,
+        Location("test"),
+        package,
+        None,
+        False,
+    )
+
+    record_type.components.table["notes"] = trlc_ast.Composite_Component(
+        "notes",
+        None,
+        Location("test"),
+        record_type,
+        trlc_ast.Builtin_String(),
+        False,
+    )
+
+    tuple_type = trlc_ast.Tuple_Type(
+        "TupleType",
+        None,
+        Location("test"),
+        package,
+    )
+    array_type = trlc_ast.Array_Type(
+        Location("test"),
+        tuple_type,
+        Location("test"),
+        0,
+        Location("test"),
+        None,
+    )
+    record_type.components.table["refs"] = trlc_ast.Composite_Component(
+        "refs",
+        None,
+        Location("test"),
+        record_type,
+        array_type,
+        False,
+    )
+
+    package.symbols.table[trlc_ast.Symbol_Table.simplified_name(record_name)] = record_type
+
+    stab = trlc_ast.Symbol_Table()
+    stab.table[trlc_ast.Symbol_Table.simplified_name(package.name)] = package
+    return stab, record_type
+
+
+class TestLexerMd(unittest.TestCase):
+    def setUp(self):
+        self.mh = ListHandler()
+
+    def tearDown(self):
+        self.assertEqual(
+            len(self.mh.messages),
+            0,
+            f"unexpected messages: {', '.join(msg[2] for msg in self.mh.messages)}",
+        )
+
+    def test_heading_and_rule_helpers(self):
+        self.assertEqual(MD_Lexer._parse_heading("### Record Name"), (3, "Record Name"))
+        self.assertEqual(MD_Lexer._parse_heading("## Section"), (2, "Section"))
+        self.assertEqual(MD_Lexer._parse_heading("###"), (0, None))
+        self.assertEqual(MD_Lexer._parse_heading("#NotAHeading"), (0, None))
+
+        self.assertTrue(MD_Lexer._is_hr("<hr>"))
+        self.assertTrue(MD_Lexer._is_hr("<hr><br><hr/>"))
+        self.assertTrue(MD_Lexer._is_hr("<BR/> <HR>"))
+        self.assertFalse(MD_Lexer._is_hr("<hrx>"))
+
+        self.assertEqual(MD_Lexer._heading_to_identifier("  Hello, world!  "), "Hello_world")
+        self.assertEqual(MD_Lexer._heading_to_identifier("A---B__C"), "A_B_C")
+
+    def test_table_helpers(self):
+        self.assertTrue(MD_Lexer._is_separator_row("|---|---|"))
+        self.assertTrue(MD_Lexer._is_separator_row("|:---|---:|"))
+        self.assertFalse(MD_Lexer._is_separator_row("| value |"))
+
+        self.assertEqual(MD_Lexer._parse_table_row("| key | value |"), ("key", "value"))
+        self.assertEqual(MD_Lexer._parse_table_row("| key | value | extra |"), ("key", "value"))
+        self.assertIsNone(MD_Lexer._parse_table_row("not a row"))
+
+    def test_scalar_value_inference(self):
+        lexer = MD_Lexer(self.mh, "test", "")
+        lexer._md_tokens = []
+
+        lexer._emit_value("true", Location("test"))
+        lexer._emit_value("42", Location("test"))
+        lexer._emit_value("3.25", Location("test"))
+        lexer._emit_value("0x10", Location("test"))
+        lexer._emit_value("0b11", Location("test"))
+        lexer._emit_value("Pkg.Enum.Value", Location("test"))
+        lexer._emit_value("(1, false, 2)", Location("test"))
+        lexer._emit_value("0x500:12345@6.1", Location("test"))
+        lexer._emit_value("plain text", Location("test"))
+
+        self.assertEqual(
+            token_pairs(lexer),
+            [
+                ("KEYWORD", "true"),
+                ("INTEGER", 42),
+                ("DECIMAL", Fraction("3.25")),
+                ("INTEGER", 16),
+                ("INTEGER", 3),
+                ("IDENTIFIER", "Pkg"),
+                ("DOT", None),
+                ("IDENTIFIER", "Enum"),
+                ("DOT", None),
+                ("IDENTIFIER", "Value"),
+                ("BRA", None),
+                ("INTEGER", 1),
+                ("COMMA", None),
+                ("KEYWORD", "false"),
+                ("COMMA", None),
+                ("INTEGER", 2),
+                ("KET", None),
+                ("INTEGER", 0x500),
+                ("COLON", None),
+                ("INTEGER", 12345),
+                ("AT", None),
+                ("DECIMAL", Fraction("6.1")),
+                ("STRING", "plain text"),
+            ],
+        )
+
+    def test_array_value_and_bracket_error(self):
+        lexer = MD_Lexer(self.mh, "test", "")
+        lexer._md_tokens = []
+
+        lexer._emit_value("DemoPkg.item_a @ 1 <br> DemoPkg.item_b via 2", Location("test"))
+        self.assertEqual(
+            token_pairs(lexer),
+            [
+                ("S_BRA", None),
+                ("IDENTIFIER", "DemoPkg"),
+                ("DOT", None),
+                ("IDENTIFIER", "item_a"),
+                ("AT", None),
+                ("INTEGER", 1),
+                ("COMMA", None),
+                ("IDENTIFIER", "DemoPkg"),
+                ("DOT", None),
+                ("IDENTIFIER", "item_b"),
+                ("IDENTIFIER", "via"),
+                ("INTEGER", 2),
+                ("S_KET", None),
+            ],
+        )
+
+        lexer = MD_Lexer(self.mh, "test", "")
+        lexer._md_tokens = []
+        lexer._emit_value("[DemoPkg.item_a @ 1, DemoPkg.item_b @ 2]", Location("test"))
+        self.assertEqual(token_pairs(lexer), [])
+        self.assertEqual(len(self.mh.messages), 1)
+        self.assertEqual(self.mh.pop_message()[2], "bracket notation for tuple-reference arrays is not supported")
+
+    def test_type_aware_field_emission(self):
+        _stab, record_type = make_record_type()
+        lexer = MD_Lexer(self.mh, "test", "")
+        lexer._md_tokens = []
+
+        lexer._emit_field_value("Hello there", Location("test"), record_type, "notes")
+        lexer._emit_field_value("DemoPkg.item_a @ 1, DemoPkg.item_b @ 2", Location("test"), record_type, "refs")
+
+        self.assertEqual(
+            token_pairs(lexer),
+            [
+                ("STRING", "Hello there"),
+                ("S_BRA", None),
+                ("IDENTIFIER", "DemoPkg"),
+                ("DOT", None),
+                ("IDENTIFIER", "item_a"),
+                ("AT", None),
+                ("INTEGER", 1),
+                ("COMMA", None),
+                ("IDENTIFIER", "DemoPkg"),
+                ("DOT", None),
+                ("IDENTIFIER", "item_b"),
+                ("AT", None),
+                ("INTEGER", 2),
+                ("S_KET", None),
+            ],
+        )
+
+    def test_process_preamble_section_and_record(self):
+        content = "\n".join(
+            [
+                "# DemoPkg",
+                "import OtherPkg",
+                "",
+                "## Overview",
+                "",
+                "### Req_1",
+                "| Property | Value |",
+                "|----------|-------|",
+                "| type | Requirement |",
+                "| priority | 7 |",
+                "",
+                "#### notes",
+                "Hello, world!",
+                "",
+                "<hr>",
+            ]
+        )
+
+        lexer = MD_Lexer(self.mh, "test.trlc.md", content)
+        self.assertEqual(
+            token_pairs(lexer),
+            [
+                ("KEYWORD", "#"),
+                ("IDENTIFIER", "DemoPkg"),
+                ("KEYWORD", "import"),
+                ("IDENTIFIER", "OtherPkg"),
+            ],
+        )
+
+        lexer.prepare_phase2(trlc_ast.Symbol_Table())
+
+        self.assertEqual(
+            token_pairs(lexer),
+            [
+                ("KEYWORD", "##"),
+                ("STRING", "Overview"),
+                ("C_BRA", None),
+                ("IDENTIFIER", "OtherPkg"),
+                ("DOT", None),
+                ("IDENTIFIER", "Requirement"),
+                ("IDENTIFIER", "Req_1"),
+                ("C_BRA", None),
+                ("IDENTIFIER", "priority"),
+                ("ASSIGN", None),
+                ("INTEGER", 7),
+                ("IDENTIFIER", "notes"),
+                ("ASSIGN", None),
+                ("STRING", "Hello, world!"),
+                ("C_KET", None),
+                ("C_KET", None),
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests-unit/test_lexer_md.py
+++ b/tests-unit/test_lexer_md.py
@@ -12,11 +12,16 @@ class ListHandler(Message_Handler):
         self.messages = []
 
     def emit(self, location, kind, message, fatal=True, extrainfo=None):
-        assert isinstance(location, Location)
-        assert isinstance(kind, Kind)
-        assert isinstance(message, str)
-        assert isinstance(fatal, bool)
-        assert isinstance(extrainfo, str) or extrainfo is None
+        if not isinstance(location, Location):
+            raise TypeError(f"expected Location, got {type(location).__name__}")
+        if not isinstance(kind, Kind):
+            raise TypeError(f"expected Kind, got {type(kind).__name__}")
+        if not isinstance(message, str):
+            raise TypeError(f"expected str message, got {type(message).__name__}")
+        if not isinstance(fatal, bool):
+            raise TypeError(f"expected bool fatal, got {type(fatal).__name__}")
+        if extrainfo is not None and not isinstance(extrainfo, str):
+            raise TypeError(f"expected str or None extrainfo, got {type(extrainfo).__name__}")
 
         self.messages.append((location, kind, message))
 
@@ -24,7 +29,8 @@ class ListHandler(Message_Handler):
             raise TRLC_Error(location, kind, message)
 
     def pop_message(self):
-        assert self.messages
+        if not self.messages:
+            raise AssertionError("pop_message called with no messages")
         message, self.messages = self.messages[0], self.messages[1:]
         return message
 
@@ -126,7 +132,6 @@ class TestLexerMd(unittest.TestCase):
 
     def test_scalar_value_inference(self):
         lexer = MD_Lexer(self.mh, "test", "")
-        lexer._md_tokens = []
 
         lexer._emit_value("true", Location("test"))
         lexer._emit_value("42", Location("test"))
@@ -169,8 +174,6 @@ class TestLexerMd(unittest.TestCase):
 
     def test_array_value_and_bracket_error(self):
         lexer = MD_Lexer(self.mh, "test", "")
-        lexer._md_tokens = []
-
         lexer._emit_value("DemoPkg.item_a @ 1 <br> DemoPkg.item_b via 2", Location("test"))
         self.assertEqual(
             token_pairs(lexer),
@@ -192,7 +195,6 @@ class TestLexerMd(unittest.TestCase):
         )
 
         lexer = MD_Lexer(self.mh, "test", "")
-        lexer._md_tokens = []
         lexer._emit_value("[DemoPkg.item_a @ 1, DemoPkg.item_b @ 2]", Location("test"))
         self.assertEqual(token_pairs(lexer), [])
         self.assertEqual(len(self.mh.messages), 1)
@@ -200,12 +202,12 @@ class TestLexerMd(unittest.TestCase):
 
     def test_type_aware_field_emission(self):
         _stab, record_type = make_record_type()
-        lexer = MD_Lexer(self.mh, "test", "")
-        lexer._md_tokens = []
 
+        # String field: value stored as-is, no array heuristics applied
+        # Tuple-array field: fully qualified references
+        lexer = MD_Lexer(self.mh, "test", "")
         lexer._emit_field_value("Hello there", Location("test"), record_type, "notes")
         lexer._emit_field_value("DemoPkg.item_a @ 1, DemoPkg.item_b @ 2", Location("test"), record_type, "refs")
-
         self.assertEqual(
             token_pairs(lexer),
             [
@@ -225,6 +227,49 @@ class TestLexerMd(unittest.TestCase):
                 ("S_KET", None),
             ],
         )
+
+        # Tuple-array field: unqualified (same-package) references
+        lexer = MD_Lexer(self.mh, "test", "")
+        lexer._emit_field_value("item_a @ 1, item_b @ 2", Location("test"), record_type, "refs")
+        self.assertEqual(
+            token_pairs(lexer),
+            [
+                ("S_BRA", None),
+                ("IDENTIFIER", "item_a"),
+                ("AT", None),
+                ("INTEGER", 1),
+                ("COMMA", None),
+                ("IDENTIFIER", "item_b"),
+                ("AT", None),
+                ("INTEGER", 2),
+                ("S_KET", None),
+            ],
+        )
+
+        # Tuple-array field: mixed array (qualified + unqualified)
+        lexer = MD_Lexer(self.mh, "test", "")
+        lexer._emit_field_value("item_a @ 1, OtherPkg.item_b @ 2", Location("test"), record_type, "refs")
+        self.assertEqual(
+            token_pairs(lexer),
+            [
+                ("S_BRA", None),
+                ("IDENTIFIER", "item_a"),
+                ("AT", None),
+                ("INTEGER", 1),
+                ("COMMA", None),
+                ("IDENTIFIER", "OtherPkg"),
+                ("DOT", None),
+                ("IDENTIFIER", "item_b"),
+                ("AT", None),
+                ("INTEGER", 2),
+                ("S_KET", None),
+            ],
+        )
+
+        # Heuristic fallback (_emit_value): unqualified must NOT be treated as array
+        lexer = MD_Lexer(self.mh, "test", "")
+        lexer._emit_value("item_a @ 1", Location("test"))
+        self.assertEqual(token_pairs(lexer), [("STRING", "item_a @ 1")])
 
     def test_process_preamble_section_and_record(self):
         content = "\n".join(

--- a/trlc/TRLC_MARKDOWN_REQUIREMENTS_WRITING_GUIDE.md
+++ b/trlc/TRLC_MARKDOWN_REQUIREMENTS_WRITING_GUIDE.md
@@ -59,6 +59,37 @@ You can continue writing text on multiple lines.
 - Keep the first table row as a header row (`Property | Value`).
 - Use `<hr>` and `<hr><br><hr>` only for readability.
 
+## Tuple-Reference Arrays
+
+Fields declared as an array of tuples can be written directly in Markdown.
+
+**Supported layouts:**
+
+```md
+// Table cell — comma-separated
+| refs | Pkg.item_a @ 1 , Pkg.item_b @ 2 |
+
+// Table cell — <br>-separated
+| refs | Pkg.item_a @ 1 <br> Pkg.item_b @ 2 |
+
+// Field block — one per line (flexible whitespace around separator)
+#### refs
+Pkg.item_a @ 1
+Pkg.item_b @ 2
+Pkg.item_c         @         3
+
+// Field block — comma-separated
+#### refs
+Pkg.item_a @ 1, Pkg.item_b @ 2
+```
+
+All LRM separator kinds are supported: `@`, `:`, `;`, and plain identifier (e.g. `covers`).
+
+**Rules:**
+
+- References must be package-qualified: `Pkg.item_name sep version`.
+- Do **not** use bracket notation `[...]` — it conflicts with Markdown URL syntax and produces an error.
+
 ## Troubleshooting
 
 ### Error: unexpected character in heading
@@ -75,3 +106,14 @@ You can continue writing text on multiple lines.
 
 - Cause: value does not match scalar pattern, or body is multi-line.
 - Fix: keep typed scalar values on a single line under `#### FieldName`.
+
+### Error: bracket notation for tuple-reference arrays is not supported
+
+- Cause: array value written with `[...]` (e.g. `[Pkg.item @ 1]`).
+- Fix: remove the brackets and use comma or newline separation instead.
+
+### Array field parsed as plain string
+
+- Cause: reference is not package-qualified (e.g. `item_a @ 1` has no dot).
+- Fix: write the full `Package.item_name sep version` form.
+

--- a/trlc/TRLC_MARKDOWN_REQUIREMENTS_WRITING_GUIDE.md
+++ b/trlc/TRLC_MARKDOWN_REQUIREMENTS_WRITING_GUIDE.md
@@ -66,7 +66,7 @@ Fields declared as an array of tuples can be written directly in Markdown.
 **Supported layouts:**
 
 ```md
-// Table cell — comma-separated
+// Table cell — comma-separated, fully qualified
 | refs | Pkg.item_a @ 1 , Pkg.item_b @ 2 |
 
 // Table cell — <br>-separated
@@ -81,13 +81,25 @@ Pkg.item_c         @         3
 // Field block — comma-separated
 #### refs
 Pkg.item_a @ 1, Pkg.item_b @ 2
+
+// Unqualified — same-package item, package prefix may be omitted
+#### refs
+item_a @ 1
+item_b @ 2
+
+// Mixed — qualified (cross-package) and unqualified (same-package) in one array
+#### refs
+item_a @ 1, OtherPkg.item_b @ 2
 ```
 
 All LRM separator kinds are supported: `@`, `:`, `;`, and plain identifier (e.g. `covers`).
 
 **Rules:**
 
-- References must be package-qualified: `Pkg.item_name sep version`.
+- References may be **fully qualified** (`Pkg.item_name sep version`) or **unqualified** (`item_name sep version`).
+  - Use the unqualified form when the item is defined in the **same package** as the current file (`# PackageName` heading).
+  - Use the qualified form when referencing an item from a **different package**.
+  - Both forms can be mixed in the same array.
 - Do **not** use bracket notation `[...]` — it conflicts with Markdown URL syntax and produces an error.
 
 ## Troubleshooting
@@ -114,6 +126,6 @@ All LRM separator kinds are supported: `@`, `:`, `;`, and plain identifier (e.g.
 
 ### Array field parsed as plain string
 
-- Cause: reference is not package-qualified (e.g. `item_a @ 1` has no dot).
-- Fix: write the full `Package.item_name sep version` form.
+- Cause: the field type is not a tuple-reference array in the RSL model, so the value is stored as a string.
+- Fix: check that the RSL field is declared as an array of a tuple type (e.g. `refs ItemRef [1 .. *]`).
 

--- a/trlc/lexer_md.py
+++ b/trlc/lexer_md.py
@@ -73,6 +73,7 @@ Values in the property table are interpreted as follows (in order):
 import re
 from fractions import Fraction
 
+from trlc import ast as trlc_ast
 from trlc.lexer import Token, TRLC_Lexer
 from trlc.errors import Location, Message_Handler
 from trlc.location_md import MD_Location
@@ -276,11 +277,15 @@ class MD_Lexer(TRLC_Lexer):
         # Initialise TRLC_Lexer to satisfy Parser lexer type checks.
         super().__init__(mh, file_name, "")
 
-        self._md_tokens = []  # pre-computed token list
-        self._tok_index = 0
+        self._raw_content = content       # kept for Phase 2 reprocessing
+        self._stab        = None          # set by prepare_phase2() after RSL
+        self._md_tokens   = []
+        self._tok_index   = 0
 
-        self._process(content)
-        # Keep parity with TRLC lexer API expected by linting/reporting.
+        # Phase 1: emit only preamble tokens (# PackageName, import lines).
+        # Phase 2 is triggered by Source_Manager after parse_rsl_files().
+        self._process_preamble(content)
+        self._preamble_end_index = len(self._md_tokens)
         self.tokens = self._md_tokens
 
     # ------------------------------------------------------------------ #
@@ -297,6 +302,107 @@ class MD_Lexer(TRLC_Lexer):
             # print("MD_Lexer: end of token stream reached", tok)
             return tok
         return None
+
+    def _process_preamble(self, content):
+        """Phase 1: emit only preamble tokens (# PackageName, import lines).
+
+        Body processing is deferred to prepare_phase2() so that RSL types
+        are available when field values are tokenised.
+        """
+        lines = content.splitlines()
+        preamble = []
+        for line in lines:
+            stripped = line.strip()
+            if not stripped:
+                preamble.append(line)
+                continue
+            if stripped.startswith("# ") or stripped == "#":
+                preamble.append(line)
+                continue
+            if stripped.startswith("import "):
+                preamble.append(line)
+                continue
+            break   # first non-preamble line stops Phase 1
+        self._process("\n".join(preamble))
+
+    def prepare_phase2(self, stab):
+        """Phase 2: reprocess the full content with RSL types available.
+
+        Called by Source_Manager after parse_rsl_files() so the stab is
+        fully populated.  After this returns, the caller must re-prime the
+        parser token cursor (set ct=None and call advance() once).
+        """
+        self._stab      = stab
+        self._md_tokens = []
+        self._tok_index = 0
+        self._process(self._raw_content)  # full reprocessing with types
+        self._tok_index = self._preamble_end_index  # skip preamble
+        self.tokens     = self._md_tokens
+
+    def _resolve_record_type(self, type_name, package_name=None):
+        """Look up the Record_Type AST node in the stab for *type_name*."""
+        if self._stab is None or not type_name:
+            return None
+        if "." in type_name:
+            pkg_name, local_name = type_name.split(".", 1)
+        elif package_name:
+            pkg_name, local_name = package_name, type_name
+        else:
+            return None
+        pkg_simple  = trlc_ast.Symbol_Table.simplified_name(pkg_name)
+        pkg         = self._stab.table.get(pkg_simple)
+        if not isinstance(pkg, trlc_ast.Package):
+            return None
+        type_simple  = trlc_ast.Symbol_Table.simplified_name(local_name)
+        record_type  = pkg.symbols.table.get(type_simple)
+        if isinstance(record_type, trlc_ast.Record_Type):
+            return record_type
+        return None
+
+    @staticmethod
+    def _get_field_type(record_type_ast, field_name):
+        """Return the declared type of *field_name*, or None."""
+        if record_type_ast is None:
+            return None
+        simple    = trlc_ast.Symbol_Table.simplified_name(field_name)
+        component = record_type_ast.components.table.get(simple)
+        return component.n_typ if component is not None else None
+
+    @staticmethod
+    def _is_tuple_array_field(record_type_ast, field_name):
+        """Return True when *field_name* is declared as an array of tuples."""
+        typ = MD_Lexer._get_field_type(record_type_ast, field_name)
+        return (isinstance(typ, trlc_ast.Array_Type) and
+                isinstance(typ.element_type, trlc_ast.Tuple_Type))
+
+    @staticmethod
+    def _is_string_field(record_type_ast, field_name):
+        """Return True when *field_name* is declared as a plain String."""
+        typ = MD_Lexer._get_field_type(record_type_ast, field_name)
+        return typ is not None and isinstance(typ, trlc_ast.Builtin_String)
+
+    def _emit_field_value(self, raw_value, location,
+                          record_type_ast=None, field_name=None):
+        """Type-aware field value emission (used in Phase 2).
+
+        Dispatch rules when RSL type info is available:
+        - String field       → emit STRING directly (never try array/tuple)
+        - Tuple-array field  → type-confirmed array tokenisation
+        - Any other field    → existing _emit_value() heuristics
+
+        Falls back to _emit_value() heuristics when type is unknown.
+        """
+        if record_type_ast is not None:
+            if self._is_string_field(record_type_ast, field_name):
+                self._emit(location, "STRING", raw_value.strip())
+                return
+            if self._is_tuple_array_field(record_type_ast, field_name):
+                if self._check_bracket_array(raw_value, location):
+                    return
+                if not self._maybe_emit_array(raw_value, location):
+                    self._emit(location, "STRING", raw_value.strip())
+                return
+        self._emit_value(raw_value, location)
 
     # ------------------------------------------------------------------ #
     # Internal helpers                                                     #
@@ -460,6 +566,16 @@ class MD_Lexer(TRLC_Lexer):
         r'$'
     )
 
+    # Chunk patterns for the multi-separator tuple scanner.
+    # A numeric chunk: hex, binary, or decimal (integer or float).
+    _TUPLE_NUM_RE = re.compile(
+        r'0[xX][0-9a-fA-F][0-9a-fA-F_]*'
+        r'|0[bB][01][01_]*'
+        r'|\d+(?:\.\d+)?'
+    )
+    # A separator chunk: @, :, ; or a word identifier.
+    _TUPLE_SEP_RE = re.compile(r'[@:;]|[a-zA-Z_]\w*')
+
     @staticmethod
     def _looks_like_array(raw_value):
         """Check if value looks like tuple-reference array without emitting.
@@ -475,6 +591,157 @@ class MD_Lexer(TRLC_Lexer):
             MD_Lexer._TUPLE_REF_RE.match(part)
             for part in parts
         )
+
+    @staticmethod
+    def _looks_like_simple_tuple(raw_value):
+        """Check if value looks like a separator-form tuple: num [sep num]+.
+
+        Handles multi-separator patterns like 0x500:12345@6.1 or 1@2:3;4.
+        Returns True only when there is at least one separator (bare numbers
+        are handled by the scalar integer/decimal paths in _emit_value).
+        """
+        value = raw_value.strip()
+        pos = 0
+        n = len(value)
+
+        def skip_ws():
+            nonlocal pos
+            while pos < n and value[pos] in (' ', '\t'):
+                pos += 1
+
+        skip_ws()
+        m = MD_Lexer._TUPLE_NUM_RE.match(value, pos)
+        if not m:
+            return False
+        pos = m.end()
+        has_sep = False
+        while pos < n:
+            skip_ws()
+            if pos >= n:
+                break
+            m = MD_Lexer._TUPLE_SEP_RE.match(value, pos)
+            if not m:
+                return False
+            pos = m.end()
+            has_sep = True
+            skip_ws()
+            m = MD_Lexer._TUPLE_NUM_RE.match(value, pos)
+            if not m:
+                return False
+            pos = m.end()
+        return pos == n and has_sep
+
+    def _maybe_emit_simple_tuple(self, raw_value, location):
+        """Try to emit tokens for a separator-form tuple: num [sep num]+.
+
+        Handles multi-separator patterns such as::
+
+          12345@42       →  INTEGER AT INTEGER
+          0x500:12345@6.1 → INTEGER COLON INTEGER AT DECIMAL
+          1@2:3;4        →  INTEGER AT INTEGER COLON INTEGER SEMICOLON INTEGER
+
+        Returns True if at least one separator was found and all tokens were
+        emitted, False to let _emit_value fall through to STRING.
+        """
+        value = raw_value.strip()
+        pos = 0
+        n = len(value)
+        chunks = []  # list of ('num', text) | ('sep', text)
+
+        def skip_ws():
+            nonlocal pos
+            while pos < n and value[pos] in (' ', '\t'):
+                pos += 1
+
+        skip_ws()
+        m = MD_Lexer._TUPLE_NUM_RE.match(value, pos)
+        if not m:
+            return False
+        chunks.append(('num', m.group()))
+        pos = m.end()
+
+        while pos < n:
+            skip_ws()
+            if pos >= n:
+                break
+            m = MD_Lexer._TUPLE_SEP_RE.match(value, pos)
+            if not m:
+                return False
+            chunks.append(('sep', m.group()))
+            pos = m.end()
+            skip_ws()
+            m = MD_Lexer._TUPLE_NUM_RE.match(value, pos)
+            if not m:
+                return False
+            chunks.append(('num', m.group()))
+            pos = m.end()
+
+        if pos != n:
+            return False
+
+        # Must have at least one separator so bare numbers fall through to
+        # the integer/decimal scalar checks in _emit_value.
+        has_sep = any(kind == 'sep' for kind, _ in chunks)
+        if not has_sep:
+            return False
+
+        for kind, text in chunks:
+            if kind == 'num':
+                if '.' in text:
+                    self._emit(location, "DECIMAL", Fraction(text.replace("_", "")))
+                else:
+                    self._emit(location, "INTEGER", self._parse_number(text))
+            else:  # sep
+                sep_kind = MD_Lexer._SEPARATOR_PUNCTUATION.get(text, "IDENTIFIER")
+                sep_val = text if sep_kind == "IDENTIFIER" else None
+                self._emit(location, sep_kind, sep_val)
+
+        return True
+
+    def _maybe_emit_parentheses_tuple(self, raw_value, location):
+        """Try to emit tokens for a tuple in parentheses form: (val1, val2, val3).
+
+        Returns True if a tuple was emitted, False for fallback to STRING.
+        """
+        value = raw_value.strip()
+        if not (value.startswith("(") and value.endswith(")")):
+            return False
+
+        inner = value[1:-1].strip()
+        if not inner:
+            # Empty tuple () - treat as error or skip
+            return False
+
+        # Split by commas and parse each value
+        self._emit(location, "BRA")
+
+        parts = [p.strip() for p in inner.split(",") if p.strip()]
+        for idx, part in enumerate(parts):
+            if idx > 0:
+                self._emit(location, "COMMA")
+
+            # Try to infer the value type for each part
+            self._emit_value(part, location)
+
+        self._emit(location, "KET")
+        return True
+
+    @staticmethod
+    def _parse_number(text):
+        """Parse a number string (decimal, hex, or binary).
+
+        Returns the integer value or None if parsing fails.
+        """
+        try:
+            text_clean = text.replace("_", "")
+            if text_clean.startswith("0x") or text_clean.startswith("0X"):
+                return int(text_clean, 16)
+            elif text_clean.startswith("0b") or text_clean.startswith("0B"):
+                return int(text_clean, 2)
+            else:
+                return int(text_clean, 10)
+        except ValueError:
+            return None
 
     def _check_bracket_array(self, raw_value, location):
         """Detect bracket notation for tuple arrays and emit a clear error.
@@ -565,6 +832,10 @@ class MD_Lexer(TRLC_Lexer):
         if self._check_bracket_array(raw_value, location):
             return
 
+        # Parentheses tuple form: (val1, val2, val3)
+        if self._maybe_emit_parentheses_tuple(raw_value, location):
+            return
+
         # Array of tuple references (before other checks)
         if self._maybe_emit_array(raw_value, location):
             return
@@ -603,6 +874,10 @@ class MD_Lexer(TRLC_Lexer):
             if end == len(value):
                 self._emit(location, "INTEGER", int(value[2:].replace("_", ""), 2))
                 return
+
+        # Simple tuple syntax (e.g., 12345@42, 0x500:6.1)
+        if self._maybe_emit_simple_tuple(raw_value, location):
+            return
 
         # Dot-qualified identifier or plain identifier
         if value and MD_Lexer._is_ident_start(value[0]):
@@ -648,6 +923,10 @@ class MD_Lexer(TRLC_Lexer):
         if text in ("true", "false", "null"):
             return True
 
+        # Parentheses tuple form (simple detection)
+        if text.startswith("(") and text.endswith(")"):
+            return True
+
         # Integer / decimal
         end = MD_Lexer._scan_integer(text)
         if end == len(text) and end > 0:
@@ -660,6 +939,10 @@ class MD_Lexer(TRLC_Lexer):
                 dec_end = MD_Lexer._scan_integer(text, dot_pos + 1)
                 if dec_end == len(text) and dec_end > dot_pos + 1:
                     return True
+
+        # Simple tuple syntax (e.g., 12345@42)
+        if MD_Lexer._looks_like_simple_tuple(text):
+            return True
 
         # Dot-qualified identifier (used e.g. for enum values)
         if "." in text and MD_Lexer._is_ident_start(text[0]):
@@ -691,6 +974,10 @@ class MD_Lexer(TRLC_Lexer):
         # ── Section tracking ─────────────────────────────────────────── #
         in_section = False
         imported_packages = []
+
+        # ── Type tracking for Phase 2 ─────────────────────────────────── #
+        current_package_name    = None   # from # PackageName heading
+        current_record_type_ast = None   # resolved after type row found
 
         # ── Record tracking ───────────────────────────────────────────── #
         # When a ### heading is seen we buffer the name and then wait for
@@ -742,14 +1029,9 @@ class MD_Lexer(TRLC_Lexer):
                 # Record already open – emit directly inside the block.
                 self._emit(str_field_loc, "IDENTIFIER", str_field_name)
                 self._emit(str_field_loc, "ASSIGN")
-                if emit_as_scalar:
-                    self._emit_value(text, value_loc)
-                elif self._check_bracket_array(text, value_loc):
-                    # Bracket notation detected – error already emitted; skip
-                    pass
-                elif not self._maybe_emit_array(text, value_loc):
-                    # Array detection failed – emit as string
-                    self._emit(value_loc, "STRING", text)
+                self._emit_field_value(
+                    text, value_loc,
+                    current_record_type_ast, str_field_name)
             else:
                 # "type" row not yet seen – buffer until the record opens.
                 # Check if it looks like an array (but don't emit yet)
@@ -864,6 +1146,7 @@ class MD_Lexer(TRLC_Lexer):
                     self.mh.lex_error(loc, "invalid package name in markdown heading")
                 self._emit(loc, "KEYWORD", "#")
                 self._emit(loc, "IDENTIFIER", package_name)
+                current_package_name = package_name
                 continue
 
             # ── H2: section ──────────────────────────────────────────────
@@ -938,38 +1221,36 @@ class MD_Lexer(TRLC_Lexer):
                     self._emit(pending_name_loc, "C_BRA")
                     in_record = True
                     record_type_found = True
+                    current_record_type_ast = self._resolve_record_type(
+                        type_name, package_name=current_package_name)
 
                     # Flush any properties that arrived before "type"
                     for bkey, bval, bline in pending_props:
                         bloc = self._loc(bline)
                         self._emit(bloc, "IDENTIFIER", bkey)
                         self._emit(bloc, "ASSIGN")
-                        self._emit_value(bval, bloc)
+                        self._emit_field_value(
+                            bval, bloc,
+                            current_record_type_ast, bkey)
                     pending_props = []
 
                     # Flush any #### string fields that arrived
                     # before "type"
-                    for (fname, floc, ftext, fis_scalar,
-                         fis_array, fis_bracket) in pending_string_fields:
+                    for (fname, floc, ftext, _fis_scalar,
+                         _fis_array, _fis_bracket) in pending_string_fields:
                         self._emit(floc, "IDENTIFIER", fname)
                         self._emit(floc, "ASSIGN")
-                        if fis_scalar:
-                            self._emit_value(ftext, floc)
-                        elif fis_bracket:
-                            # Bracket notation – emit error, skip value
-                            self._check_bracket_array(ftext, floc)
-                        elif fis_array:
-                            # Emit array tokens
-                            self._maybe_emit_array(ftext, floc)
-                        else:
-                            # Not scalar, not array → emit as STRING
-                            self._emit(floc, "STRING", ftext)
+                        self._emit_field_value(
+                            ftext, floc,
+                            current_record_type_ast, fname)
                     pending_string_fields.clear()
 
                 elif record_type_found:
                     self._emit(loc, "IDENTIFIER", key)
                     self._emit(loc, "ASSIGN")
-                    self._emit_value(value, loc)
+                    self._emit_field_value(
+                        value, loc,
+                        current_record_type_ast, key)
 
                 else:
                     # Buffer: "type" has not appeared yet

--- a/trlc/lexer_md.py
+++ b/trlc/lexer_md.py
@@ -277,9 +277,9 @@ class MD_Lexer(TRLC_Lexer):
         # Initialise TRLC_Lexer to satisfy Parser lexer type checks.
         super().__init__(mh, file_name, "")
 
-        self._raw_content = content       # kept for Phase 2 reprocessing
-        self._stab        = None          # set by prepare_phase2() after RSL
-        self._md_tokens   = []
+        self._raw_content = content  # kept for Phase 2 reprocessing
+        self._stab = None  # set by prepare_phase2() after RSL
+        self._md_tokens = []
         self._tok_index   = 0
 
         # Phase 1: emit only preamble tokens (# PackageName, import lines).
@@ -332,12 +332,12 @@ class MD_Lexer(TRLC_Lexer):
         fully populated.  After this returns, the caller must re-prime the
         parser token cursor (set ct=None and call advance() once).
         """
-        self._stab      = stab
+        self._stab = stab
         self._md_tokens = []
         self._tok_index = 0
         self._process(self._raw_content)  # full reprocessing with types
         self._tok_index = self._preamble_end_index  # skip preamble
-        self.tokens     = self._md_tokens
+        self.tokens = self._md_tokens
 
     def _resolve_record_type(self, type_name, package_name=None):
         """Look up the Record_Type AST node in the stab for *type_name*."""
@@ -349,12 +349,12 @@ class MD_Lexer(TRLC_Lexer):
             pkg_name, local_name = package_name, type_name
         else:
             return None
-        pkg_simple  = trlc_ast.Symbol_Table.simplified_name(pkg_name)
-        pkg         = self._stab.table.get(pkg_simple)
+        pkg_simple = trlc_ast.Symbol_Table.simplified_name(pkg_name)
+        pkg = self._stab.table.get(pkg_simple)
         if not isinstance(pkg, trlc_ast.Package):
             return None
-        type_simple  = trlc_ast.Symbol_Table.simplified_name(local_name)
-        record_type  = pkg.symbols.table.get(type_simple)
+        type_simple = trlc_ast.Symbol_Table.simplified_name(local_name)
+        record_type = pkg.symbols.table.get(type_simple)
         if isinstance(record_type, trlc_ast.Record_Type):
             return record_type
         return None
@@ -364,7 +364,7 @@ class MD_Lexer(TRLC_Lexer):
         """Return the declared type of *field_name*, or None."""
         if record_type_ast is None:
             return None
-        simple    = trlc_ast.Symbol_Table.simplified_name(field_name)
+        simple = trlc_ast.Symbol_Table.simplified_name(field_name)
         component = record_type_ast.components.table.get(simple)
         return component.n_typ if component is not None else None
 
@@ -399,7 +399,9 @@ class MD_Lexer(TRLC_Lexer):
             if self._is_tuple_array_field(record_type_ast, field_name):
                 if self._check_bracket_array(raw_value, location):
                     return
-                if not self._maybe_emit_array(raw_value, location):
+                if not self._maybe_emit_array(
+                    raw_value, location, allow_unqualified=True
+                ):
                     self._emit(location, "STRING", raw_value.strip())
                 return
         self._emit_value(raw_value, location)
@@ -468,13 +470,13 @@ class MD_Lexer(TRLC_Lexer):
         if not MD_Lexer._is_alpha(name[0]):
             self.mh.lex_error(
                 self._source_ref(loc_line, heading_prefix_len + 1, source_line),
-                "unexpected character '%s'" % name[0],
+                f"unexpected character '{name[0]}'",
             )
         for i, ch in enumerate(name[1:], 1):
             if not (MD_Lexer._is_alnum(ch) or ch == "_"):
                 self.mh.lex_error(
                     self._source_ref(loc_line, heading_prefix_len + 1 + i, source_line),
-                    "unexpected character '%s'" % ch,
+                    f"unexpected character '{ch}'",
                 )
 
     @staticmethod
@@ -566,6 +568,19 @@ class MD_Lexer(TRLC_Lexer):
         r'$'
     )
 
+    # Like _TUPLE_REF_RE but the dot is optional, so unqualified same-package
+    # references (e.g. ``item @ 1``) are also accepted.  Only safe in the
+    # Phase 2 type-aware path where the field type is already known.
+    _TUPLE_REF_FLEXIBLE_RE = re.compile(
+        r'^'
+        r'(?P<ref>[a-zA-Z_]\w*(?:\.[a-zA-Z_]\w*)*)'
+        r' '
+        r'(?P<sep>[@:;]|[a-zA-Z_]\w*)'
+        r' '
+        r'(?P<ver>\d+)'
+        r'$'
+    )
+
     # Chunk patterns for the multi-separator tuple scanner.
     # A numeric chunk: hex, binary, or decimal (integer or float).
     _TUPLE_NUM_RE = re.compile(
@@ -577,18 +592,24 @@ class MD_Lexer(TRLC_Lexer):
     _TUPLE_SEP_RE = re.compile(r'[@:;]|[a-zA-Z_]\w*')
 
     @staticmethod
-    def _looks_like_array(raw_value):
+    def _looks_like_array(raw_value, allow_unqualified=False):
         """Check if value looks like tuple-reference array without emitting.
 
         Expected format (separator may be @, :, ;, or any identifier)::
 
           identifier[.identifier]* sep integer
           [, identifier[.identifier]* sep integer]*
+
+        When *allow_unqualified* is True, unqualified same-package references
+        (e.g. ``item @ 1``) are also accepted.  Only pass True when the field
+        type is confirmed as a tuple-reference array.
         """
         normalized = MD_Lexer._normalize_array_value(raw_value)
         parts = [p.strip() for p in normalized.split(',') if p.strip()]
+        pattern = (MD_Lexer._TUPLE_REF_FLEXIBLE_RE if allow_unqualified
+                   else MD_Lexer._TUPLE_REF_RE)
         return bool(parts) and all(
-            MD_Lexer._TUPLE_REF_RE.match(part)
+            pattern.match(part)
             for part in parts
         )
 
@@ -772,8 +793,12 @@ class MD_Lexer(TRLC_Lexer):
         )
         return True
 
-    def _maybe_emit_array(self, raw_value, location):
-        """Try to emit array tokens for package-qualified tuple-reference format.
+    def _maybe_emit_array(self, raw_value, location, allow_unqualified=False):
+        """Try to emit array tokens for tuple-reference format.
+
+        When *allow_unqualified* is True, unqualified same-package references
+        (e.g. ``item @ 1``) are also accepted.  Only safe when the field type
+        is confirmed as a tuple-reference array (Phase 2 path).
 
         Recognises values of the form::
 
@@ -785,18 +810,20 @@ class MD_Lexer(TRLC_Lexer):
 
         Returns True if array was emitted, False for STRING fallback.
         """
-        if not self._looks_like_array(raw_value):
+        if not self._looks_like_array(raw_value, allow_unqualified=allow_unqualified):
             return False
 
         normalized = self._normalize_array_value(raw_value)
         parts = [p.strip() for p in normalized.split(',')]
         self._emit(location, "S_BRA")
+        pattern = (MD_Lexer._TUPLE_REF_FLEXIBLE_RE if allow_unqualified
+                   else MD_Lexer._TUPLE_REF_RE)
 
         for idx, part in enumerate(parts):
             if idx > 0:
                 self._emit(location, "COMMA")
 
-            match = MD_Lexer._TUPLE_REF_RE.match(part)
+            match = pattern.match(part)
             if match:
                 qual_ident = match.group("ref")
                 sep = match.group("sep")
@@ -1063,8 +1090,8 @@ class MD_Lexer(TRLC_Lexer):
                 if pending_name is not None and not record_type_found:
                     self.mh.error(
                         pending_name_loc,
-                        "record heading '%s' has no 'type' property in its "
-                        "property table; record will be skipped" % pending_name,
+                        f"record heading '{pending_name}' has no 'type' property"
+                        " in its property table; record will be skipped",
                         fatal=False,
                     )
                 pending_name = None

--- a/trlc/lexer_md.py
+++ b/trlc/lexer_md.py
@@ -70,6 +70,7 @@ Values in the property table are interpreted as follows (in order):
   * Anything else                    → STRING token
 """
 
+import re
 from fractions import Fraction
 
 from trlc.lexer import Token, TRLC_Lexer
@@ -407,6 +408,151 @@ class MD_Lexer(TRLC_Lexer):
             if idx < len(parts) - 1:
                 self._emit(location, "DOT")
 
+    # Separator symbol token kinds (mirrors TRLC_Lexer.PUNCTUATION).
+    _SEPARATOR_PUNCTUATION = {'@': 'AT', ':': 'COLON', ';': 'SEMICOLON'}
+
+    @staticmethod
+    def _normalize_array_value(raw_value):
+        """Normalize array value by converting various separators to comma format.
+
+        Handles:
+        - <br> tags (converted to newlines, then normalized)
+        - Multiple spaces around @, :, ; separators (normalized to single space)
+        - Identifier separators (multiple spaces collapsed to single space)
+        - Newlines (preserved initially for multiline detection, then normalized)
+
+        Returns normalized string with tuple refs as
+        ``"identifier <sep> integer, ..."``.
+        """
+        # Replace <br> and <BR> tags with newlines for uniform processing
+        normalized = re.sub(r'<[Bb][Rr]\s*/?>', '\n', raw_value)
+
+        # Split on newlines and commas, trim each part
+        parts = []
+        for line in normalized.split('\n'):
+            for item in line.split(','):
+                trimmed = item.strip()
+                if trimmed:
+                    parts.append(trimmed)
+
+        # Normalize whitespace around each part:
+        # - punctuation separators (@, :, ;) get exactly one space each side
+        # - identifier separators: collapse multiple spaces to one
+        normalized_parts = []
+        for part in parts:
+            part = re.sub(r'\s*([@:;])\s*', r' \1 ', part)
+            part = re.sub(r' +', ' ', part.strip())
+            normalized_parts.append(part)
+
+        return ', '.join(normalized_parts)
+
+    # Tuple-reference pattern: package-qualified identifier, separator, integer.
+    # The reference MUST contain at least one dot (Package.name) so that plain
+    # free-text values are never falsely matched.
+    # Separator is @, :, ; or a plain identifier.
+    _TUPLE_REF_RE = re.compile(
+        r'^'
+        r'(?P<ref>[a-zA-Z_]\w*\.[a-zA-Z_]\w*(?:\.[a-zA-Z_]\w*)*)'
+        r' '
+        r'(?P<sep>[@:;]|[a-zA-Z_]\w*)'
+        r' '
+        r'(?P<ver>\d+)'
+        r'$'
+    )
+
+    @staticmethod
+    def _looks_like_array(raw_value):
+        """Check if value looks like tuple-reference array without emitting.
+
+        Expected format (separator may be @, :, ;, or any identifier)::
+
+          identifier[.identifier]* sep integer
+          [, identifier[.identifier]* sep integer]*
+        """
+        normalized = MD_Lexer._normalize_array_value(raw_value)
+        parts = [p.strip() for p in normalized.split(',') if p.strip()]
+        return bool(parts) and all(
+            MD_Lexer._TUPLE_REF_RE.match(part)
+            for part in parts
+        )
+
+    def _check_bracket_array(self, raw_value, location):
+        """Detect bracket notation for tuple arrays and emit a clear error.
+
+        Bracket syntax like ``[Pkg.item @ 1, Pkg.item @ 2]`` is not supported
+        because brackets conflict with Markdown URL syntax.
+
+        Returns True when bracket array syntax was detected (error was emitted),
+        so the caller can skip further processing of this value.
+        """
+        value = raw_value.strip()
+        if not (value.startswith('[') and value.endswith(']')):
+            return False
+        inner = value[1:-1].strip()
+        # Only reject if the content inside the brackets actually looks like
+        # tuple references – avoids false positives on URLs containing '@'
+        if not MD_Lexer._looks_like_array(inner):
+            return False
+        self.mh.error(
+            location,
+            "bracket notation for tuple-reference arrays is not supported",
+            explanation=(
+                "Use comma-separated or newline-separated tuple references "
+                "without brackets instead, e.g. "
+                "'Pkg.item_a @ 1, Pkg.item_b @ 2'"
+            ),
+            fatal=False,
+        )
+        return True
+
+    def _maybe_emit_array(self, raw_value, location):
+        """Try to emit array tokens for package-qualified tuple-reference format.
+
+        Recognises values of the form::
+
+          Package.item sep integer [, Package.item sep integer]*
+
+        The reference must be package-qualified (contain at least one dot)
+        so that plain free-text values (e.g. ``Revision : 12``) are never
+        misinterpreted as tuple-reference arrays.
+
+        Returns True if array was emitted, False for STRING fallback.
+        """
+        if not self._looks_like_array(raw_value):
+            return False
+
+        normalized = self._normalize_array_value(raw_value)
+        parts = [p.strip() for p in normalized.split(',')]
+        self._emit(location, "S_BRA")
+
+        for idx, part in enumerate(parts):
+            if idx > 0:
+                self._emit(location, "COMMA")
+
+            match = MD_Lexer._TUPLE_REF_RE.match(part)
+            if match:
+                qual_ident = match.group("ref")
+                sep = match.group("sep")
+                integer = int(match.group("ver"))
+
+                # Emit qualified identifier (Pkg.item → IDENTIFIER DOT IDENTIFIER)
+                ident_parts = qual_ident.split('.')
+                for i, ident_part in enumerate(ident_parts):
+                    self._emit(location, "IDENTIFIER", ident_part)
+                    if i < len(ident_parts) - 1:
+                        self._emit(location, "DOT")
+
+                # Emit separator: @→AT, :→COLON, ;→SEMICOLON, word→IDENTIFIER
+                sep_kind = MD_Lexer._SEPARATOR_PUNCTUATION.get(sep, "IDENTIFIER")
+                sep_val = sep if sep_kind == "IDENTIFIER" else None
+                self._emit(location, sep_kind, sep_val)
+
+                # Emit version integer
+                self._emit(location, "INTEGER", integer)
+
+        self._emit(location, "S_KET")
+        return True
+
     def _emit_value(self, raw_value, location):
         """Emit one or more tokens representing a property value.
 
@@ -414,6 +560,14 @@ class MD_Lexer(TRLC_Lexer):
         module docstring.
         """
         value = raw_value.strip()
+
+        # Bracket array notation is not supported – emit a clear error
+        if self._check_bracket_array(raw_value, location):
+            return
+
+        # Array of tuple references (before other checks)
+        if self._maybe_emit_array(raw_value, location):
+            return
 
         # Boolean / null keywords
         if value in MD_Lexer.KEYWORDS:
@@ -553,14 +707,18 @@ class MD_Lexer(TRLC_Lexer):
         str_field_name = None
         str_field_loc = None
         str_field_lines = []
+        str_field_first_content_line = None
+        str_field_first_content_col = 1
         # #### fields seen before the "type" row are buffered here, then
         # emitted inside the record after C_BRA (mirrors pending_props).
-        pending_string_fields = []  # [(name, loc, text, emit_as_scalar)]
+        # Tuple: (name, loc, text, emit_as_scalar, is_array, is_bracket)
+        pending_string_fields = []
 
         # ── Helpers (closures) ────────────────────────────────────────── #
 
         def flush_string_field():
             nonlocal in_string_field, str_field_name, str_field_lines
+            nonlocal str_field_first_content_line, str_field_first_content_col
             if not in_string_field:
                 return
             # Strip leading and trailing blank lines
@@ -573,21 +731,47 @@ class MD_Lexer(TRLC_Lexer):
             emit_as_scalar = ("\n" not in text and
                               MD_Lexer._looks_like_scalar_value(text))
 
+            value_loc = str_field_loc
+            if str_field_first_content_line is not None:
+                value_loc = self._loc(
+                    str_field_first_content_line,
+                    str_field_first_content_col,
+                )
+
             if in_record:
                 # Record already open – emit directly inside the block.
                 self._emit(str_field_loc, "IDENTIFIER", str_field_name)
                 self._emit(str_field_loc, "ASSIGN")
                 if emit_as_scalar:
-                    self._emit_value(text, str_field_loc)
-                else:
-                    self._emit(str_field_loc, "STRING", text)
+                    self._emit_value(text, value_loc)
+                elif self._check_bracket_array(text, value_loc):
+                    # Bracket notation detected – error already emitted; skip
+                    pass
+                elif not self._maybe_emit_array(text, value_loc):
+                    # Array detection failed – emit as string
+                    self._emit(value_loc, "STRING", text)
             else:
                 # "type" row not yet seen – buffer until the record opens.
+                # Check if it looks like an array (but don't emit yet)
+                is_bracket = (
+                    not emit_as_scalar and
+                    text.strip().startswith('[') and
+                    text.strip().endswith(']') and
+                    '@' in text
+                )
+                is_array = (
+                    not emit_as_scalar and
+                    not is_bracket and
+                    MD_Lexer._looks_like_array(text)
+                )
                 pending_string_fields.append(
-                    (str_field_name, str_field_loc, text, emit_as_scalar))
+                    (str_field_name, value_loc, text,
+                     emit_as_scalar, is_array, is_bracket))
             in_string_field = False
             str_field_name = None
             str_field_lines = []
+            str_field_first_content_line = None
+            str_field_first_content_col = 1
 
         def flush_record(loc):
             nonlocal in_record, pending_name, pending_props
@@ -651,6 +835,12 @@ class MD_Lexer(TRLC_Lexer):
                     flush_string_field()
                     # fall through to table-row handling
                 else:
+                    if str_field_first_content_line is None and stripped:
+                        line_stripped = line.lstrip()
+                        str_field_first_content_line = line_no
+                        str_field_first_content_col = (
+                            len(line) - len(line_stripped) + 1
+                        )
                     str_field_lines.append(line)
                     continue
 
@@ -708,6 +898,8 @@ class MD_Lexer(TRLC_Lexer):
                 self._validate_identifier(str_field_name, line_no, _h_level + 1, line)
                 str_field_loc = loc
                 str_field_lines = []
+                str_field_first_content_line = None
+                str_field_first_content_col = 1
                 in_string_field = True
                 continue
 
@@ -755,13 +947,22 @@ class MD_Lexer(TRLC_Lexer):
                         self._emit_value(bval, bloc)
                     pending_props = []
 
-                    # Flush any #### string fields that arrived before "type"
-                    for fname, floc, ftext, fis_scalar in pending_string_fields:
+                    # Flush any #### string fields that arrived
+                    # before "type"
+                    for (fname, floc, ftext, fis_scalar,
+                         fis_array, fis_bracket) in pending_string_fields:
                         self._emit(floc, "IDENTIFIER", fname)
                         self._emit(floc, "ASSIGN")
                         if fis_scalar:
                             self._emit_value(ftext, floc)
+                        elif fis_bracket:
+                            # Bracket notation – emit error, skip value
+                            self._check_bracket_array(ftext, floc)
+                        elif fis_array:
+                            # Emit array tokens
+                            self._maybe_emit_array(ftext, floc)
                         else:
+                            # Not scalar, not array → emit as STRING
                             self._emit(floc, "STRING", ftext)
                     pending_string_fields.clear()
 

--- a/trlc/trlc.py
+++ b/trlc/trlc.py
@@ -518,6 +518,23 @@ class Source_Manager:
             self.callback_parse_end()
             return None
 
+        # ─────────────────────────────────────────────────────────────
+        # Phase 2: reprocess markdown files with RSL types available
+        # ─────────────────────────────────────────────────────────────
+        for _md_fname in sorted(self.trlc_files):
+            if not _md_fname.endswith(MARKDOWN_EXTENSION):
+                continue
+            _md_parser = self.trlc_files[_md_fname]
+            if not (_md_parser.primary or _md_parser.secondary):
+                continue
+            if _md_fname in self.files_with_preamble_errors:
+                continue
+            _md_lexer = getattr(_md_parser, "lexer", None)
+            if isinstance(_md_lexer, MD_Lexer):
+                _md_lexer.prepare_phase2(self.stab)  # Rebuild tokens with types
+                _md_parser.ct = None                 # Reset parser cursor
+                _md_parser.advance()                 # Prime first body token
+
         # Perform sanity checks (enabled by default). We only do this
         # if there were no errors so far.
         if self.lint_mode and ok:


### PR DESCRIPTION
## Summary
Support specifying TRLC tuple-reference arrays in \`.trlc.md\` files including same-package references.

## Supported syntax
| Form | Example |
|------|---------|
| Table cell, comma | \`Pkg.item_a @ 1 , Pkg.item_b @ 2\` |
| Table cell, \`<br>\` | \`Pkg.item_a @ 1 <br> Pkg.item_b @ 2\` |
| Field block, single | \`Pkg.item_a @ 1\` |
| Field block, comma | \`Pkg.item_a @ 1, Pkg.item_b @ 2\` |
| Field block, newlines | one ref per line, flexible whitespace around \`@\` |
| same pkg | 	item_a @ 1 |

All LRM separator kinds supported --> @ : ; identifier
Bracket notation (\`[...]\`) is explicitly rejected.

## Tests
- \`tests-system/markdown-array/\` — 5 must-have forms, all pass
- \`tests-system/markdown-array-bracket-error/\` — 3 bracket error cases"