### PR TITLE
fix: TRLC Markdown type-row errors report on correct line

### DIFF
--- a/tests-system/markdown-type-row-line-number/model.rsl
+++ b/tests-system/markdown-type-row-line-number/model.rsl
@@ -1,0 +1,5 @@
+package TypeRowLineTest
+
+type Requirement {
+  description String
+}

--- a/tests-system/markdown-type-row-line-number/output
+++ b/tests-system/markdown-type-row-line-number/output
@@ -1,0 +1,2 @@
+markdown-type-row-line-number/requirements.trlc.md:9:1: error: unknown symbol RequirementTypo
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/markdown-type-row-line-number/output.brief
+++ b/tests-system/markdown-type-row-line-number/output.brief
@@ -1,0 +1,2 @@
+markdown-type-row-line-number/requirements.trlc.md:9:1: trlc error: unknown symbol RequirementTypo
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/markdown-type-row-line-number/output.json
+++ b/tests-system/markdown-type-row-line-number/output.json
@@ -1,0 +1,2 @@
+markdown-type-row-line-number/requirements.trlc.md:9:1: error: unknown symbol RequirementTypo
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/markdown-type-row-line-number/output.smtlib
+++ b/tests-system/markdown-type-row-line-number/output.smtlib
@@ -1,0 +1,2 @@
+markdown-type-row-line-number/requirements.trlc.md:9:1: error: unknown symbol RequirementTypo
+Processed 1 model and 1 requirement file and found 1 error

--- a/tests-system/markdown-type-row-line-number/requirements.trlc.md
+++ b/tests-system/markdown-type-row-line-number/requirements.trlc.md
@@ -1,0 +1,12 @@
+# TypeRowLineTest
+
+## Requirements
+
+### REQ_001
+
+| Property    | Value                                  |
+|-------------|----------------------------------------|
+| type        | RequirementTypo                        |
+| description | Test requirement with bad type on row  |
+
+<hr>

--- a/tests-unit/test_lexer_md.py
+++ b/tests-unit/test_lexer_md.py
@@ -349,6 +349,48 @@ class TestLexerMd(unittest.TestCase):
             ],
         )
 
+    def test_type_row_tokens_use_type_row_location(self):
+        content = "\n".join(
+            [
+                "# DemoPkg",
+                "",
+                "## Overview",
+                "",
+                "### Req_1",
+                "",
+                "| Property | Value |",
+                "|----------|-------|",
+                "| type | Requirement |",
+                "| priority | 7 |",
+            ]
+        )
+
+        lexer = MD_Lexer(self.mh, "test.trlc.md", content)
+        lexer.prepare_phase2(trlc_ast.Symbol_Table())
+
+        tokens = []
+        while True:
+            token = lexer.token()
+            if token is None:
+                break
+            tokens.append(token)
+
+        type_row_tokens = [token for token in tokens if token.location.line_no == 9]
+        heading_tokens = [token for token in tokens if token.location.line_no == 5]
+
+        self.assertEqual(
+            [(token.kind, token.value) for token in type_row_tokens],
+            [("IDENTIFIER", "Requirement")],
+        )
+
+        self.assertEqual(
+            [(token.kind, token.value) for token in heading_tokens[-2:]],
+            [
+                ("IDENTIFIER", "Req_1"),
+                ("C_BRA", None),
+            ],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/trlc/lexer_md.py
+++ b/trlc/lexer_md.py
@@ -1256,7 +1256,7 @@ class MD_Lexer(TRLC_Lexer):
                     type_name = value.strip()
                     if "." not in type_name and len(imported_packages) == 1:
                         type_name = imported_packages[0] + "." + type_name
-                    self._emit_qualified_identifier(pending_name_loc, type_name)
+                    self._emit_qualified_identifier(loc, type_name)
                     self._emit(pending_name_loc, "IDENTIFIER", pending_name)
                     self._emit(pending_name_loc, "C_BRA")
                     in_record = True


### PR DESCRIPTION
- Fixed the line number in error message for an invalid type in a type-row
- Earlier it was pointing to the record heading instead of the type-row.
- Adds a system test and unit test.